### PR TITLE
Restructure docs: succinct README + INSTALL/BUILD + pg_licht_mcp(1) man page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,20 @@ jobs:
 
       - name: Package (tar.gz)
         if: matrix.extension == 'tar.gz'
-        run: tar -czf ${{ matrix.artifact }}.tar.gz -C cpp/build pg_licht_mcp
+        env:
+          # BSD tar on macOS otherwise stores AppleDouble (._*) sidecars for
+          # extended attributes, which show up as junk on extraction.
+          COPYFILE_DISABLE: "1"
+        run: |
+          rm -rf stage
+          # Stage through the install rules rather than tarring the build tree,
+          # so the archive carries the same bin/ + share/man/ layout the .deb,
+          # .rpm, and Homebrew keg get. The binary was already stripped above,
+          # and `cmake --install` needs no target beyond pg_licht_mcp.
+          cmake --install cpp/build --prefix "$PWD/stage"
+          tar -czf ${{ matrix.artifact }}.tar.gz -C stage bin share
+          tar -tzf ${{ matrix.artifact }}.tar.gz | sort
+          test -f stage/share/man/man1/pg_licht_mcp.1
 
       - name: Package (deb)
         if: matrix.extension == 'deb'

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -43,7 +43,9 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
             | sudo tee /etc/apt/sources.list.d/pgdg.list
           sudo apt-get update -q
-          sudo apt-get install -y cmake libpq-dev nlohmann-json3-dev libgtest-dev pkg-config
+          # mandoc is only needed for the manpage_lint ctest; the build itself
+          # has no doc-toolchain dependency, since the man page is checked in.
+          sudo apt-get install -y cmake libpq-dev nlohmann-json3-dev libgtest-dev pkg-config mandoc
           curl -fsSL https://github.com/jtv/libpqxx/archive/refs/tags/8.0.2.tar.gz | tar -xz -C /tmp
           cmake -S /tmp/libpqxx-8.0.2 -B /tmp/libpqxx-build \
             -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DSKIP_BUILD_TEST=ON

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,155 @@
+# Building pg-licht from source
+
+For pre-built packages, see [INSTALL.md](INSTALL.md). This document covers compiling,
+testing, and the CI setup — it is aimed at contributors.
+
+## Requirements
+
+- CMake 3.20+
+- A C++23 compiler
+- libpqxx
+- libpq
+- nlohmann_json
+- pkg-config
+- GoogleTest (only when building the test suite, which is the default)
+
+## Build
+
+```bash
+cmake -S cpp -B cpp/build -DBUILD_TESTING=OFF
+cmake --build cpp/build
+```
+
+Release binaries link libpqxx statically (built from a pinned version) so every platform
+runs the same libpqxx regardless of what each distro packages; libpq stays a dynamic
+runtime dependency, since its C ABI is stable and distros patch it independently. Local
+builds use whatever libpqxx your system provides — dynamic or static both work.
+
+### Build options
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `BUILD_TESTING` | `ON` | Build `pg_licht_mcp_test` and register the ctest suite. Requires GoogleTest. |
+| `CMAKE_BUILD_TYPE` | *(unset)* | `Release` for packaging, `RelWithDebInfo` for debugging and sanitizers. |
+| `PGLICHT_SANITIZER` | `NONE` | `ADDRESS`, `UNDEFINED`, `ADDRESS_UNDEFINED`, or `THREAD`. |
+| `CMAKE_INSTALL_PREFIX` | `/usr/local` | Install destination. |
+
+Hardening flags are always on, not opt-in: `-Wall -Wextra -Wpedantic -Wconversion
+-Wsign-conversion -Wshadow -Werror`, plus `_GLIBCXX_ASSERTIONS` / `_LIBCPP_HARDENING_MODE`.
+Expect to add explicit `static_cast`s for any `size_t` / `int` / `pqxx::result::size_type`
+conversion.
+
+### Installing a local build
+
+```bash
+cmake --install cpp/build --prefix ~/.local
+```
+
+This installs `bin/pg_licht_mcp` and `share/man/man1/pg_licht_mcp.1`, which is what puts
+`pg_licht_mcp(1)` on your `MANPATH`.
+
+## Test
+
+```bash
+DATABASE_URL="port=5432 dbname=mydb" ./cpp/build/pg_licht_mcp_test
+# or
+DATABASE_URL="port=5432 dbname=mydb" ctest --test-dir cpp/build --output-on-failure
+```
+
+The fixtures create and destroy a temporary database named `pg_licht_test_<PID>`
+automatically, so `DATABASE_URL` only needs to name a database they can connect to in
+order to issue `CREATE DATABASE`. Installing the `pg_stat_statements`, `postgres_fdw`, and
+`pgstattuple` extensions requires superuser.
+
+`ctest` also runs, when the tools are present:
+
+- `*_valgrind` — registered automatically by `pglicht_add_valgrind_test()` whenever
+  Valgrind is installed and no sanitizer is active.
+- `manpage_lint` — `mandoc -Tlint -Wwarning` over `cpp/man/pg_licht_mcp.1`.
+
+### Through a connection pooler
+
+Because the read-only guard is transaction-scoped specifically so it survives a
+transaction-mode pooler, there is a script that verifies exactly that. It stands up a
+throwaway PostgreSQL cluster and a companion PgBouncer (`pool_mode=transaction`,
+`server_reset_query=DISCARD ALL`) in a temp directory, runs the full suite both directly
+and through the pooler, and tears everything down — touching nothing else on the machine:
+
+```bash
+cmake --build cpp/build          # the script needs the test binary built
+cpp/test/run-pooled-tests.sh
+```
+
+Requires `initdb`/`pg_ctl` (PostgreSQL 14+) and `pgbouncer`. It picks the newest installed
+PostgreSQL and free default ports, all overridable via the environment: `PG_BINDIR`,
+`PGBOUNCER`, `TEST_BIN`, `PG_PORT`, `BOUNCER_PORT`. To pin a specific major:
+
+```bash
+PG_BINDIR=/usr/lib/postgresql/16/bin cpp/test/run-pooled-tests.sh
+```
+
+This is also the only path that covers the `pg_stat_statements` queryid tests, because the
+rig preloads the extension while a stock server usually does not.
+
+### Debugging with MCP Inspector
+
+The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) lets you call tools
+interactively and inspect responses without an AI client:
+
+```bash
+npx @modelcontextprotocol/inspector \
+  -e DATABASE_URL="postgresql://user:pass@host/dbname" \
+  ./cpp/build/pg_licht_mcp
+```
+
+## PostgreSQL version support
+
+Supports PostgreSQL 14 and newer, verified in CI on 14–18. One feature degrades gracefully
+below 16: `explainQuery` can only produce a plan for a `pg_stat_statements` statement
+(whose text is normalized to `$1`/`$2`) by using `EXPLAIN (GENERIC_PLAN)`, which is
+PostgreSQL 16+. On 14/15 that path returns an actionable hint instead — supplying `params`
+(which prepares and plans the statement with real values) works on every supported version.
+
+Two catalog fields are omitted where the column does not exist: index `last_use`
+(`pg_stat_user_indexes.last_idx_scan`, PG16+) and subscription `two_phase`
+(`pg_subscription.subtwophasestate`, PG15+). Both are gated on the server version reported
+by the connection handshake, so a mixed-version multi-database setup behaves correctly.
+
+## Editing the man page
+
+`cpp/man/pg_licht_mcp.1` is a hand-written mdoc source, deliberately **not** generated: the
+release containers (`debian:trixie`, `rockylinux:9`) carry no doc toolchain, and the
+release build runs `--target pg_licht_mcp` rather than `all`, so a generator target would
+never run and CPack would then fail on a missing install file.
+
+```bash
+mandoc -Tlint -Wwarning cpp/man/pg_licht_mcp.1   # what CI gates on
+groff -mdoc -Tascii -ww cpp/man/pg_licht_mcp.1 >/dev/null   # second renderer
+man --local-file cpp/man/pg_licht_mcp.1          # preview
+```
+
+Adding a tool to `get_tools_list()` in `cpp/src/server.h` means adding a matching
+`.It Ic <name>` entry under the right `.Ss` group. This check keeps the two in sync:
+
+```bash
+diff <(grep -oE '\{"name", "[A-Za-z]+"' cpp/src/server.h | sed 's/.*"name", "//; s/"//' | sort) \
+     <(grep -oE '^\.It Ic [A-Za-z]+' cpp/man/pg_licht_mcp.1 | awk '{print $3}' | sort -u)
+```
+
+Keep the tools table wording in the man page authoritative; `README.md` deliberately does
+not duplicate it.
+
+## CI
+
+- `.github/workflows/sanitizers.yml` — ASan/UBSan, TSan, Valgrind, and the pooled-connection
+  job, each across PostgreSQL 14, 15, 16, 17, and 18.
+- `.github/workflows/release.yml` — 7 build targets (Linux x86_64/arm64, Debian 13 deb,
+  Rocky 9 rpm, macOS arm64). Tarballs are staged through `cmake --install`; deb and rpm are
+  produced by CPack, which picks up the same install rules. libpqxx is pinned via
+  `PQXX_VERSION`.
+
+## Release process
+
+Push a `v*` tag on `main`. The release workflow builds and uploads all seven artifacts,
+creates the GitHub release, and bumps the Homebrew tap formula (URL and sha256)
+automatically.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.2.0 (unreleased)
 
 ### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Documentation
+
+- **`pg_licht_mcp(1)` manual page.** Configuration, connection strings, all 40 operations with their arguments, MCP client setup, environment, files, diagnostics, and compatibility now live in a real man page, readable from the terminal where the server actually runs. It is hand-written mdoc (FreeBSD style), installed to `share/man/man1` by every channel — Homebrew, deb, rpm, and tarball — so `man pg_licht_mcp` works after any install. A `manpage_lint` ctest gates it with `mandoc -Tlint -Wwarning`.
+- **README split by audience.** `README.md` drops from 297 to ~70 lines and now covers only purpose, safety summary, quick start, and links. Installing pre-built packages moved to `INSTALL.md`; building from source, testing, sanitizers, CI, and the release process moved to `BUILD.md`.
+- **Release tarballs now carry the man page.** They are staged through `cmake --install` instead of being tarred out of the build tree, so they contain `bin/pg_licht_mcp` + `share/man/man1/pg_licht_mcp.1` and can be unpacked straight onto a prefix (`sudo tar -xzf … -C /usr/local`). This changes the archive layout from a single flat binary.
+- `--help` output is now English and points at `pg_licht_mcp(1)`.
+
 ## 2.1.0 (2026-07-22)
 
 ### Security

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,110 @@
+# Installing pg-licht
+
+Pre-built packages and binaries for every supported platform. To compile from source
+instead, see [BUILD.md](BUILD.md).
+
+Every channel below installs the manual page, so once installed:
+
+```bash
+man pg_licht_mcp
+```
+
+is the reference for configuration, connection strings, all 40 operations, and MCP client
+setup.
+
+## Homebrew (macOS and Linux)
+
+```bash
+brew tap sqlambda/pg-licht
+brew install pg-licht
+```
+
+## Pre-built packages and binaries
+
+Download the latest release for your platform from the
+[releases page](https://github.com/sqlambda/pg_licht/releases):
+
+| Platform | File | Format |
+|----------|------|--------|
+| Debian 13 (Trixie) x86_64 | `pg_licht_mcp-linux-x86_64-debian13.deb` | `.deb` |
+| Debian 13 (Trixie) arm64 | `pg_licht_mcp-linux-arm64-debian13.deb` | `.deb` |
+| Rocky Linux 9 x86_64 | `pg_licht_mcp-linux-x86_64-rocky9.rpm` | `.rpm` |
+| Rocky Linux 9 arm64 | `pg_licht_mcp-linux-arm64-rocky9.rpm` | `.rpm` |
+| Linux x86_64 (generic) | `pg_licht_mcp-linux-x86_64.tar.gz` | tarball |
+| Linux arm64 (generic) | `pg_licht_mcp-linux-arm64.tar.gz` | tarball |
+| macOS Apple Silicon | `pg_licht_mcp-macos-arm64.tar.gz` | tarball |
+
+### Debian / Ubuntu / other apt-based distros (`.deb`)
+
+```bash
+sudo apt install ./pg_licht_mcp-linux-x86_64-debian13.deb
+```
+
+Use `apt install ./file.deb` rather than `dpkg -i` so apt resolves the declared `libpq5`
+dependency automatically. Installs `/usr/bin/pg_licht_mcp`, already on `PATH`.
+
+### Rocky Linux / RHEL / Fedora / other dnf-based distros (`.rpm`)
+
+```bash
+sudo dnf install ./pg_licht_mcp-linux-x86_64-rocky9.rpm
+```
+
+Same reasoning: `dnf install ./file.rpm` resolves the declared `libpq5` dependency, while
+`rpm -i` will not. Installs `/usr/bin/pg_licht_mcp`.
+
+### Generic tarball (any glibc-based Linux, or macOS)
+
+The archive holds a standard prefix tree — `bin/pg_licht_mcp` and
+`share/man/man1/pg_licht_mcp.1` — so it can be unpacked directly onto a prefix.
+
+System-wide, into `/usr/local`:
+
+```bash
+sudo tar -xzf pg_licht_mcp-linux-x86_64.tar.gz -C /usr/local
+```
+
+`/usr/local/bin` is on `PATH` and `/usr/local/share/man` is on the default `MANPATH`, so
+both the binary and `man pg_licht_mcp` work immediately.
+
+For a single user, into `~/.local`:
+
+```bash
+mkdir -p ~/.local
+tar -xzf pg_licht_mcp-linux-x86_64.tar.gz -C ~/.local
+```
+
+Add `~/.local/bin` to your `PATH` if it is not already there. Most distributions add
+`~/.local/share/man` to the man search path automatically; if `man pg_licht_mcp` does not
+find it, export `MANPATH="$HOME/.local/share/man:$MANPATH"`.
+
+## Verify the installation
+
+```bash
+command -v pg_licht_mcp     # where it landed
+pg_licht_mcp --help         # usage and connection resolution order
+man pg_licht_mcp            # the full manual
+```
+
+Then point it at a database:
+
+```bash
+DATABASE_URL="postgresql://user:pass@host/dbname" pg_licht_mcp
+```
+
+It speaks JSON-RPC 2.0 on stdin/stdout and is normally launched by an MCP client rather
+than run by hand — see the EXAMPLES section of `man pg_licht_mcp` for Claude Code, Claude
+Desktop, and Grok Build setup.
+
+## Uninstall
+
+```bash
+brew uninstall pg-licht                 # Homebrew
+sudo apt remove pg-licht                # deb
+sudo dnf remove pg-licht                # rpm
+```
+
+For a tarball install, remove the two files it added:
+
+```bash
+sudo rm /usr/local/bin/pg_licht_mcp /usr/local/share/man/man1/pg_licht_mcp.1
+```

--- a/README.md
+++ b/README.md
@@ -8,289 +8,64 @@ Motivation to create another PostgreSQL MCP:
 - Allow to describe database model and routines based on what is in the database
 - Fast inspection of available indexes and relationships when analyzing a query plan
 
-Every query is parameterized (`$1`/`$2` bindings or `::regnamespace`/`::regclass` casts) — no schema, table, or search-term argument is ever concatenated into SQL text. The one deliberate exception is `explainQuery`, which has to place the statement under analysis into the `EXPLAIN` text because `EXPLAIN` cannot take a bind parameter; it is guarded by a leading-keyword whitelist, a single-statement check, `PREPARE`d parameter binding with every value escaped through libpq, a `ModifyTable` gate that refuses to execute anything that writes, and a bounded `statement_timeout`. Every tool call runs inside its own `READ ONLY` transaction, so even a bug that let a query attempt a write would still fail (SQLSTATE `25006`) rather than succeed silently.
+## Safety
 
-The read-only guard is deliberately *transaction*-scoped rather than session-scoped. Under a connection pooler in transaction mode (PgBouncer's `pool_mode = transaction` with `server_reset_query = DISCARD ALL`), the server connection is returned to the pool at commit and its session state is wiped — so a `SET` issued once at startup silently stops applying to later calls. Transaction scope is the scope a pooler preserves. The setting cannot be pushed into the connection string either: PgBouncer rejects GUCs in the startup packet outright (`unsupported startup parameter in options: ...`).
+Every catalog query is parameterized — no schema, table, or search-term argument is ever
+concatenated into SQL text. Every tool call runs inside its own `READ ONLY` transaction,
+so even a bug that let a query attempt a write would fail rather than succeed silently.
+That guard is transaction-scoped rather than session-scoped, which is what makes it hold
+behind a connection pooler in transaction mode.
+
+Full rationale, including the guarded exception for `explainQuery`, is in the
+SECURITY CONSIDERATIONS section of `man pg_licht_mcp`.
+
+## Quick start
+
+```bash
+brew tap sqlambda/pg-licht && brew install pg-licht
+
+claude mcp add --transport stdio pg-licht \
+  -e DATABASE_URL="postgresql://user:pass@host/dbname" \
+  -- /usr/local/bin/pg_licht_mcp
+
+man pg_licht_mcp
+```
+
+Other install channels — deb, rpm, tarball, source — are in [INSTALL.md](INSTALL.md).
 
 ## Tools
 
-| Tool | Description |
-|------|-------------|
-| `listSchemas` | All schemas with their table/view names and role grants |
-| `listTables` | Tables and views in a schema with kind, row counts, sizes, scan stats, autovacuum stats (dead/live tuples, mods-since-analyze, inserts-since-vacuum, last vacuum/analyze, per-table reloptions), columns (name, description, and per-column index count), and index/constraint counts. Full index and constraint definitions live in `tableDetails`, not here — this tool is intentionally light for browsing a schema |
-| `tableDetails` | Full detail: columns (types, nullability, defaults, pg_stats histograms, per-column TOAST storage strategy and compression method), TOAST table (name, size, index size — `null` if the table has no toastable columns), primary key (single or composite, as ordered column list), indexes (size, usage counts), constraints, foreign keys, inbound foreign keys (`referenced_by`), triggers (timing, events, when condition, language), rules (`CREATE RULE`, excludes the implicit view `_RETURN` rule), row-level security status and policies, view definition, scan stats, and role grants |
-| `searchTables` | Full-text search across table/schema names, descriptions, column names/descriptions, enum values used by columns, and role names; returns the same fields as `listTables` plus `roles` |
-| `listFunctions` | Functions and procedures in a schema with kind, language, return type, arguments, volatility, security_definer, and is_strict |
-| `functionDetails` | Full function detail: source code, full definition, arguments, volatility, trigger usage, and role grants |
-| `searchFunctions` | Full-text search across function names, source code, language, trigger names, and descriptions |
-| `listEnums` | Enum types in a schema with their ordered values and descriptions |
-| `enumDetails` | Full enum detail: ordered values and all columns (across all tables) that reference it |
-| `searchEnums` | Full-text search across enum names, values, and descriptions |
-| `listTypes` | Composite types, domains, and range types in a schema (excludes enums, implicit table/view row types, and the auto-generated multirange companion of each range type); composites include their attribute list, domains include base type/nullability/default/constraints, ranges include subtype and the multirange type name |
-| `typeDetails` | Full composite type, domain, or range type detail: attributes/constraints/subtype and which columns use it |
-| `listRoles` | Cluster-wide roles with kind (login/group), attributes (superuser, create_role, create_db, replication, bypass_rls, connection_limit, valid_until), and group memberships |
-| `listForeignTables` | Foreign tables in a schema with their foreign server, FDW, options, and columns (never exposes user mapping credentials) |
-| `listForeignServers` | Cluster-wide foreign servers with FDW, owner, and options (host/port/dbname-style only, never user mapping credentials) |
-| `listTablespaces` | Cluster-wide tablespaces with owner, filesystem location, options, and description |
-| `listCollations` | Collations usable in the current database's encoding for a schema, with provider, locale settings, and determinism flag |
-| `listEventTriggers` | Cluster-wide event triggers with event type, tags, function, owner, enabled status, and description |
-| `listPublications` | Logical replication publications with owner, all-tables flag, per-operation flags, and member tables |
-| `listSubscriptions` | Logical replication subscriptions for the current database with owner, enabled status, publications, slot name, and sync settings (never exposes the connection string) |
-| `listLanguages` | Procedural languages installed in the current database (e.g. plpgsql, plpython3u) with owner, trusted/procedural flags, handler function, and description |
-| `listExtendedStatistics` | Extended statistics objects (`CREATE STATISTICS`) for a schema with target table, columns, statistics kinds (ndistinct, dependencies, mcv), and description |
-| `listOperators` | Custom operators in a schema with left/right operand types, result type, and implementing function; mostly relevant for schemas using extensions with custom types (e.g. PostGIS) |
-| `listOperatorClasses` | Operator classes in a schema with their index access method, input type, and default flag; describes what index types (btree/gist/gin/etc) a type supports |
-| `listAccessMethods` | Index and table access methods available in the cluster (btree, gist, gin, heap, etc) with type and handler function |
-| `listCasts` | Type casts involving at least one user-defined type (excludes built-in-to-built-in casts) with source/target types, context, and method |
-| `listTextSearchConfigs` | Full-text search configurations for a schema with parser and the token-type-to-dictionary mapping |
-| `listSequences` | Sequences in a schema with data type, range, increment, cycle, cache size, current value, and owning table.column (for `SERIAL`/`IDENTITY` columns) |
-| `listExtensions` | Installed PostgreSQL extensions with version, schema, relocatable flag, and description |
-| `databaseSize` | Current database name and total disk size |
-| `serverSettings` | All PostgreSQL server settings (`pg_settings`) grouped by category; each setting includes current value, unit, description, context, type, source, and `pending_restart` flag |
-| `currentActivity` | Current server connections and running queries (`pg_stat_activity`) across all databases: pid, database, user, application_name, backend_type, state, wait event, and query text |
-| `currentLocks` | Current locks (`pg_locks`) joined with the holding backend's query and user, plus which pids are blocking each waiting lock; use to diagnose lock contention |
-| `replicationSlots` | Replication slots with retained WAL bytes; a lagging or unused slot holds back WAL indefinitely and is a common cause of disk bloat incidents |
-| `databaseStats` | Per-database statistics (`pg_stat_database`) for every database in the cluster: connections, commits/rollbacks, block hit ratio inputs, tuple counts, conflicts, deadlocks, temp file usage, and checksum failures |
-| `statementStats` | The slowest tracked queries by total execution time (`pg_stat_statements`), with calls, timing, row counts, and buffer usage; returns a clear error with setup instructions if the extension is not installed |
-| `tableBloat` | Physical storage bloat for a table (`pgstattuple`/`pgstattuple_approx`): live/dead tuple counts and percentages, free space and percentage. Defaults to the cheap visibility-map-based approximation; `exact: true` runs a precise but I/O-heavy full table scan. More accurate than the ANALYZE-time estimates in `listTables`/`tableDetails`. Returns a clear error with setup instructions if the extension is not installed |
-| `checkKey` | Check if a row exists by primary key (single or composite); validates value types against PK column types before querying |
-| `explainQuery` | Raw `EXPLAIN (FORMAT JSON)` plan for a statement, recovered from `pg_stat_statements` by `queryid` (full untruncated text) or supplied directly as `sql`. Runs in a read-only transaction bounded by `statement_timeout`. Statements with `$n` placeholders are planned with `GENERIC_PLAN`; supply `params` to have the statement `PREPARE`d and planned with real values. `analyze: true` runs `EXPLAIN (ANALYZE, BUFFERS)` — but only after the plan is proven free of any `ModifyTable` node, so data-modifying statements (including data-modifying CTEs) are never executed, and it requires an explicit `timeout_ms`. Returns the plan verbatim plus `generic`/`analyzed`/`read_only` flags and the `pg_stat_statements` row; no heuristics and no generated DDL — the plan is yours to interpret |
-| `listConnections` | The configured database connections by name, with the libpq `service` name or host/port/dbname/user for each, and which is the default. Passwords are never returned and a service file is never expanded |
+40 read-only operations, grouped as schema exploration, catalog search, cluster-wide
+objects, extensibility and text search, foreign data and replication, monitoring and
+statistics, diagnostics and query planning, and connections. Highlights include
+`tableDetails` (columns, indexes, constraints, foreign keys in both directions, triggers,
+policies), `searchTables` (full-text search across names, descriptions, and enum values),
+and `explainQuery` (recover a slow statement from `pg_stat_statements` by `queryid` and get
+its `EXPLAIN` plan).
 
-Every tool also accepts an optional `connection` argument naming one of the configured connections (see [Configuration](#configuration)); omit it to use the default.
+Each one is documented, with its arguments, in `man pg_licht_mcp` under OPERATIONS. Every
+operation also accepts an optional `connection` argument to select one of several
+configured databases.
 
-## Install
+## Documentation
 
-### Homebrew (macOS and Linux)
+| | |
+|---|---|
+| `man pg_licht_mcp` | configuration, connection strings, all 40 operations, MCP client setup |
+| [INSTALL.md](INSTALL.md) | Homebrew, deb, rpm, tarball, verifying, uninstalling |
+| [BUILD.md](BUILD.md) | building from source, tests, sanitizers, CI, release process |
+| [CHANGES.md](CHANGES.md) | changelog |
+
+Before installing, the manual page can be read straight from the source tree:
 
 ```bash
-brew tap sqlambda/pg-licht
-brew install pg-licht
+man --local-file cpp/man/pg_licht_mcp.1
 ```
-
-### Pre-built packages and binaries
-
-Download the latest release for your platform from the [releases page](https://github.com/sqlambda/pg_licht/releases):
-
-| Platform | File | Format |
-|----------|------|--------|
-| Debian 13 (Trixie) x86_64 | `pg_licht_mcp-linux-x86_64-debian13.deb` | `.deb` |
-| Debian 13 (Trixie) arm64 | `pg_licht_mcp-linux-arm64-debian13.deb` | `.deb` |
-| Rocky Linux 9 x86_64 | `pg_licht_mcp-linux-x86_64-rocky9.rpm` | `.rpm` |
-| Rocky Linux 9 arm64 | `pg_licht_mcp-linux-arm64-rocky9.rpm` | `.rpm` |
-| Linux x86_64 (generic) | `pg_licht_mcp-linux-x86_64.tar.gz` | tarball |
-| Linux arm64 (generic) | `pg_licht_mcp-linux-arm64.tar.gz` | tarball |
-| macOS Apple Silicon | `pg_licht_mcp-macos-arm64.tar.gz` | tarball |
-
-**Debian / Ubuntu / other apt-based distros (`.deb`):**
-
-```bash
-sudo apt install ./pg_licht_mcp-linux-x86_64-debian13.deb
-pg_licht_mcp "postgresql://user:pass@host/dbname"
-```
-
-`apt install ./file.deb` (not `dpkg -i`) so apt resolves the declared `libpq5` dependency automatically. Installs to `/usr/bin/pg_licht_mcp`, already on `PATH`.
-
-**Rocky Linux / RHEL / Fedora / other dnf-based distros (`.rpm`):**
-
-```bash
-sudo dnf install ./pg_licht_mcp-linux-x86_64-rocky9.rpm
-pg_licht_mcp "postgresql://user:pass@host/dbname"
-```
-
-Same reasoning: `dnf install ./file.rpm` resolves the declared `libpq5` dependency; `rpm -i` won't. Installs to `/usr/bin/pg_licht_mcp`.
-
-**Generic tarball (any glibc-based Linux, or macOS):**
-
-```bash
-tar -xzf pg_licht_mcp-<platform>.tar.gz
-./pg_licht_mcp "postgresql://user:pass@host/dbname"
-```
-
-### Build from source
-
-Requirements: CMake 3.20+, a C++23 compiler, libpqxx, libpq, nlohmann_json, pkg-config
-
-Release binaries link libpqxx statically (built from a pinned version) so every platform runs the same libpqxx regardless of what each distro packages; libpq stays a dynamic runtime dependency since its C ABI is stable and distros patch it independently. Local builds use whatever libpqxx your system provides — dynamic or static both work.
-
-```bash
-cmake -S cpp -B cpp/build -DBUILD_TESTING=OFF
-cmake --build cpp/build
-```
-
-## Run
-
-```bash
-DATABASE_URL="postgresql://user:pass@host/dbname" ./pg_licht_mcp
-
-# libpq key-value format also works
-DATABASE_URL="host=localhost port=5432 dbname=mydb" ./pg_licht_mcp
-
-# or as an argument
-./pg_licht_mcp "postgresql://user:pass@host/dbname"
-
-# or several named databases from a config file
-./pg_licht_mcp --config ~/.config/pg_licht/connections.ini
-```
-
-## Configuration
-
-A single database needs nothing beyond `DATABASE_URL`. To reach several databases from one
-server, list them in an INI file:
-
-```ini
-[default]
-port    = 6432
-dbname  = pglicht
-user    = daniel
-sslmode = prefer
-; no password here — use ~/.pgpass or a service file
-
-[prod]
-; a libpq service name, resolved from ~/.pg_service.conf,
-; $PGSERVICEFILE, or $PGSYSCONFDIR/pg_service.conf
-service = db01_ro
-
-[staging]
-service = db01_ro        ; the service supplies the defaults…
-dbname  = db01_staging   ; …and explicit keys override them
-```
-
-Pass a section name as the `connection` argument of any tool to run it against that
-database; omit it to use `[default]` (or, if there is no `[default]`, the first section).
-`listConnections` reports what is configured.
-
-Keys are passed through to libpq, so anything libpq accepts works — including `service`,
-which may be used on its own in place of `host`/`port`/`dbname`/`user`. Each section must
-set either `service` or at least `dbname`. `options` is rejected, because PgBouncer refuses
-GUCs in the startup packet; pg-licht sets what it needs per transaction instead.
-
-The file is resolved in this order: `--config <path>`, `$PG_LICHT_CONFIG`,
-`~/.config/pg_licht/connections.ini` (only if it exists), then `DATABASE_URL`, then
-`argv[1]`.
-
-Because sections may carry passwords, the file must not be group- or world-accessible —
-pg-licht refuses to load it otherwise, the same rule libpq applies to `~/.pgpass`:
-
-```bash
-chmod 600 ~/.config/pg_licht/connections.ini
-```
-
-Note that libpq enforces that rule on `~/.pgpass` but *not* on `pg_service.conf`, so if a
-service file holds a password, its permissions are yours to manage.
-
-## Test
-
-```bash
-DATABASE_URL="port=5432 dbname=mydb" ./cpp/build/pg_licht_mcp_test
-# or
-DATABASE_URL="port=5432 dbname=mydb" ctest --test-dir cpp/build --output-on-failure
-```
-
-Tests create and destroy a temporary database named `pg_licht_test_<PID>` automatically.
-
-### Through a connection pooler
-
-Because the read-only guard is transaction-scoped specifically so it survives a
-transaction-mode pooler, there is a script that verifies exactly that. It stands up a
-throwaway PostgreSQL cluster and a companion PgBouncer (`pool_mode=transaction`,
-`server_reset_query=DISCARD ALL`) in a temp directory, runs the full suite both directly
-and through the pooler, and tears everything down — touching nothing else on the machine:
-
-```bash
-cmake --build cpp/build          # the script needs the test binary built
-cpp/test/run-pooled-tests.sh
-```
-
-Requires `initdb`/`pg_ctl` (PostgreSQL 14+) and `pgbouncer` on the machine; it picks the
-newest installed PostgreSQL and free defaults, all overridable via environment
-(`PG_BINDIR`, `PGBOUNCER`, `PG_PORT`, `BOUNCER_PORT`). CI runs it across PostgreSQL
-14, 15, 16, 17, and 18.
 
 ## PostgreSQL version support
 
-Supports **PostgreSQL 14 and newer**, verified in CI on 14–18. One feature degrades
-gracefully below 16: `explainQuery` can only produce a plan for a `pg_stat_statements`
-statement (whose text is normalized to `$1`/`$2`) by using `EXPLAIN (GENERIC_PLAN)`, which
-is PostgreSQL 16+. On 14/15 that path returns an actionable hint instead — supplying
-`params` (which prepares and plans the statement with real values) works on every supported
-version. Two catalog fields are simply omitted where the column doesn't exist: index
-`last_use` (`pg_stat_user_indexes.last_idx_scan`, PG16+) and subscription `two_phase`
-(`pg_subscription.subtwophasestate`, PG15+).
-
-## Debugging with MCP Inspector
-
-The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) lets you call tools interactively and inspect responses without an AI client.
-
-```bash
-npx @modelcontextprotocol/inspector \
-  -e DATABASE_URL="postgresql://user:pass@host/dbname" \
-  ./cpp/build/pg_licht_mcp
-```
-
-## MCP Configuration
-
-### Claude Code (`claude mcp add`)
-
-The `--scope`/`-s` flag controls where the configuration is saved:
-
-| Scope | Flag | Stored in | Use when |
-|-------|------|-----------|----------|
-| Local (default) | `--scope local` | `~/.claude.json`, under this project's entry | personal, current project only, not shared |
-| Project | `--scope project` | `.mcp.json` in project root | shared with the team via version control (each teammate approves it once) |
-| User | `--scope user` | `~/.claude.json` | available across all your projects |
-
-```bash
-claude mcp add --transport stdio pg-licht \
-  -e DATABASE_URL="postgresql://user:pass@host/dbname" \
-  -- /path/to/pg-licht/cpp/build/pg_licht_mcp
-```
-
-Add `--scope project` or `--scope user` to change where it's saved; omit for the local-only default.
-
-### Manual — `.mcp.json` / `~/.claude.json`
-
-Project-scoped servers live in `.mcp.json` at the project root (commit this to share with your team):
-
-```json
-{
-  "mcpServers": {
-    "pg-licht": {
-      "command": "/path/to/pg-licht/cpp/build/pg_licht_mcp",
-      "args": [],
-      "env": {
-        "DATABASE_URL": "postgresql://user:pass@host/dbname"
-      }
-    }
-  }
-}
-```
-
-Local- and user-scoped servers live in `~/.claude.json` instead (edit via `claude mcp add`/`claude mcp add-json` rather than by hand, since that file also holds per-project state).
-
-### Claude Desktop
-
-Add the same JSON block above under `mcpServers` in `claude_desktop_config.json`.
-
-### Grok Build (`grok mcp add`)
-
-Grok Build reads `.mcp.json` and `~/.claude.json` for compatibility, so an MCP server already configured for Claude Code (above) is picked up automatically — no extra steps needed.
-
-To configure it directly instead:
-
-```bash
-grok mcp add pg-licht -- /path/to/pg-licht/cpp/build/pg_licht_mcp
-```
-
-Environment variables for stdio servers are set in the config file rather than on the command line. `--scope project` writes to `.grok/config.toml` in the project (add it to your repo to share); omit it for the user-level `~/.grok/config.toml`:
-
-```toml
-[mcp_servers.pg-licht]
-command = "/path/to/pg-licht/cpp/build/pg_licht_mcp"
-env = { DATABASE_URL = "postgresql://user:pass@host/dbname" }
-```
-
-Verify with `grok mcp list` or `grok mcp doctor pg-licht`.
+PostgreSQL 14 and newer, verified in CI on 14–18. See the COMPATIBILITY section of
+`man pg_licht_mcp` for the two fields that are version-gated.
 
 ## License
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(pg_licht_mcp VERSION 2.1.0 LANGUAGES CXX)
+project(pg_licht_mcp VERSION 2.2.0 LANGUAGES CXX)
 
 # Standard bin/ and share/man/ layout, so `cmake --install` produces a tree that
 # can be dropped onto a prefix as-is: the release tarballs are staged this way,

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.20)
 project(pg_licht_mcp VERSION 2.1.0 LANGUAGES CXX)
 
+# Standard bin/ and share/man/ layout, so `cmake --install` produces a tree that
+# can be dropped onto a prefix as-is: the release tarballs are staged this way,
+# CPack lays the same tree under /usr for the deb and rpm, and Homebrew installs
+# it into its keg. In every case share/man/man1 is already on the default
+# MANPATH, so `man pg_licht_mcp` works with no further setup.
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -28,7 +35,13 @@ target_link_libraries(pg_licht_mcp
 )
 pglicht_harden(pg_licht_mcp)
 pglicht_apply_sanitizers(pg_licht_mcp)
-install(TARGETS pg_licht_mcp DESTINATION bin)
+install(TARGETS pg_licht_mcp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+# The man page is checked in rather than generated: the release containers
+# (debian:trixie, rockylinux:9) carry no doc toolchain, and the release build
+# runs `--target pg_licht_mcp` rather than `all`, so a generator target would
+# never run and CPack would then fail on a missing install file.
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/man/pg_licht_mcp.1
+        DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
 option(BUILD_TESTING "Build the test suite" ON)
 if(BUILD_TESTING)
@@ -47,6 +60,19 @@ if(BUILD_TESTING)
     pglicht_apply_sanitizers(pg_licht_mcp_test)
     add_test(NAME mcp_test COMMAND pg_licht_mcp_test)
     pglicht_add_valgrind_test(pg_licht_mcp_test)
+
+    # Since the man page is hand-written, lint it here rather than trusting
+    # review. -Wwarning (not -Wall) is deliberate: it fails on real WARNINGs but
+    # ignores STYLE notes such as "referenced manual not found: Xr libpq 3",
+    # which fire on any machine without PostgreSQL's own man pages installed.
+    find_program(MANDOC_EXECUTABLE mandoc)
+    if(MANDOC_EXECUTABLE)
+        add_test(NAME manpage_lint
+                 COMMAND ${MANDOC_EXECUTABLE} -Tlint -Wwarning
+                         ${CMAKE_CURRENT_SOURCE_DIR}/man/pg_licht_mcp.1)
+    else()
+        message(STATUS "mandoc not found: skipping the manpage_lint test")
+    endif()
 endif()
 
 message(STATUS "Using compiler: ${CMAKE_CXX_COMPILER} (${CMAKE_CXX_COMPILER_ID})")

--- a/cpp/man/pg_licht_mcp.1
+++ b/cpp/man/pg_licht_mcp.1
@@ -1,0 +1,745 @@
+.\" Copyright (c) 2026 Daniel Cristian.
+.\" Licensed under the Apache License, Version 2.0; see LICENSE.
+.\"
+.Dd August 3, 2026
+.Dt PG_LICHT_MCP 1
+.Os pg-licht
+.Sh NAME
+.Nm pg_licht_mcp
+.Nd read-only PostgreSQL catalog exploration server for the Model Context Protocol
+.Sh SYNOPSIS
+.Nm
+.Op Fl c Ar file.ini
+.Op Ar database_url
+.Nm
+.Fl h
+.Sh DESCRIPTION
+.Nm
+is a Model Context Protocol server that exposes the PostgreSQL system catalog to
+an MCP client over JSON-RPC 2.0 on standard input and standard output.
+It is meant to be launched by the client, not run interactively.
+.Pp
+.Nm
+queries the catalog only: schemas, tables, columns, functions, types, roles, and
+the statistics views.
+It does not read user table data, with the single narrow exception of
+.Ic checkKey ,
+which tests a primary key for existence.
+Every tool call runs inside its own
+.Ql READ ONLY
+transaction; see
+.Sx SECURITY CONSIDERATIONS .
+.Pp
+The options are as follows:
+.Bl -tag -width Ds
+.It Fl c Ar file.ini , Fl -config Ar file.ini
+Read named database connections from the INI file
+.Ar file.ini
+instead of taking a single connection string from the environment.
+See
+.Sx CONFIGURATION .
+.It Fl h , Fl -help
+Print a usage summary and the connection resolution order, then exit.
+.El
+.Pp
+A single positional
+.Ar database_url
+argument is used as the connection string when neither a configuration file nor
+.Ev DATABASE_URL
+is present.
+.Ss Selecting a database
+When a configuration file defines more than one connection, every operation
+accepts an optional
+.Va connection
+argument naming one of its sections; omitting it uses the default section.
+.Ic listConnections
+reports what is configured.
+.Sh CONFIGURATION
+.Ss Connection strings
+A connection string is handed to libpq unchanged, so both accepted forms work:
+.Bd -literal -offset indent
+postgresql://user:pass@host:5432/dbname?sslmode=require
+host=localhost port=5432 dbname=mydb user=daniel
+.Ed
+.Pp
+A single database needs nothing beyond
+.Ev DATABASE_URL .
+.Ss The connections file
+To reach several databases from one server, list them as INI sections:
+.Bd -literal -offset indent
+[default]
+port    = 6432
+dbname  = pglicht
+user    = daniel
+sslmode = prefer
+; no password here \(em use ~/.pgpass or a service file
+
+[prod]
+; a libpq service name, resolved from ~/.pg_service.conf,
+; $PGSERVICEFILE, or $PGSYSCONFDIR/pg_service.conf
+service = db01_ro
+
+[staging]
+service = db01_ro        ; the service supplies the defaults
+dbname  = db01_staging   ; and explicit keys override them
+.Ed
+.Pp
+Pass a section name as the
+.Va connection
+argument of any operation to run it against that database; omit it to use
+.Sy [default] ,
+or, if there is no
+.Sy [default] ,
+the first section in the file.
+.Ss libpq passthrough and services
+Keys are passed through to libpq, so anything libpq accepts works, including
+.Va service ,
+which may be used on its own in place of
+.Va host ,
+.Va port ,
+.Va dbname ,
+and
+.Va user .
+A service name is resolved from
+.Pa ~/.pg_service.conf ,
+.Ev PGSERVICEFILE ,
+or
+.Pa $PGSYSCONFDIR/pg_service.conf .
+.Pp
+Each section must set either
+.Va service
+or at least
+.Va dbname ;
+a section with neither is reported by name at startup rather than failing later
+with an obscure libpq error.
+.Pp
+The key
+.Va options
+is rejected.
+PgBouncer refuses GUCs in the startup packet, so
+.Nm
+sets what it needs per transaction instead; see
+.Sx SECURITY CONSIDERATIONS .
+.Ss Resolution order
+The connection source is resolved in this order:
+.Bl -enum -width 2n
+.It
+.Fl -config Ar file
+.It
+.Ev PG_LICHT_CONFIG
+.It
+.Pa ~/.config/pg_licht/connections.ini ,
+only if it exists
+.It
+.Ev DATABASE_URL
+.It
+the positional
+.Ar database_url
+argument
+.El
+.Ss File permissions
+Because sections may carry passwords, the configuration file must not be group-
+or world-accessible.
+.Nm
+refuses to load it otherwise, the same rule libpq applies to
+.Pa ~/.pgpass :
+.Bd -literal -offset indent
+chmod 600 ~/.config/pg_licht/connections.ini
+.Ed
+.Pp
+Note that libpq enforces that rule on
+.Pa ~/.pgpass
+but not on
+.Pa pg_service.conf ,
+so if a service file holds a password its permissions are yours to manage.
+.Sh OPERATIONS
+Every operation below except
+.Ic listConnections
+also accepts an optional
+.Va connection
+argument naming a section of the configuration file; omit it to use the default
+connection.
+Arguments shown as
+.Ar name
+are required.
+.Ss Schema exploration
+.Bl -tag -width Ds
+.It Ic listSchemas
+All schemas with their table and view names and role grants.
+.It Ic listTables Ar schema
+Tables and views in
+.Ar schema
+with kind, row counts, sizes, scan stats, autovacuum stats (dead and live
+tuples, mods-since-analyze, inserts-since-vacuum, last vacuum and analyze,
+per-table reloptions), columns (name, description, per-column index count), and
+index and constraint counts.
+Full index and constraint definitions live in
+.Ic tableDetails ,
+not here; this operation is deliberately light for browsing a schema.
+.It Ic tableDetails Ar schema Ar table
+Columns (types, nullability, defaults,
+.Li pg_stats
+histograms, per-column TOAST storage strategy and compression method), TOAST
+table (name, size, index size;
+.Dv null
+if the table has no toastable columns), primary key as an ordered column list,
+indexes (size, usage counts), constraints, foreign keys, inbound foreign keys
+.Pq Va referenced_by ,
+triggers (timing, events, when condition, language), rules (excluding the
+implicit view
+.Li _RETURN
+rule), row-level security status and policies, view definition, scan stats, and
+role grants.
+.It Ic listFunctions Ar schema
+Functions and procedures in
+.Ar schema
+with kind, language, return type, arguments, volatility,
+.Va security_definer ,
+and
+.Va is_strict .
+.It Ic functionDetails Ar schema Ar function
+Source code, full definition, arguments, volatility, trigger usage, and role
+grants.
+.It Ic listEnums Ar schema
+Enum types in
+.Ar schema
+with their ordered values and descriptions.
+.It Ic enumDetails Ar schema Ar enum
+Ordered values and every column, across all tables, that references the enum.
+.It Ic listTypes Ar schema
+Composite types, domains, and range types in
+.Ar schema .
+Excludes enums, implicit table and view row types, and the auto-generated
+multirange companion of each range type.
+Composites include their attribute list, domains include base type, nullability,
+default, and constraints, and ranges include the subtype and multirange type
+name.
+.It Ic typeDetails Ar schema Ar type
+Attributes, constraints, or subtype of a composite type, domain, or range type,
+and which columns use it.
+.It Ic listSequences Ar schema
+Sequences in
+.Ar schema
+with data type, range, increment, cycle, cache size, current value, and owning
+table and column for
+.Ic SERIAL
+and
+.Ic IDENTITY
+columns.
+.It Ic listExtendedStatistics Ar schema
+Extended statistics objects
+.Pq Ic CREATE STATISTICS
+for
+.Ar schema
+with target table, columns, statistics kinds (ndistinct, dependencies, mcv), and
+description.
+.El
+.Ss Catalog search
+.Bl -tag -width Ds
+.It Ic searchTables Ar web_search
+Full-text search across table and schema names, descriptions, column names and
+descriptions, enum values used by columns, and role names.
+Returns the same fields as
+.Ic listTables
+plus
+.Va roles .
+.It Ic searchFunctions Ar web_search
+Full-text search across function names, source code, language, trigger names,
+and descriptions.
+.It Ic searchEnums Ar web_search
+Full-text search across enum names, values, and descriptions.
+.El
+.Ss Cluster-wide objects
+.Bl -tag -width Ds
+.It Ic listRoles
+Cluster-wide roles with kind (login or group), attributes (superuser,
+create_role, create_db, replication, bypass_rls, connection_limit, valid_until),
+and group memberships.
+.It Ic listTablespaces
+Cluster-wide tablespaces with owner, filesystem location, options, and
+description.
+.It Ic listEventTriggers
+Cluster-wide event triggers with event type, tags, function, owner, enabled
+status, and description.
+.It Ic listLanguages
+Procedural languages installed in the current database, such as
+.Li plpgsql
+or
+.Li plpython3u ,
+with owner, trusted and procedural flags, handler function, and description.
+.It Ic listAccessMethods
+Index and table access methods available in the cluster (btree, gist, gin, heap,
+and so on) with type and handler function.
+.It Ic listCasts
+Type casts involving at least one user-defined type, excluding
+built-in-to-built-in casts, with source and target types, context, and method.
+.It Ic listExtensions
+Installed extensions with version, schema, relocatable flag, and description.
+.El
+.Ss Extensibility and text search
+.Bl -tag -width Ds
+.It Ic listCollations Ar schema
+Collations usable in the current database's encoding for
+.Ar schema ,
+with provider, locale settings, and determinism flag.
+.It Ic listOperators Ar schema
+Custom operators in
+.Ar schema
+with left and right operand types, result type, and implementing function.
+Mostly relevant for schemas using extensions with custom types, such as PostGIS.
+.It Ic listOperatorClasses Ar schema
+Operator classes in
+.Ar schema
+with their index access method, input type, and default flag.
+Describes which index types a given type supports.
+.It Ic listTextSearchConfigs Ar schema
+Full-text search configurations for
+.Ar schema
+with parser and the token-type-to-dictionary mapping.
+.El
+.Ss Foreign data and replication
+.Bl -tag -width Ds
+.It Ic listForeignTables Ar schema
+Foreign tables in
+.Ar schema
+with their foreign server, foreign data wrapper, options, and columns.
+User mapping credentials are never exposed.
+.It Ic listForeignServers
+Cluster-wide foreign servers with foreign data wrapper, owner, and options;
+host, port, and dbname-style options only, never user mapping credentials.
+.It Ic listPublications
+Logical replication publications with owner, all-tables flag, per-operation
+flags, and member tables.
+.It Ic listSubscriptions
+Logical replication subscriptions for the current database with owner, enabled
+status, publications, slot name, and sync settings.
+The connection string is never exposed, as it may contain credentials.
+.It Ic replicationSlots
+Replication slots with retained WAL bytes.
+A lagging or unused slot holds back WAL indefinitely and is a common cause of
+disk bloat incidents.
+.El
+.Ss Monitoring and statistics
+.Bl -tag -width Ds
+.It Ic databaseSize
+Current database name and total disk size.
+.It Ic serverSettings
+All server settings
+.Pq Li pg_settings
+grouped by category, each with current value, unit, description, context, type,
+source, and
+.Va pending_restart
+flag.
+.It Ic currentActivity
+Current server connections and running queries
+.Pq Li pg_stat_activity
+across all databases: pid, database, user, application_name, backend_type,
+state, wait event, and query text.
+.It Ic currentLocks
+Current locks
+.Pq Li pg_locks
+joined with the holding backend's query and user, plus which pids are blocking
+each waiting lock.
+Use to diagnose lock contention.
+.It Ic databaseStats
+Per-database statistics
+.Pq Li pg_stat_database
+for every database in the cluster: connections, commits and rollbacks, block hit
+ratio inputs, tuple counts, conflicts, deadlocks, temp file usage, and checksum
+failures.
+.It Ic statementStats Op Va limit
+The slowest tracked queries by total execution time
+.Pq Li pg_stat_statements ,
+with calls, timing, row counts, and buffer usage.
+Returns a clear error with setup instructions if the extension is not installed.
+.Pp
+.Bl -tag -width "timeout_ms" -compact
+.It Va limit
+Maximum number of statements to return.
+Defaults to 20.
+.El
+.El
+.Ss Diagnostics and query planning
+.Bl -tag -width Ds
+.It Ic tableBloat Ar schema Ar table Op Va exact
+Physical storage bloat for a table
+.Pq Li pgstattuple No or Li pgstattuple_approx :
+table size, live and dead tuple counts and percentages, free space and
+percentage.
+More accurate than the ANALYZE-time estimates in
+.Ic listTables
+and
+.Ic tableDetails .
+Returns a clear error with setup instructions if the extension is not installed.
+.Pp
+.Bl -tag -width "timeout_ms" -compact
+.It Va exact
+Run a precise but I/O-heavy full table scan instead of the cheap
+visibility-map-based approximation.
+Default
+.Dv false .
+.El
+.It Ic checkKey Ar schema Ar table Ar values
+Check whether a row exists by primary key, single or composite.
+Value types are validated against the primary key column types before querying.
+.Pp
+.Bl -tag -width "timeout_ms" -compact
+.It Va values
+Ordered array of primary key values, matching the key columns in order.
+.El
+.It Ic explainQuery Op Va queryid | Va sql
+Raw
+.Ql "EXPLAIN (FORMAT JSON)"
+plan for a statement, recovered from
+.Li pg_stat_statements
+by
+.Va queryid
+or supplied directly as
+.Va sql .
+Runs in a read-only transaction bounded by
+.Va statement_timeout .
+Returns the plan verbatim plus
+.Va generic ,
+.Va analyzed ,
+and
+.Va read_only
+flags and the
+.Li pg_stat_statements
+row.
+There are no heuristics and no generated DDL; the plan is yours to interpret.
+.Pp
+.Bl -tag -width "timeout_ms" -compact
+.It Va queryid
+A
+.Li pg_stat_statements
+queryid, as a decimal string.
+It is a 64-bit value and does not survive JSON number precision.
+Mutually exclusive with
+.Va sql .
+.It Va sql
+A single
+.Ic SELECT , INSERT , UPDATE , DELETE , MERGE , WITH , TABLE ,
+or
+.Ic VALUES
+statement.
+Utility statements are rejected.
+Mutually exclusive with
+.Va queryid .
+.It Va params
+Concrete values for the statement's
+.Ar $1
+through
+.Ar $n
+placeholders, in order.
+Statements recovered from
+.Li pg_stat_statements
+are normalized, so without params they are planned with
+.Ql GENERIC_PLAN ;
+supplying params has the statement
+.Ic PREPARE Ns d
+and planned with real values.
+.It Va analyze
+Run
+.Ql "EXPLAIN (ANALYZE, BUFFERS)" ,
+which really executes the statement.
+Honoured only after the plan is proven free of any
+.Li ModifyTable
+node, so data-modifying statements, including data-modifying CTEs, are never
+executed.
+Requires
+.Va timeout_ms .
+Default
+.Dv false .
+.It Va timeout_ms
+Statement timeout in milliseconds, clamped to 100 through 30000.
+Defaults to 5000 for plan-only calls.
+.El
+.El
+.Ss Connections
+.Bl -tag -width Ds
+.It Ic listConnections
+The configured database connections by name, with the libpq
+.Va service
+name or host, port, dbname, and user for each, and which is the default.
+Passwords are never returned and a service file is never expanded.
+This is the only operation that does not take a
+.Va connection
+argument.
+.El
+.Sh ENVIRONMENT
+.Bl -tag -width ".Ev PG_LICHT_CONFIG"
+.It Ev DATABASE_URL
+Connection string used when no configuration file is found.
+Accepts either libpq form.
+.It Ev PG_LICHT_CONFIG
+Path to a connections INI file, consulted after
+.Fl -config
+and before
+.Pa ~/.config/pg_licht/connections.ini .
+.It Ev PGSERVICEFILE
+Path to a libpq service file, used to resolve a
+.Va service
+key.
+.It Ev PGSYSCONFDIR
+Directory holding the system-wide
+.Pa pg_service.conf .
+.It Ev PGPASSFILE
+Path to a libpq password file; defaults to
+.Pa ~/.pgpass .
+.It Ev HOME
+Used to locate
+.Pa ~/.config/pg_licht/connections.ini .
+.El
+.Pp
+Any other libpq environment variable is honoured as usual, since connection
+strings are passed through unchanged.
+.Sh FILES
+.Bl -tag -width ".Pa ~/.config/pg_licht/connections.ini"
+.It Pa ~/.config/pg_licht/connections.ini
+Default connections file, used only if it exists.
+Must not be group- or world-accessible.
+.It Pa ~/.pg_service.conf
+libpq service definitions, referenced by the
+.Va service
+key.
+.It Pa ~/.pgpass
+libpq password file, the recommended place for passwords.
+.It Pa .mcp.json
+Project-scoped MCP client configuration, in a repository root.
+.It Pa ~/.claude.json
+Local- and user-scoped MCP client configuration.
+.It Pa ~/.grok/config.toml
+Grok Build MCP client configuration.
+.El
+.Sh EXIT STATUS
+.Ex -std
+.Pp
+.Nm
+exits non-zero when no connection source is given, when the configuration file
+cannot be parsed or has unsafe permissions, or when the default connection
+cannot be reached at startup.
+.Sh EXAMPLES
+.Ss Standalone
+Run against a single database given by the environment:
+.Bd -literal -offset indent
+DATABASE_URL="postgresql://user:pass@host/dbname" pg_licht_mcp
+.Ed
+.Pp
+The libpq key-value form works too, as does a positional argument or a
+configuration file:
+.Bd -literal -offset indent
+DATABASE_URL="host=localhost port=5432 dbname=mydb" pg_licht_mcp
+pg_licht_mcp "postgresql://user:pass@host/dbname"
+pg_licht_mcp --config ~/.config/pg_licht/connections.ini
+.Ed
+.Ss Claude Code
+Register the server with
+.Ic claude mcp add :
+.Bd -literal -offset indent
+claude mcp add --transport stdio pg-licht \e
+  -e DATABASE_URL="postgresql://user:pass@host/dbname" \e
+  -- /usr/local/bin/pg_licht_mcp
+.Ed
+.Pp
+The
+.Fl -scope
+flag controls where the configuration is written:
+.Bl -column "Local (default)" "--scope project" "~/.claude.json" -offset indent
+.It Sy Scope Ta Sy Flag Ta Sy Stored in
+.It "Local (default)" Ta Fl -scope Cm local Ta Pa ~/.claude.json
+.It Project Ta Fl -scope Cm project Ta Pa .mcp.json
+.It User Ta Fl -scope Cm user Ta Pa ~/.claude.json
+.El
+.Pp
+Local scope is personal and limited to the current project, project scope is
+shared with the team through version control, and user scope applies across all
+of your projects.
+.Ss Project configuration
+A project-scoped server lives in
+.Pa .mcp.json
+at the repository root; commit it to share it with the team:
+.Bd -literal -offset indent
+{
+  "mcpServers": {
+    "pg-licht": {
+      "command": "/usr/local/bin/pg_licht_mcp",
+      "args": [],
+      "env": {
+        "DATABASE_URL": "postgresql://user:pass@host/dbname"
+      }
+    }
+  }
+}
+.Ed
+.Pp
+Local- and user-scoped servers live in
+.Pa ~/.claude.json
+instead.
+Edit that file with
+.Ic claude mcp add
+or
+.Ic claude mcp add-json
+rather than by hand, since it also holds per-project state.
+.Ss Claude Desktop
+Add the same JSON block under
+.Va mcpServers
+in
+.Pa claude_desktop_config.json .
+.Ss Grok Build
+Grok Build reads
+.Pa .mcp.json
+and
+.Pa ~/.claude.json
+for compatibility, so a server already configured for Claude Code is picked up
+automatically.
+To configure it directly:
+.Bd -literal -offset indent
+grok mcp add pg-licht -- /usr/local/bin/pg_licht_mcp
+.Ed
+.Pp
+Environment variables for stdio servers are set in the configuration file rather
+than on the command line.
+.Fl -scope Cm project
+writes to
+.Pa .grok/config.toml
+in the project; omit it for the user-level
+.Pa ~/.grok/config.toml :
+.Bd -literal -offset indent
+[mcp_servers.pg-licht]
+command = "/usr/local/bin/pg_licht_mcp"
+env = { DATABASE_URL = "postgresql://user:pass@host/dbname" }
+.Ed
+.Pp
+Verify with
+.Ic grok mcp list
+or
+.Ic grok mcp doctor pg-licht .
+.Sh DIAGNOSTICS
+.Bl -tag -width Ds
+.It Sy Fatal DB Error No at startup
+The default connection could not be reached, or the configuration file could not
+be parsed.
+The libpq or parser message follows.
+.It Sy config file ... is group/world accessible
+The connections file has unsafe permissions; see
+.Sx File permissions .
+.It Sy [section] must set either 'service' or at least 'dbname'
+A configuration section is incomplete.
+The offending section is named.
+.It Sy unknown connection ...
+The
+.Va connection
+argument does not match any configured section.
+The message lists the configured names.
+.It Sy pg_stat_statements is not installed
+.Ic statementStats
+and the
+.Va queryid
+path of
+.Ic explainQuery
+require the extension.
+The returned hint gives the setup steps.
+An equivalent error is returned for
+.Li pgstattuple
+by
+.Ic tableBloat .
+.It Sy SQLSTATE Er 25006
+A statement attempted to write inside the read-only transaction.
+This is the backstop described in
+.Sx SECURITY CONSIDERATIONS
+and should not occur in normal use.
+.It Sy unsupported startup parameter in options
+PgBouncer rejected a GUC in the startup packet.
+Remove the
+.Va options
+key from the configuration file.
+.El
+.Sh COMPATIBILITY
+.Nm
+supports PostgreSQL 14 and newer, and is verified on 14 through 18.
+.Pp
+One feature degrades gracefully below 16.
+.Ic explainQuery
+can only plan a normalized
+.Li pg_stat_statements
+statement by using
+.Ql "EXPLAIN (GENERIC_PLAN)" ,
+which requires PostgreSQL 16.
+On 14 and 15 that path returns an actionable hint instead; supplying
+.Va params ,
+which prepares and plans the statement with real values, works on every
+supported version.
+.Pp
+Two catalog fields are omitted where the underlying column does not exist: the
+index
+.Va last_use
+field
+.Pq Li pg_stat_user_indexes.last_idx_scan , No PostgreSQL 16 and newer
+and the subscription
+.Va two_phase
+field
+.Pq Li pg_subscription.subtwophasestate , No PostgreSQL 15 and newer .
+.Sh SEE ALSO
+.Xr pgbouncer 1 ,
+.Xr psql 1 ,
+.Xr libpq 3
+.Pp
+.Lk https://github.com/sqlambda/pg_licht "pg-licht source and releases"
+.Pp
+.Lk https://modelcontextprotocol.io/ "Model Context Protocol specification"
+.Sh HISTORY
+.Nm
+first appeared in 2025.
+Version 2.0 extended it to full pgAdmin-shaped catalog parity.
+Version 2.1 made the read-only guard per transaction rather than per session,
+added named multi-database connections, and added
+.Ic explainQuery .
+.Sh AUTHORS
+.An Daniel Cristian Aq Mt danielcristian@gmail.com
+.Sh SECURITY CONSIDERATIONS
+Every catalog query is parameterized, using
+.Ar $1
+and
+.Ar $2
+bindings or
+.Li ::regnamespace
+and
+.Li ::regclass
+casts.
+No schema, table, or search-term argument is ever concatenated into SQL text.
+.Pp
+The one deliberate exception is
+.Ic explainQuery ,
+which must place the statement under analysis into the
+.Ic EXPLAIN
+text because
+.Ic EXPLAIN
+cannot take a bind parameter.
+It is guarded by a leading-keyword whitelist, a single-statement check,
+.Ic PREPARE Ns d
+parameter binding with every value escaped through libpq, a
+.Li ModifyTable
+gate that refuses to execute anything that writes, and a bounded
+.Va statement_timeout .
+.Pp
+Every tool call runs inside its own
+.Ql READ ONLY
+transaction, so even a bug that let a query attempt a write would fail with
+SQLSTATE
+.Er 25006
+rather than succeed silently.
+.Pp
+That guard is deliberately transaction-scoped rather than session-scoped.
+Under a connection pooler in transaction mode, such as PgBouncer with
+.Li pool_mode = transaction
+and
+.Li server_reset_query = DISCARD ALL ,
+the server connection is returned to the pool at commit and its session state is
+wiped, so a
+.Ic SET
+issued once at startup silently stops applying to later calls.
+Transaction scope is the scope a pooler preserves.
+The setting cannot be pushed into the connection string either: PgBouncer
+rejects GUCs in the startup packet outright, which is why the
+.Va options
+configuration key is refused.

--- a/cpp/man/pg_licht_mcp.1
+++ b/cpp/man/pg_licht_mcp.1
@@ -1,7 +1,7 @@
 .\" Copyright (c) 2026 Daniel Cristian.
 .\" Licensed under the Apache License, Version 2.0; see LICENSE.
 .\"
-.Dd August 3, 2026
+.Dd August 4, 2026
 .Dt PG_LICHT_MCP 1
 .Os pg-licht
 .Sh NAME
@@ -694,6 +694,7 @@ Version 2.0 extended it to full pgAdmin-shaped catalog parity.
 Version 2.1 made the read-only guard per transaction rather than per session,
 added named multi-database connections, and added
 .Ic explainQuery .
+This manual page first appeared in version 2.2.
 .Sh AUTHORS
 .An Daniel Cristian Aq Mt danielcristian@gmail.com
 .Sh SECURITY CONSIDERATIONS

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -18,14 +18,16 @@ bool file_exists(const std::string& path) {
 
 void usage(const char* argv0) {
   std::cerr
-    << "Uso: " << argv0 << " [--config <arquivo.ini>] [database_url]" << std::endl
+    << "Usage: " << argv0 << " [--config <file.ini>] [database_url]" << std::endl
     << std::endl
-    << "Ordem de resolucao:" << std::endl
-    << "  1. --config <arquivo>" << std::endl
+    << "Resolution order:" << std::endl
+    << "  1. --config <file>" << std::endl
     << "  2. $PG_LICHT_CONFIG" << std::endl
-    << "  3. ~/.config/pg_licht/connections.ini (se existir)" << std::endl
+    << "  3. ~/.config/pg_licht/connections.ini (if present)" << std::endl
     << "  4. $DATABASE_URL" << std::endl
-    << "  5. argv[1]" << std::endl;
+    << "  5. argv[1]" << std::endl
+    << std::endl
+    << "See pg_licht_mcp(1) for the full manual." << std::endl;
 }
 
 }  // namespace
@@ -38,7 +40,7 @@ int main(int argc, char *argv[]) {
     std::string arg = argv[i];
     if (arg == "--config" || arg == "-c") {
       if (i + 1 >= argc) {
-        std::cerr << "--config requer um caminho de arquivo." << std::endl;
+        std::cerr << "--config requires a file path." << std::endl;
         return 1;
       }
       config_path = argv[++i];


### PR DESCRIPTION
## Summary

`README.md` had grown to 297 lines and was four documents wearing one hat: what the project is, how to install it on five platforms, how to configure it, a 40-row table of every tool, how to wire it into four MCP clients, and how to run the test suite. The reference material was also in the worst possible place — a web page you can't consult from the terminal where the server actually runs.

Split by audience, with the reference material moved into a real man page:

| File | Audience | Content |
|---|---|---|
| `README.md` (297 → **72** lines) | deciding whether to use it | purpose, safety summary, quick start, links |
| `INSTALL.md` (new) | installing a release | Homebrew, deb, rpm, tarball, verify, uninstall |
| `BUILD.md` (new) | contributors | source build, options, tests, pooled rig, sanitizers, CI, release process |
| `cpp/man/pg_licht_mcp.1` (new) | *using* it | configuration, connection strings, all 40 operations, MCP client setup, environment, files, diagnostics, compatibility, security |

`man pg_licht_mcp` works after installing from **any** channel — Homebrew, deb, rpm, or tarball.

## The man page

Hand-written **mdoc** (FreeBSD style), **section 1** — the same section `pgbouncer(1)`, `psql(1)`, and `pg_dump(1)` use; section 8 is for root-run system utilities with init integration, which this isn't.

**One page serves every platform.** mdoc renders through groff on Linux (`man-db` depends on `groff-base`, which ships `mdoc.tmac`) and is native on macOS/BSD. Verified rendering under both mandoc and groff, and separately inside a `rockylinux:9` container as well as Debian.

`.Os pg-licht` is set explicitly: a bare `.Os` renders the *rendering machine's* identity, which would footer as "Debian" here and "Darwin" on macOS for one cross-platform tool.

It is **checked in rather than generated** — the release containers carry no doc toolchain, and the release build runs `--target pg_licht_mcp` rather than `all`, so a generator target would never run and CPack would then fail on a missing install file.

## Packaging

- `CMakeLists.txt` gains `include(GNUInstallDirs)` and installs the page to `${CMAKE_INSTALL_MANDIR}/man1` → `/usr/share/man/man1` in the deb and rpm (CPack reuses the install rules) and in the Homebrew keg (**no formula change** — the tap already runs `cmake --install`).
- **Release tarballs are now staged through `cmake --install`** rather than tarred out of the build tree, so they carry the page too. ⚠️ **This changes their layout** from a flat binary to `bin/` + `share/man/`; `INSTALL.md` documents unpacking straight onto a prefix (`sudo tar -xzf … -C /usr/local`).
- A `manpage_lint` ctest gates the page with `mandoc -Tlint -Wwarning` (not `-Wall` — it must fail on real warnings while tolerating STYLE notes like `referenced manual not found: Xr libpq 3`, which fire on any machine without PostgreSQL's own man pages).

**No new build dependencies.** The man page is static, so building and installing needs no doc toolchain; verified by configuring and building with mandoc unavailable. `mandoc` is added to the `sanitize` CI job only, because the lint gate was otherwise silently skipping on every runner.

Also translates `main.cpp`'s `--help` from Portuguese to English and points it at `pg_licht_mcp(1)`, which is how a user discovers the manual exists.

## Verification

- **All 40 tools documented** — mechanical diff of `get_tools_list()` against the page's `.It Ic` entries: exact match.
- `cmake --install` produces exactly `bin/pg_licht_mcp` + `share/man/man1/pg_licht_mcp.1`; `man pg_licht_mcp` resolves and renders from a staged prefix.
- `dpkg -c` and `rpm -qlp` both list the page. (rpmbuild's `brp-compress` gzips it to `.1.gz`, which is idiomatic and `man` reads transparently — the anticipated `%files` breakage did not occur, so no CPack workaround was needed.)
- Tarball unpacks onto a prefix correctly; no `./` prefix, no top-level dir, no macOS AppleDouble entries.
- `ctest` 3/3 green including Valgrind and the new lint gate; the pooled rig still passes **176/176** directly and through the transaction-mode pooler.