### PR TITLE
v3.0.0: operational diagnostics, targeted lookups, and host capacity correlation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.0 (unreleased)
+## 3.0.0 (2026-08-06)
 
 ### Breaking
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 2.3.0 (unreleased)
+
+### New tools
+
+- **`wraparoundStatus`** — transaction id and multixact headroom, the one failure mode where a monitoring gap ends in a full cluster outage rather than a slowdown. Reports `age(datfrozenxid)` and `age(datminmxid)` for every database and the oldest tables by `age(relfrozenxid)`, each expressed both as a percentage of `autovacuum_freeze_max_age` (where an anti-wraparound autovacuum is forced) and of the hard limit of 2 146 483 647 (where the cluster stops accepting commands that assign a transaction id) — two thresholds that are an order of magnitude apart and are routinely confused.
+
+  Per-table freeze storage parameters are resolved, so a table with its own `autovacuum_freeze_max_age` is measured against *its* limit, not the server's, and the output says which one applied. TOAST tables are included and labelled with the table they belong to: they carry their own `relfrozenxid`, never appear in `pg_stat_user_tables`, and are frequently the relation actually holding the horizon back.
+
+- **`duplicateIndexes`** — indexes that duplicate, or are covered by, another index on the same table. `identical` groups indexes matching on key columns, operator classes, collations, sort order, `INCLUDE` columns and partial predicate; `redundant` reports an index whose keys are a leading prefix of a wider index that also covers its `INCLUDE` columns.
+
+  The comparison key is a per-column signature built from the column *expression* rather than `indkey`. Comparing attribute numbers instead would call any two expression indexes identical (an expression column is attnum 0) and would treat `(a DESC)` as covered by `(a, b)`, which it cannot serve. A unique index is never reported as redundant for being a prefix — dropping it would drop a constraint the wider index does not enforce. Each entry carries size, `idx_scan`, the backing constraint name, and the replica identity and validity flags, since those decide whether the index can be dropped at all.
+
+- **`checkpointStats`** — checkpoint, WAL and background writer activity: timed against requested checkpoints and the ratio between them, write and sync time, buffers written by the checkpointer, by the background writer, and directly by backends, plus `pg_stat_wal` volume and the settings that govern all of it.
+
+  PostgreSQL 17 split the checkpointer counters out of `pg_stat_bgwriter` into `pg_stat_checkpointer`, renamed them, and moved the backend-written buffer counts to `pg_stat_io`; PostgreSQL 18 dropped four more columns from `pg_stat_wal`. All of that is gated on the server version and normalized to one set of field names, so a caller never branches on the major; a `source` field names the views that produced the numbers.
+
+- **`tableIOStats`** — buffer cache hit ratio per object from `pg_statio_all_tables`: `heap_blks_read` against `heap_blks_hit`, the index pair, the TOAST and TOAST-index pairs, and a combined ratio, with relation size and scan counts. Naming a single table adds a per-index breakdown. A ratio is null rather than zero for an object that has seen no reads, so "no traffic" is not misread as "every read missed the cache".
+
+- **`hostCapacity`** — memory and parallelism settings correlated with the machine PostgreSQL runs on. Every memory-related setting is resolved to bytes whatever unit it is counted in (8kB pages for `shared_buffers`, kB for `work_mem`, …), alongside `shared_buffers` and `effective_cache_size` as a percentage of RAM, `work_mem × max_connections`, `maintenance_work_mem × autovacuum_max_workers`, their combined total, and parallel workers per vCPU.
+
+  Numbers only, no verdicts, matching `explainQuery`'s stance that interpretation belongs to the caller — with two factual caveats returned inline, since the worst-case figures are easy to misread: `work_mem` is a per-node rather than per-connection limit, and the OS page cache is not counted.
+
+### Configuration
+
+- **Host capacity injection.** Total RAM and vCPU count are properties of the host, not of the cluster: no catalog holds them, and a backend could not read them portably in any case — it would read the *client's* host. Three paths supply them, and `hostCapacity` reports which one did:
+
+  - `host_ram_mb`, `host_vcpus`, `host_storage` and `host_note` keys per section of the connections file. They are consumed by pg-licht and never reach libpq, which would reject the whole connection string over an unrecognised keyword. A non-numeric or non-positive value is rejected at startup naming the section and the key: `64GB` where megabytes are meant would be wrong by three orders of magnitude and would silently invalidate every derived ratio.
+  - `PG_LICHT_HOST_RAM_MB`, `PG_LICHT_HOST_VCPUS`, `PG_LICHT_HOST_STORAGE` and `PG_LICHT_HOST_NOTE`, honoured only with the single-connection `DATABASE_URL` form, where there is no question which host they describe. With a connections file each section declares its own, since the sections may live on different machines.
+  - `ram_mb` and `vcpus` arguments to `hostCapacity` itself, taking precedence over both — the path for an agent that inspects the host at run time.
+
+  Nothing is ever inferred: with no RAM figure, every ratio that needs one is null and the result carries a hint naming the three ways to supply it.
+
+- **`listConnections`** now echoes the configured host capacity per connection, so a caller can see which ones still need it injected.
+
 ## 2.2.0 (2026-08-04)
 
 ### Documentation

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.3.0 (unreleased)
+## 3.0.0 (unreleased)
 
 ### Breaking
 
@@ -33,6 +33,27 @@
   PostgreSQL 17 renamed the vacuum dead-tuple columns from counts to bytes (`max_dead_tuples` → `max_dead_tuple_bytes`, `num_dead_tuples` → `num_dead_item_ids`). Both are reported under their own names with a `dead_tuple_unit` label rather than forced into one field, because they measure genuinely different things.
 
 - **`ioStats`** — `pg_stat_io` per backend type, object and context: reads, writes, extends, hits, evictions, reuses, fsyncs and their timings, with a hit percentage. This is where buffers written directly by backends, vacuum's ring-buffer reuse, and bulk read/write I/O become visible separately from the aggregate counters. Rows with no activity are omitted, since the view is a dense matrix of combinations most of which are structurally impossible. Requires PostgreSQL 16, and says so plainly on older servers rather than failing with an undefined-table error.
+
+### Targeted lookups
+
+The monitoring tools were all-or-nothing: they returned the whole view, which is fine on a test box and unusable on a server with several hundred backends. They now take optional filters, all of which preserve the unfiltered shape when omitted. There are only two correlation keys in play, `pid` and `query_id`, and threading both through turns the tool set into a path rather than a pile:
+
+```
+statementStats → query_id → currentActivity(query_id) → pid → currentLocks(pid)
+                                                            → progressStats(pid)
+                                                            → ioStats(pid)
+                                                            → explainQuery(query_id)
+```
+
+- **`currentActivity`** takes `pid`, `query_id`, `min_duration_s` and `state`. A `pid` brings that backend's parallel workers with it, matched on `leader_pid` — being shown a leader without its workers hides where the work is happening, which is the reason for asking. `min_duration_s` excludes plain idle backends, since an idle connection's `query_start` dates a statement that already finished and would otherwise be reported as a long-running query.
+
+- **`currentLocks`** takes `pid`, and resolves the **transitive** blocking chain through `pg_blocking_pids` rather than merely filtering rows. Each row is tagged with `chain_depth`: 0 is the backend asked about, and the largest depth is the one at the root of the pile-up. A flat lock dump left you to reconstruct that graph by hand, which is the work the tool should be doing. The recursion carries a path array, because a deadlock is a cycle in that graph and would otherwise not terminate.
+
+- **`ioStats`** takes `pid`, `backend_type`, `object` and `context`. With a `pid` it reports one backend via `pg_stat_get_backend_io`, plus its WAL volume from `pg_stat_get_backend_wal` — a backend can be quiet in I/O and still be generating WAL heavily. That is a different source rather than a filter, since `pg_stat_io` has no pid column at all, and it requires PostgreSQL 18.
+
+- **`statementStats`** takes `query_id`, `order_by` and `min_calls`. `order_by` is arguably a bug fix: the list was hardcoded to `total_exec_time DESC`, which buries a statement called twice at 40 seconds under one called ten million times at 2 ms, and there was no way to ask the other question. The sort column cannot be a bind parameter, so it is resolved through a fixed table and anything outside it is rejected — nothing caller-supplied reaches the SQL text. Naming a `query_id` also returns the query text whole instead of truncated.
+
+- **`progressStats`** takes `pid` and `relation`. A relation is matched by name against `pg_class` rather than cast to `regclass`, so a name that matches nothing comes back as an empty result rather than as an error.
 
 ### Enriched existing tools
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## 2.3.0 (unreleased)
 
+### Breaking
+
+- **`statementStats` now returns an object, not an array.** The rows moved under `statements`, joined by an `info` block from `pg_stat_statements_info` and the configured `max`. The reason is `info.dealloc`: it counts how often the extension has evicted its least-used entries, and a non-zero value means the returned list is not the slowest queries in the cluster but the slowest of those that survived eviction. That cannot be inferred from the rows themselves, and a caller reading the old array had no way to know it was looking at a truncated picture.
+
+- **`query_id` is now text everywhere.** `statementStats` previously returned it as a JSON number. A queryid is 64-bit, so any client parsing JSON numbers as doubles — every JavaScript-based MCP client — silently rounded it, and the rounded value would then not be found by `explainQuery`, which has always documented the field as a string for exactly this reason. `explainQuery`'s own echoed `statement.query_id` changed with it, and the new `currentActivity.query_id` follows the same rule.
+
 ### New tools
 
 - **`wraparoundStatus`** — transaction id and multixact headroom, the one failure mode where a monitoring gap ends in a full cluster outage rather than a slowdown. Reports `age(datfrozenxid)` and `age(datminmxid)` for every database and the oldest tables by `age(relfrozenxid)`, each expressed both as a percentage of `autovacuum_freeze_max_age` (where an anti-wraparound autovacuum is forced) and of the hard limit of 2 146 483 647 (where the cluster stops accepting commands that assign a transaction id) — two thresholds that are an order of magnitude apart and are routinely confused.
@@ -21,6 +27,28 @@
 - **`hostCapacity`** — memory and parallelism settings correlated with the machine PostgreSQL runs on. Every memory-related setting is resolved to bytes whatever unit it is counted in (8kB pages for `shared_buffers`, kB for `work_mem`, …), alongside `shared_buffers` and `effective_cache_size` as a percentage of RAM, `work_mem × max_connections`, `maintenance_work_mem × autovacuum_max_workers`, their combined total, and parallel workers per vCPU.
 
   Numbers only, no verdicts, matching `explainQuery`'s stance that interpretation belongs to the caller — with two factual caveats returned inline, since the worst-case figures are easy to misread: `work_mem` is a per-node rather than per-connection limit, and the OS page cache is not counted.
+
+- **`progressStats`** — every long-running maintenance command currently reporting progress: `VACUUM`, `ANALYZE`, `CREATE INDEX`, `CLUSTER`, `COPY`, and base backups, each with its phase, blocks or tuples done against the total, a completion percentage, and elapsed time. This is the companion to `wraparoundStatus`: knowing an XID age is only half of "will the vacuum finish in time". All six categories are always present, empty when nothing is running, so an absent key never has to be read as either "idle" or "unsupported here".
+
+  PostgreSQL 17 renamed the vacuum dead-tuple columns from counts to bytes (`max_dead_tuples` → `max_dead_tuple_bytes`, `num_dead_tuples` → `num_dead_item_ids`). Both are reported under their own names with a `dead_tuple_unit` label rather than forced into one field, because they measure genuinely different things.
+
+- **`ioStats`** — `pg_stat_io` per backend type, object and context: reads, writes, extends, hits, evictions, reuses, fsyncs and their timings, with a hit percentage. This is where buffers written directly by backends, vacuum's ring-buffer reuse, and bulk read/write I/O become visible separately from the aggregate counters. Rows with no activity are omitted, since the view is a dense matrix of combinations most of which are structurally impossible. Requires PostgreSQL 16, and says so plainly on older servers rather than failing with an undefined-table error.
+
+### Enriched existing tools
+
+- **`currentActivity`** now returns `query_id`, the join key to `statementStats` and `explainQuery` — without it there was no route from "this statement is running now" to "this is its plan". Also added: `leader_pid` (which parallel worker belongs to which query), `backend_xid` and `backend_xmin`, and pre-computed transaction and query durations. On PostgreSQL 17+ each wait event carries its prose description from `pg_wait_events`, turning a bare `BufFileRead` into something actionable without leaving the output.
+
+- **`replicationSlots`** now returns `wal_status` and `safe_wal_size` — the verdict that `retained_wal_bytes` only hints at, since `extended` means the slot is already past `max_wal_size` and `lost` means the WAL it needs is gone and the slot is unusable. It also joins `pg_stat_replication_slots`, a different view entirely, for the spill and stream counters: logical decoding spilling large transactions to disk is invisible in the slot's own row and is a common, silent throughput cliff. Plus `two_phase`, `conflicting` (16+), and `invalidation_reason` / `inactive_since` (17+).
+
+- **`databaseStats`** now returns the session counters `session_time`, `active_time`, `idle_in_transaction_time`, `sessions`, `sessions_abandoned`, `sessions_fatal` and `sessions_killed`, which distinguish a database that is busy from one merely holding transactions open — something the commit and rollback counts cannot tell apart. On PostgreSQL 18, `parallel_workers_to_launch` and `parallel_workers_launched`, whose shortfall means queries planned for parallelism ran without it.
+
+- **`statementStats`** now also returns temporary block I/O and WAL volume per statement, plus `stats_since` / `minmax_stats_since` (17+) and `wal_buffers_full` and the parallel worker counters (18+).
+
+- **`listTables` and `tableDetails`** now return `n_tup_newpage_upd` and `last_seq_scan` on PostgreSQL 16 and newer. The first counts updates that had to move the row to another page — the direct measure of failed HOT updates, usually a too-high fillfactor or an index on a frequently updated column. The second dates the last sequential scan, which turns a large `seq_scan` count into something you can act on.
+
+- **`wraparoundStatus`** now returns `frozen_percent` (from `pg_class.relallfrozen`) and the cumulative vacuum and autovacuum times per table on PostgreSQL 18. These turn an age into an estimate of work remaining: an old `relfrozenxid` on a table that is already almost entirely frozen is a different problem from the same age with nothing frozen, and the timings say whether autovacuum has been trying and failing or has simply never run.
+
+- **`checkpointStats`** now returns `checkpoints_done` and `slru_written` on PostgreSQL 18.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Other install channels — deb, rpm, tarball, source — are in [INSTALL.md](INS
 
 ## Tools
 
-45 read-only operations, grouped as schema exploration, catalog search, cluster-wide
+47 read-only operations, grouped as schema exploration, catalog search, cluster-wide
 objects, extensibility and text search, foreign data and replication, monitoring and
 statistics, diagnostics and query planning, and connections. Highlights include
 `tableDetails` (columns, indexes, constraints, foreign keys in both directions, triggers,
@@ -46,10 +46,15 @@ its `EXPLAIN` plan).
 For operational triage there are `wraparoundStatus` (XID and multixact headroom, per
 database and per table, TOAST tables included), `checkpointStats` (timed against requested
 checkpoints, backend-written buffers, WAL volume — normalized across the PostgreSQL 17
-`pg_stat_checkpointer` split), `tableIOStats` (cache hit ratio per table and per index),
-`duplicateIndexes` (identical and prefix-redundant indexes, compared by column expression,
-opclass, collation and sort order), and `hostCapacity` (memory settings against the host's
-actual RAM and vCPU count — see below).
+`pg_stat_checkpointer` split), `progressStats` (every running VACUUM, CREATE INDEX, COPY…
+with a completion percentage), `ioStats` (`pg_stat_io` per backend type and context, 16+),
+`tableIOStats` (cache hit ratio per table and per index), `duplicateIndexes` (identical and
+prefix-redundant indexes, compared by column expression, opclass, collation and sort order),
+and `hostCapacity` (memory settings against the host's actual RAM and vCPU count — see
+below).
+
+`currentActivity` returns `query_id`, so a statement seen running can be looked up in
+`statementStats` and handed straight to `explainQuery`.
 
 Each one is documented, with its arguments, in `man pg_licht_mcp` under OPERATIONS. Every
 operation also accepts an optional `connection` argument to select one of several
@@ -75,7 +80,7 @@ the tool, which takes precedence over both.
 
 | | |
 |---|---|
-| `man pg_licht_mcp` | configuration, connection strings, all 45 operations, MCP client setup |
+| `man pg_licht_mcp` | configuration, connection strings, all 47 operations, MCP client setup |
 | [INSTALL.md](INSTALL.md) | Homebrew, deb, rpm, tarball, verifying, uninstalling |
 | [BUILD.md](BUILD.md) | building from source, tests, sanitizers, CI, release process |
 | [CHANGES.md](CHANGES.md) | changelog |
@@ -88,8 +93,13 @@ man --local-file cpp/man/pg_licht_mcp.1
 
 ## PostgreSQL version support
 
-PostgreSQL 14 and newer, verified in CI on 14–18. See the COMPATIBILITY section of
-`man pg_licht_mcp` for the two fields that are version-gated.
+PostgreSQL 14 and newer, verified in CI on 14–18. Every operation returns its full result
+on every supported version, apart from `ioStats`, which needs the PostgreSQL 16
+`pg_stat_io` view and says so on older servers. Individual fields are omitted where the
+underlying column does not exist, and views that changed shape upstream —
+`pg_stat_checkpointer` in 17, the `pg_stat_wal` and `pg_stat_progress_vacuum` columns in
+17 and 18 — are normalized to one set of field names. The COMPATIBILITY section of
+`man pg_licht_mcp` lists every gated field by version.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,18 @@ prefix-redundant indexes, compared by column expression, opclass, collation and 
 and `hostCapacity` (memory settings against the host's actual RAM and vCPU count — see
 below).
 
-`currentActivity` returns `query_id`, so a statement seen running can be looked up in
-`statementStats` and handed straight to `explainQuery`.
+The monitoring tools take optional `pid` and `query_id` filters, so a symptom can be
+followed to its cause rather than read out of a full dump:
+
+```
+statementStats → query_id → currentActivity(query_id) → pid → currentLocks(pid)
+                                                            → progressStats(pid)
+                                                            → ioStats(pid)
+                                                            → explainQuery(query_id)
+```
+
+`currentLocks(pid)` resolves the transitive blocking chain and tags each row with
+`chain_depth`, so the backend at the root of a pile-up is the one with the highest depth.
 
 Each one is documented, with its arguments, in `man pg_licht_mcp` under OPERATIONS. Every
 operation also accepts an optional `connection` argument to select one of several

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Other install channels — deb, rpm, tarball, source — are in [INSTALL.md](INS
 
 ## Tools
 
-40 read-only operations, grouped as schema exploration, catalog search, cluster-wide
+45 read-only operations, grouped as schema exploration, catalog search, cluster-wide
 objects, extensibility and text search, foreign data and replication, monitoring and
 statistics, diagnostics and query planning, and connections. Highlights include
 `tableDetails` (columns, indexes, constraints, foreign keys in both directions, triggers,
@@ -43,15 +43,39 @@ policies), `searchTables` (full-text search across names, descriptions, and enum
 and `explainQuery` (recover a slow statement from `pg_stat_statements` by `queryid` and get
 its `EXPLAIN` plan).
 
+For operational triage there are `wraparoundStatus` (XID and multixact headroom, per
+database and per table, TOAST tables included), `checkpointStats` (timed against requested
+checkpoints, backend-written buffers, WAL volume — normalized across the PostgreSQL 17
+`pg_stat_checkpointer` split), `tableIOStats` (cache hit ratio per table and per index),
+`duplicateIndexes` (identical and prefix-redundant indexes, compared by column expression,
+opclass, collation and sort order), and `hostCapacity` (memory settings against the host's
+actual RAM and vCPU count — see below).
+
 Each one is documented, with its arguments, in `man pg_licht_mcp` under OPERATIONS. Every
 operation also accepts an optional `connection` argument to select one of several
 configured databases.
+
+## Host capacity
+
+Total RAM and vCPU count live outside the catalog, so `hostCapacity` cannot read them and
+will not guess. Inject them per connection in the connections file:
+
+```ini
+[prod]
+service      = db01_ro
+host_ram_mb  = 65536
+host_vcpus   = 16
+```
+
+or, with a single `DATABASE_URL`, via `PG_LICHT_HOST_RAM_MB` and `PG_LICHT_HOST_VCPUS`. An
+agent that inspects the host at run time can instead pass `ram_mb` and `vcpus` straight to
+the tool, which takes precedence over both.
 
 ## Documentation
 
 | | |
 |---|---|
-| `man pg_licht_mcp` | configuration, connection strings, all 40 operations, MCP client setup |
+| `man pg_licht_mcp` | configuration, connection strings, all 45 operations, MCP client setup |
 | [INSTALL.md](INSTALL.md) | Homebrew, deb, rpm, tarball, verifying, uninstalling |
 | [BUILD.md](BUILD.md) | building from source, tests, sanitizers, CI, release process |
 | [CHANGES.md](CHANGES.md) | changelog |

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(pg_licht_mcp VERSION 2.3.0 LANGUAGES CXX)
+project(pg_licht_mcp VERSION 3.0.0 LANGUAGES CXX)
 
 # Standard bin/ and share/man/ layout, so `cmake --install` produces a tree that
 # can be dropped onto a prefix as-is: the release tarballs are staged this way,

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(pg_licht_mcp VERSION 2.2.0 LANGUAGES CXX)
+project(pg_licht_mcp VERSION 2.3.0 LANGUAGES CXX)
 
 # Standard bin/ and share/man/ layout, so `cmake --install` produces a tree that
 # can be dropped onto a prefix as-is: the release tarballs are staged this way,

--- a/cpp/man/pg_licht_mcp.1
+++ b/cpp/man/pg_licht_mcp.1
@@ -401,7 +401,7 @@ grouped by category, each with current value, unit, description, context, type,
 source, and
 .Va pending_restart
 flag.
-.It Ic currentActivity
+.It Ic currentActivity Op Va pid , Va query_id , Va min_duration_s , Va state
 Current server connections and running queries
 .Pq Li pg_stat_activity
 across all databases: pid, database, user, application_name, backend_type,
@@ -428,12 +428,53 @@ is loaded.
 On PostgreSQL 17 and newer each wait event also carries its prose description
 from
 .Li pg_wait_events .
-.It Ic currentLocks
+.Pp
+All four filters are optional and combine; with none of them the whole view is
+returned, which on a busy server is mostly idle connections and internal
+processes.
+.Pp
+.Bl -tag -width "min_duration_s" -compact
+.It Va pid
+A single backend, together with its parallel workers, matched on
+.Va leader_pid .
+Being shown a leader without its workers hides where the work is happening,
+which is the reason for asking.
+.It Va query_id
+Only backends running this
+.Va query_id ,
+as a decimal string.
+This is how a statement identified by
+.Ic statementStats
+is traced to whoever is running it now.
+.It Va min_duration_s
+Only backends whose current query has been running at least this many seconds.
+Plain idle backends are excluded, since their
+.Va query_start
+dates a statement that already finished.
+.It Va state
+Only backends in this state, e.g.
+.Ql active
+or
+.Ql "idle in transaction" .
+.El
+.It Ic currentLocks Op Va pid
 Current locks
 .Pq Li pg_locks
 joined with the holding backend's query and user, plus which pids are blocking
 each waiting lock.
 Use to diagnose lock contention.
+.Pp
+.Bl -tag -width "min_duration_s" -compact
+.It Va pid
+Restrict the result to this backend and every backend blocking it,
+transitively, resolved through
+.Fn pg_blocking_pids .
+Each row is tagged with
+.Va chain_depth :
+0 is the backend asked about, and the largest depth is the one at the root of
+the pile-up, which is the one to look at first.
+Omit it for every lock in the cluster.
+.El
 .It Ic databaseStats
 Per-database statistics
 .Pq Li pg_stat_database
@@ -450,7 +491,7 @@ PostgreSQL 18 adds
 and
 .Va parallel_workers_launched ;
 a shortfall between them means queries planned for parallelism ran without it.
-.It Ic statementStats Op Va limit
+.It Ic statementStats Op Va limit , Va query_id , Va order_by , Va min_calls
 The slowest tracked queries by total execution time
 .Pq Li pg_stat_statements ,
 with calls, timing, row counts, buffer usage, temporary block I/O, and WAL
@@ -475,12 +516,36 @@ is text, not a number: it is a 64-bit value that a client parsing JSON numbers
 as doubles would round, and the rounded value would then not be found by
 .Ic explainQuery .
 .Pp
-.Bl -tag -width "timeout_ms" -compact
+.Bl -tag -width "min_duration_s" -compact
 .It Va limit
 Maximum number of statements to return.
 Defaults to 20.
+.It Va query_id
+Only statements with this queryid, as a decimal string; their query text comes
+back whole rather than truncated.
+.Li pg_stat_statements
+keeps one entry per user and database, so a queryid can match more than one row.
+.It Va order_by
+Ranking column:
+.Va total_exec_time
+(the default),
+.Va mean_exec_time , Va max_exec_time , Va calls , Va rows ,
+.Va shared_blks_read , Va temp_blks_written ,
+or
+.Va wal_bytes .
+Ranking by total time buries a statement called twice at 40 seconds under one
+called ten million times at 2 milliseconds;
+.Va mean_exec_time
+is the other question, and there was previously no way to ask it.
+Anything outside this list is rejected: the sort column cannot be a bind
+parameter, so it is resolved through a fixed table rather than reaching the SQL.
+.It Va min_calls
+Ignore statements called fewer times than this, to keep one-off maintenance
+queries out of a
+.Va mean_exec_time
+ranking.
 .El
-.It Ic progressStats
+.It Ic progressStats Op Va pid , Va relation
 Every long-running maintenance command currently reporting progress:
 .Li VACUUM , ANALYZE , CREATE INDEX , CLUSTER , COPY ,
 and base backups.
@@ -503,7 +568,17 @@ PostgreSQL 17 renamed the vacuum dead-tuple columns from counts to bytes;
 both are reported under their own names, with
 .Va dead_tuple_unit
 saying which the server produced, because they measure different things.
-.It Ic ioStats
+.Pp
+.Bl -tag -width "min_duration_s" -compact
+.It Va pid
+Only the command running in this backend; pair it with the pid from
+.Ic currentActivity .
+.It Va relation
+Only commands operating on this table, named bare or schema-qualified.
+A base backup has no relation, so this excludes that category entirely.
+A name that matches nothing yields an empty result rather than an error.
+.El
+.It Ic ioStats Op Va pid , Va backend_type , Va object , Va context
 Cumulative I/O statistics per backend type, object, and context
 .Pq Li pg_stat_io :
 reads, writes, extends, hits, evictions, reuses, fsyncs, their timings, and a
@@ -521,6 +596,33 @@ column.
 .Pp
 Requires PostgreSQL 16 or newer; older servers get a clear error naming the
 alternatives.
+.Pp
+.Bl -tag -width "min_duration_s" -compact
+.It Va pid
+Report this one backend instead of the cluster-wide aggregate, via
+.Fn pg_stat_get_backend_io ,
+together with its WAL volume from
+.Fn pg_stat_get_backend_wal :
+a backend can be quiet in I/O and still be generating WAL heavily.
+.Li pg_stat_io
+has no pid column at all, so this is a different source rather than a filter,
+and it requires PostgreSQL 18.
+.It Va backend_type
+Only this backend type, e.g.
+.Ql "client backend"
+or
+.Ql "autovacuum worker" .
+.It Va object
+Only this object class, e.g.
+.Ql relation
+or
+.Ql "temp relation" .
+.It Va context
+Only this I/O context, e.g.
+.Ql normal , Ql vacuum , Ql bulkread ,
+or
+.Ql bulkwrite .
+.El
 .It Ic wraparoundStatus Op Va schema , Va limit
 Transaction id and multixact wraparound headroom.
 For every database:

--- a/cpp/man/pg_licht_mcp.1
+++ b/cpp/man/pg_licht_mcp.1
@@ -120,6 +120,54 @@ PgBouncer refuses GUCs in the startup packet, so
 .Nm
 sets what it needs per transaction instead; see
 .Sx SECURITY CONSIDERATIONS .
+.Ss Host capacity
+Total RAM and vCPU count belong to the machine, not to the cluster.
+PostgreSQL has no catalog for them, and a backend could not read them portably
+in any case \(em it would read the client's host, which is the wrong machine.
+They are therefore injected, and
+.Ic hostCapacity
+correlates them with
+.Va shared_buffers , Va work_mem ,
+and the rest.
+Four optional keys per section carry them:
+.Bd -literal -offset indent
+[prod]
+service      = db01_ro
+host_ram_mb  = 65536
+host_vcpus   = 16
+host_storage = local nvme          ; free text, never interpreted
+host_note    = shared with the app ; free text, never interpreted
+.Ed
+.Pp
+These keys are consumed by
+.Nm
+and never reach libpq, which would reject the whole connection string over an
+unrecognised keyword.
+.Va host_ram_mb
+and
+.Va host_vcpus
+must be positive integers; anything else is rejected at startup naming the
+section and the key, because
+.Ql 64GB
+where megabytes are meant would be wrong by three orders of magnitude and would
+silently invalidate every derived ratio.
+.Pp
+There are two other ways in.
+The environment variables under
+.Sx ENVIRONMENT
+apply to the single-connection
+.Ev DATABASE_URL
+form only, where there is no question which host they describe; with a
+connections file each section declares its own, since the sections may well
+live on different machines.
+And an agent that inspects the host at run time \(em over SSH, say \(em can
+pass
+.Va ram_mb
+and
+.Va vcpus
+straight to
+.Ic hostCapacity ,
+which takes precedence over both.
 .Ss Resolution order
 The connection source is resolved in this order:
 .Bl -enum -width 2n
@@ -358,9 +406,157 @@ Returns a clear error with setup instructions if the extension is not installed.
 Maximum number of statements to return.
 Defaults to 20.
 .El
+.It Ic wraparoundStatus Op Va schema , Va limit
+Transaction id and multixact wraparound headroom.
+For every database:
+.Li age(datfrozenxid) ,
+.Li age(datminmxid) ,
+and each as a percentage of
+.Va autovacuum_freeze_max_age
+and of the hard limit of 2146483647 transactions, at which the cluster stops
+accepting commands that assign a new transaction id.
+For tables: the oldest by
+.Li age(relfrozenxid) ,
+with the effective
+.Va autovacuum_freeze_max_age
+and whether it came from the table's storage parameters or the server, plus
+last vacuum times and dead tuple counts.
+.Pp
+TOAST tables are included, labelled with the table they belong to.
+They carry their own
+.Va relfrozenxid ,
+do not appear in
+.Li pg_stat_user_tables ,
+and are frequently the relation actually holding the horizon back.
+.Pp
+.Bl -tag -width "timeout_ms" -compact
+.It Va schema
+Restrict the table list to one schema.
+Omit it to cover the whole database, which is the scope wraparound risk is
+actually measured over.
+.It Va limit
+Maximum number of tables to return, oldest first.
+Defaults to 20.
+.El
+.It Ic checkpointStats
+Checkpoint, write-ahead log, and background writer activity: timed against
+requested checkpoint counts and the ratio between them, write and sync time,
+buffers written by the checkpointer, by the background writer, and directly by
+backends, the
+.Li pg_stat_wal
+record, full-page-image, and byte counters, and the settings that govern all of
+it
+.Pq Va checkpoint_timeout , Va max_wal_size , Va checkpoint_completion_target , No the Va bgwriter No knobs .
+.Pp
+The source views differ by major version: PostgreSQL 17 split the checkpointer
+counters into
+.Li pg_stat_checkpointer
+and moved the backend-written buffer counts to
+.Li pg_stat_io ,
+while earlier versions keep everything in
+.Li pg_stat_bgwriter .
+Field names are normalized across both, so a caller never branches on the
+version; the
+.Va source
+field names the views that produced the numbers.
+.It Ic tableIOStats Ar schema Op Va table , Va limit
+Buffer cache hit ratios per object
+.Pq Li pg_statio_all_tables :
+.Va heap_blks_read
+against
+.Va heap_blks_hit ,
+.Va idx_blks_read
+against
+.Va idx_blks_hit ,
+the TOAST and TOAST-index pairs, and a combined ratio, with relation size and
+scan counts for context.
+.Pp
+A ratio is null, not zero, for an object that has seen no reads at all, so
+.Dq no traffic
+is never mistaken for
+.Dq every read missed the cache .
+.Pp
+.Bl -tag -width "timeout_ms" -compact
+.It Va table
+A single table.
+Only a named table gets the per-index breakdown from
+.Li pg_statio_all_indexes ;
+over a whole schema it would multiply the payload by the index count without
+making the table-level ratios any easier to read.
+.It Va limit
+Maximum number of tables to return, most physical reads first.
+Defaults to 20.
+.El
+.It Ic hostCapacity Op Va ram_mb , Va vcpus , Va storage
+Memory and parallelism settings correlated with the capacity of the machine
+PostgreSQL runs on.
+Returns every memory-related setting resolved to bytes, whatever unit it is
+counted in, and derived ratios:
+.Va shared_buffers
+and
+.Va effective_cache_size
+as a percentage of RAM,
+.Va work_mem
+times
+.Va max_connections ,
+.Va maintenance_work_mem
+times
+.Va autovacuum_max_workers ,
+their combined total, and parallel workers per vCPU.
+.Pp
+Total RAM and vCPU count are properties of the host, not of the cluster: no
+catalog holds them, so they have to be injected.
+See
+.Sx Host capacity .
+The reported
+.Va source
+says which of the three paths supplied them.
+Every ratio that needs RAM is null when none was supplied, together with a hint
+naming the three ways to provide it.
+Nothing is ever guessed: a wrong memory figure would silently invalidate every
+number derived from it.
+.Pp
+.Bl -tag -width "timeout_ms" -compact
+.It Va ram_mb
+Total host memory in megabytes, overriding any configured value.
+.It Va vcpus
+Number of vCPUs or cores available to the host, overriding any configured value.
+.It Va storage
+Free-text description of the storage, echoed back and never interpreted.
+.El
 .El
 .Ss Diagnostics and query planning
 .Bl -tag -width Ds
+.It Ic duplicateIndexes Ar schema Op Va table
+Indexes that duplicate, or are covered by, another index on the same table.
+.Pp
+.Va identical
+groups indexes whose key columns, operator classes, collations, sort order,
+.Ic INCLUDE
+columns, and partial predicate all match.
+.Va redundant
+reports an index whose key columns are a leading prefix of a wider index that
+also covers its
+.Ic INCLUDE
+columns.
+.Pp
+Comparison is by column expression rather than attribute number, so two
+different expression indexes are not confused with each other, and
+.Li (a DESC)
+is not treated as covered by
+.Li (a, b) .
+A unique index is never reported as redundant for being a prefix: dropping it
+would drop a constraint the wider index does not enforce.
+Each entry carries size,
+.Va idx_scan ,
+the name of any backing constraint, and the replica identity and validity
+flags, since those decide whether the index can be dropped at all.
+.Pp
+.Bl -tag -width "timeout_ms" -compact
+.It Va table
+Restrict the check to one table.
+Omit it to check every table in the schema.
+.El
 .It Ic tableBloat Ar schema Ar table Op Va exact
 Physical storage bloat for a table
 .Pq Li pgstattuple No or Li pgstattuple_approx :
@@ -476,6 +672,22 @@ Path to a connections INI file, consulted after
 .Fl -config
 and before
 .Pa ~/.config/pg_licht/connections.ini .
+.It Ev PG_LICHT_HOST_RAM_MB
+Total host memory in megabytes, read by
+.Ic hostCapacity .
+Honoured only with the single-connection
+.Ev DATABASE_URL
+form; with a connections file, use
+.Va host_ram_mb
+in the section instead.
+See
+.Sx Host capacity .
+.It Ev PG_LICHT_HOST_VCPUS
+Number of vCPUs or cores on the host, under the same rule.
+.It Ev PG_LICHT_HOST_STORAGE
+Free-text storage description, under the same rule.
+.It Ev PG_LICHT_HOST_NOTE
+Free-text note about the host, under the same rule.
 .It Ev PGSERVICEFILE
 Path to a libpq service file, used to resolve a
 .Va service

--- a/cpp/man/pg_licht_mcp.1
+++ b/cpp/man/pg_licht_mcp.1
@@ -366,6 +366,29 @@ The connection string is never exposed, as it may contain credentials.
 Replication slots with retained WAL bytes.
 A lagging or unused slot holds back WAL indefinitely and is a common cause of
 disk bloat incidents.
+.Pp
+.Va wal_status
+is the verdict that retained WAL bytes only hint at:
+.Ql extended
+means the slot is already past
+.Va max_wal_size ,
+and
+.Ql lost
+means the WAL it needs is gone and the slot is unusable.
+.Va safe_wal_size
+is how much more WAL may be written before that happens.
+.Pp
+The spill and stream counters come from
+.Li pg_stat_replication_slots ,
+a different view: they show logical decoding spilling large transactions to
+disk, which is invisible in the slot's own row and is a common, silent
+throughput cliff.
+PostgreSQL 16 adds
+.Va conflicting ,
+and 17 adds
+.Va invalidation_reason
+and
+.Va inactive_since .
 .El
 .Ss Monitoring and statistics
 .Bl -tag -width Ds
@@ -382,7 +405,29 @@ flag.
 Current server connections and running queries
 .Pq Li pg_stat_activity
 across all databases: pid, database, user, application_name, backend_type,
-state, wait event, and query text.
+state, wait event, query text, transaction and query duration, leader pid for
+parallel workers, and the backend's xid and xmin.
+.Pp
+.Va query_id
+is the join key to
+.Ic statementStats
+and
+.Ic explainQuery ,
+which is what turns
+.Dq this is running now
+into
+.Dq this is its plan .
+It is returned as text, since a 64-bit value does not survive JSON number
+precision, and is null unless
+.Va compute_query_id
+is enabled; the default
+.Ql auto
+enables it when
+.Li pg_stat_statements
+is loaded.
+On PostgreSQL 17 and newer each wait event also carries its prose description
+from
+.Li pg_wait_events .
 .It Ic currentLocks
 Current locks
 .Pq Li pg_locks
@@ -395,17 +440,87 @@ Per-database statistics
 for every database in the cluster: connections, commits and rollbacks, block hit
 ratio inputs, tuple counts, conflicts, deadlocks, temp file usage, and checksum
 failures.
+.Pp
+The session counters
+.Pq Va session_time , Va active_time , Va idle_in_transaction_time , Va sessions , Va sessions_abandoned , Va sessions_fatal , Va sessions_killed
+distinguish a database that is busy from one merely holding transactions open,
+which the commit and rollback counts alone cannot tell apart.
+PostgreSQL 18 adds
+.Va parallel_workers_to_launch
+and
+.Va parallel_workers_launched ;
+a shortfall between them means queries planned for parallelism ran without it.
 .It Ic statementStats Op Va limit
 The slowest tracked queries by total execution time
 .Pq Li pg_stat_statements ,
-with calls, timing, row counts, and buffer usage.
+with calls, timing, row counts, buffer usage, temporary block I/O, and WAL
+volume, under
+.Va statements ,
+alongside an
+.Va info
+block from
+.Li pg_stat_statements_info .
 Returns a clear error with setup instructions if the extension is not installed.
+.Pp
+.Va info.dealloc
+counts how often the extension has evicted its least-used entries because
+.Va pg_stat_statements.max
+was exceeded.
+A non-zero value means this list is not the slowest queries in the cluster but
+the slowest of those that survived eviction \(em a distinction that cannot be
+drawn from the rows themselves, which is why it is returned beside them.
+.Pp
+.Va query_id
+is text, not a number: it is a 64-bit value that a client parsing JSON numbers
+as doubles would round, and the rounded value would then not be found by
+.Ic explainQuery .
 .Pp
 .Bl -tag -width "timeout_ms" -compact
 .It Va limit
 Maximum number of statements to return.
 Defaults to 20.
 .El
+.It Ic progressStats
+Every long-running maintenance command currently reporting progress:
+.Li VACUUM , ANALYZE , CREATE INDEX , CLUSTER , COPY ,
+and base backups.
+Each carries its phase, blocks or tuples done against the total, a completion
+percentage, and how long it has been running.
+Use it to decide whether a
+.Li VACUUM
+will finish before wraparound \(em the natural companion to
+.Ic wraparoundStatus
+\(em or whether a
+.Li CREATE INDEX
+is stuck waiting on a locker.
+.Pp
+All six categories are always present, empty when nothing is running, so an
+absent key never has to be read as either
+.Dq idle
+or
+.Dq unsupported here .
+PostgreSQL 17 renamed the vacuum dead-tuple columns from counts to bytes;
+both are reported under their own names, with
+.Va dead_tuple_unit
+saying which the server produced, because they measure different things.
+.It Ic ioStats
+Cumulative I/O statistics per backend type, object, and context
+.Pq Li pg_stat_io :
+reads, writes, extends, hits, evictions, reuses, fsyncs, their timings, and a
+hit percentage.
+This is where buffers written directly by backends, vacuum's ring-buffer
+reuse, and bulk read and write I/O become visible separately from the aggregate
+counters in
+.Ic checkpointStats .
+Rows with no activity at all are omitted, since the view is a dense matrix of
+combinations most of which are structurally impossible.
+Byte counters are reported on PostgreSQL 18 and newer, where they replaced the
+former
+.Va op_bytes
+column.
+.Pp
+Requires PostgreSQL 16 or newer; older servers get a clear error naming the
+alternatives.
 .It Ic wraparoundStatus Op Va schema , Va limit
 Transaction id and multixact wraparound headroom.
 For every database:
@@ -428,6 +543,16 @@ They carry their own
 do not appear in
 .Li pg_stat_user_tables ,
 and are frequently the relation actually holding the horizon back.
+.Pp
+On PostgreSQL 18 and newer each table also reports
+.Va frozen_percent
+.Pq Li pg_class.relallfrozen
+and its cumulative vacuum and autovacuum times.
+Those turn an age into an estimate of the work remaining: an old
+.Va relfrozenxid
+on a table that is already almost entirely frozen is a different problem from
+the same age with nothing frozen, and the timings say whether autovacuum has
+been trying and failing to keep up or has simply never run.
 .Pp
 .Bl -tag -width "timeout_ms" -compact
 .It Va schema
@@ -882,15 +1007,71 @@ On 14 and 15 that path returns an actionable hint instead; supplying
 which prepares and plans the statement with real values, works on every
 supported version.
 .Pp
-Two catalog fields are omitted where the underlying column does not exist: the
+.Ic ioStats
+requires PostgreSQL 16, where
+.Li pg_stat_io
+was introduced, and returns an error naming the alternatives on older servers.
+.Pp
+Elsewhere, a field is simply omitted where the underlying column does not
+exist, and normalized where it was renamed.
+Every operation returns its full result on every supported version; only these
+individual fields vary:
+.Bl -tag -width "PostgreSQL 18" -compact
+.It PostgreSQL 15
+subscription
+.Va two_phase
+.Pq Li pg_subscription.subtwophasestate .
+.It PostgreSQL 16
 index
 .Va last_use
-field
-.Pq Li pg_stat_user_indexes.last_idx_scan , No PostgreSQL 16 and newer
-and the subscription
-.Va two_phase
-field
-.Pq Li pg_subscription.subtwophasestate , No PostgreSQL 15 and newer .
+.Pq Li pg_stat_user_indexes.last_idx_scan ;
+table
+.Va n_tup_newpage_upd
+and
+.Va last_seq_scan ;
+slot
+.Va conflicting .
+.It PostgreSQL 17
+wait event descriptions
+.Pq Li pg_wait_events ;
+slot
+.Va invalidation_reason
+and
+.Va inactive_since ;
+statement
+.Va stats_since
+and
+.Va minmax_stats_since .
+.It PostgreSQL 18
+table
+.Va frozen_percent , Va relallfrozen ,
+and the cumulative vacuum timings;
+.Va checkpoints_done
+and
+.Va slru_written ;
+database
+.Va parallel_workers_to_launch
+and
+.Va parallel_workers_launched ;
+.Li pg_stat_io
+byte counters.
+.El
+.Pp
+Two views changed shape upstream and are normalized rather than passed through.
+.Ic checkpointStats
+reads
+.Li pg_stat_checkpointer
+on PostgreSQL 17 and newer and
+.Li pg_stat_bgwriter
+before it, reporting one set of field names either way and naming its sources
+in
+.Va source ;
+it also drops the four
+.Li pg_stat_wal
+timing columns that PostgreSQL 18 removed.
+.Ic progressStats
+reports the PostgreSQL 17 vacuum dead-tuple columns under their own names and
+labels the unit, since the old and new columns count different things.
 .Sh SEE ALSO
 .Xr pgbouncer 1 ,
 .Xr psql 1 ,

--- a/cpp/src/config.h
+++ b/cpp/src/config.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
 #include <fstream>
 #include <map>
 #include <stdexcept>
@@ -23,6 +24,30 @@
 
 namespace pglicht {
 
+// Capacity of the machine the server runs on.
+//
+// Total RAM and vCPU count are properties of the host, not of the cluster:
+// PostgreSQL has no catalog for them, and a backend cannot read them portably
+// (and would read the *client's* host anyway, which is the wrong machine).
+// They therefore have to be injected by whoever knows -- the operator, via the
+// connections file or the environment, or an agent that inspects the host over
+// SSH and passes them as arguments to hostCapacity.
+//
+// Zero means "not configured" and is reported as such. Nothing here is ever
+// guessed: a wrong RAM figure would silently invalidate every ratio derived
+// from it.
+struct HostCapacity {
+  long long ram_mb = 0;
+  int vcpus = 0;
+  std::string storage;   // free text, e.g. "nvme", "gp3", "spinning rust"
+  std::string note;      // free text, e.g. "shared with the app server"
+  std::string source;    // where the values came from, for the caller to judge
+
+  bool configured() const {
+    return ram_mb > 0 || vcpus > 0 || !storage.empty() || !note.empty();
+  }
+};
+
 // One named connection.
 struct ConnConfig {
   std::string name;
@@ -35,6 +60,8 @@ struct ConnConfig {
   std::string port;
   std::string dbname;
   std::string user;
+
+  HostCapacity capacity;
 };
 
 namespace detail {
@@ -67,6 +94,27 @@ inline std::string quote_conninfo(const std::string& v) {
   return out + "'";
 }
 
+// Parse a strictly positive integer, or throw with the caller's context. Used
+// for the host capacity keys, where a typo ("64GB" where megabytes are meant)
+// must fail loudly at startup rather than silently produce ratios that are off
+// by three orders of magnitude.
+inline long long positive_int(const std::string& v, const std::string& where) {
+  if (v.empty())
+    throw std::runtime_error(where + ": expected a positive integer, got an empty value");
+  for (char c : v) {
+    if (!std::isdigit(static_cast<unsigned char>(c)))
+      throw std::runtime_error(where + ": expected a positive integer, got \"" + v + "\"");
+  }
+  try {
+    long long n = std::stoll(v);
+    if (n <= 0)
+      throw std::runtime_error(where + ": expected a positive integer, got \"" + v + "\"");
+    return n;
+  } catch (const std::out_of_range&) {
+    throw std::runtime_error(where + ": value out of range: \"" + v + "\"");
+  }
+}
+
 }  // namespace detail
 
 // A set of named connections, plus which one is the default.
@@ -87,6 +135,12 @@ public:
         url.find("application_name") == std::string::npos) {
       cfg.conninfo += " application_name=" + detail::quote_conninfo(app_name);
     }
+    // Host capacity from the environment. Deliberately only on this path:
+    // there is exactly one connection here, so there is no question which host
+    // the variables describe. With a connections file each section declares
+    // its own, since the sections may well live on different machines.
+    cfg.capacity = capacity_from_env();
+
     reg.order_.push_back("default");
     reg.conns_["default"] = cfg;
     reg.default_name_ = "default";
@@ -190,6 +244,25 @@ public:
   const std::vector<std::string>& names() const { return order_; }
   const std::string& default_name() const { return default_name_; }
 
+  // PG_LICHT_HOST_RAM_MB / _VCPUS / _STORAGE / _NOTE, for the single-connection
+  // form. Exposed for the test suite; from_url is its only caller.
+  static HostCapacity capacity_from_env() {
+    HostCapacity cap;
+    auto env = [](const char* n) -> std::string {
+      const char* v = std::getenv(n);
+      return v ? detail::trim(v) : std::string{};
+    };
+    std::string ram = env("PG_LICHT_HOST_RAM_MB");
+    std::string cpu = env("PG_LICHT_HOST_VCPUS");
+    if (!ram.empty()) cap.ram_mb = detail::positive_int(ram, "PG_LICHT_HOST_RAM_MB");
+    if (!cpu.empty()) cap.vcpus = static_cast<int>(
+                        detail::positive_int(cpu, "PG_LICHT_HOST_VCPUS"));
+    cap.storage = env("PG_LICHT_HOST_STORAGE");
+    cap.note    = env("PG_LICHT_HOST_NOTE");
+    if (cap.configured()) cap.source = "environment";
+    return cap;
+  }
+
 private:
   std::map<std::string, ConnConfig> conns_;
   std::vector<std::string> order_;
@@ -215,6 +288,21 @@ private:
           "unsupported startup parameter. pg-licht sets what it needs per "
           "transaction (BEGIN READ ONLY, SET LOCAL statement_timeout) instead");
 
+      // Host capacity keys describe the machine, not the connection. They are
+      // consumed here and never reach the conninfo -- libpq would reject the
+      // whole string as an invalid option otherwise.
+      if (key == "host_ram_mb") {
+        cfg.capacity.ram_mb = detail::positive_int(val, path + ": [" + name + "] host_ram_mb");
+        continue;
+      }
+      if (key == "host_vcpus") {
+        cfg.capacity.vcpus = static_cast<int>(
+          detail::positive_int(val, path + ": [" + name + "] host_vcpus"));
+        continue;
+      }
+      if (key == "host_storage") { cfg.capacity.storage = val; continue; }
+      if (key == "host_note")    { cfg.capacity.note = val;    continue; }
+
       if (key == "service") cfg.service = val;
       else if (key == "host")   cfg.host   = val;
       else if (key == "port")   cfg.port   = val;
@@ -238,6 +326,8 @@ private:
       if (!conninfo.empty()) conninfo += " ";
       conninfo += "application_name=" + detail::quote_conninfo(app_name);
     }
+
+    if (cfg.capacity.configured()) cfg.capacity.source = "config file";
 
     cfg.conninfo = conninfo;
     return cfg;

--- a/cpp/src/server.h
+++ b/cpp/src/server.h
@@ -162,6 +162,20 @@ public:
     return check_key(schema, table_name, values);
   }
 
+  const json call_wraparound_status(const std::string& schema, int limit) {
+    return wraparound_status(schema, limit);
+  }
+  const json call_duplicate_indexes(const std::string& schema, const std::string& table_name) {
+    return duplicate_indexes(schema, table_name);
+  }
+  const json call_checkpoint_stats() { return checkpoint_stats(); }
+  const json call_table_io_stats(const std::string& schema, const std::string& table_name, int limit) {
+    return table_io_stats(schema, table_name, limit);
+  }
+  const json call_host_capacity(long long ram_mb, int vcpus, const std::string& storage) {
+    return host_capacity(ram_mb, vcpus, storage);
+  }
+
   const json call_connections() { return connections(); }
   const json call_explain_query(const std::string& queryid, const std::string& sql,
                                 const json& params, bool analyze, int timeout_ms) {
@@ -203,6 +217,12 @@ private:
       if (!c.port.empty())    entry["port"]    = c.port;
       if (!c.dbname.empty())  entry["dbname"]  = c.dbname;
       if (!c.user.empty())    entry["user"]    = c.user;
+      // Host capacity, so a caller can see at a glance which connections still
+      // need it injected before hostCapacity can compute anything.
+      if (c.capacity.ram_mb > 0)        entry["host_ram_mb"]  = c.capacity.ram_mb;
+      if (c.capacity.vcpus > 0)         entry["host_vcpus"]   = c.capacity.vcpus;
+      if (!c.capacity.storage.empty())  entry["host_storage"] = c.capacity.storage;
+      if (!c.capacity.note.empty())     entry["host_note"]    = c.capacity.note;
       out.push_back(entry);
     }
     return out;
@@ -557,6 +577,86 @@ private:
 		{"properties", {
 		    {"limit", {{"type", "integer"}}}
 		  }}
+	      }}
+	  },
+	  {
+	    {"name", "wraparoundStatus"},
+	    {"description", "return transaction id and multixact wraparound headroom: age(datfrozenxid) and age(datminmxid) for every database, the oldest tables by age(relfrozenxid) including TOAST tables (often the relation actually holding the horizon back), each age as a percentage of the effective autovacuum_freeze_max_age and of the 2^31 hard limit at which the cluster stops accepting write transactions, plus the per-table freeze storage parameters and last vacuum times"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", {
+		    {"schema", {
+			{"type", "string"},
+			{"description", "restrict the table list to one schema; omit to cover the whole database, which is what wraparound risk is actually measured over"}
+		      }},
+		    {"limit", {
+			{"type", "integer"},
+			{"description", "how many tables to return, oldest first. Defaults to 20"}
+		      }}
+		  }}
+	      }}
+	  },
+	  {
+	    {"name", "checkpointStats"},
+	    {"description", "return checkpoint, WAL, and background writer activity (pg_stat_checkpointer and pg_stat_bgwriter on PostgreSQL 17+, pg_stat_bgwriter alone before that, plus pg_stat_wal) with field names normalized across both shapes: timed versus requested checkpoint counts and the ratio between them, write and sync time, buffers written by the checkpointer, by the background writer, and directly by backends, WAL record/FPI/byte counts, and the related settings (checkpoint_timeout, max_wal_size, checkpoint_completion_target, the bgwriter knobs)"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", json::object()}
+	      }}
+	  },
+	  {
+	    {"name", "tableIOStats"},
+	    {"description", "return per-object buffer cache hit ratios (pg_statio_all_tables): heap_blks_read versus heap_blks_hit, idx_blks_read versus idx_blks_hit, the TOAST and TOAST-index pairs, and a combined ratio, with relation size and scan counts. Naming a single table adds a per-index breakdown from pg_statio_all_indexes. Ratios are null, not zero, for an object that has seen no reads at all"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", {
+		    {"schema", {{"type", "string"}}},
+		    {"table",  {
+			{"type", "string"},
+			{"description", "a single table; omit to sweep the schema. Only a named table gets the per-index breakdown"}
+		      }},
+		    {"limit", {
+			{"type", "integer"},
+			{"description", "how many tables to return, most physical reads first. Defaults to 20"}
+		      }}
+		  }},
+		{"required", {"schema"}}
+	      }}
+	  },
+	  {
+	    {"name", "hostCapacity"},
+	    {"description", "correlate memory and parallelism settings with the capacity of the machine PostgreSQL runs on. Host RAM and vCPU count exist outside the catalog, so they must be injected: pass them as arguments, set host_ram_mb/host_vcpus in the connection's section of the connections file, or export PG_LICHT_HOST_RAM_MB/PG_LICHT_HOST_VCPUS. Returns the host facts with the source they came from, every memory-related setting resolved to bytes, and derived ratios (shared_buffers and effective_cache_size as a percentage of RAM, work_mem times max_connections, maintenance_work_mem times autovacuum_max_workers, parallel workers per vCPU). Ratios are null when no RAM figure was supplied; nothing is ever guessed"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", {
+		    {"ram_mb", {
+			{"type", "integer"},
+			{"description", "total host memory in megabytes, overriding any configured value"}
+		      }},
+		    {"vcpus", {
+			{"type", "integer"},
+			{"description", "number of vCPUs or cores available to the host, overriding any configured value"}
+		      }},
+		    {"storage", {
+			{"type", "string"},
+			{"description", "free-text description of the storage, e.g. \"local nvme\" or \"gp3 3000 iops\"; echoed back, never interpreted"}
+		      }}
+		  }}
+	      }}
+	  },
+	  {
+	    {"name", "duplicateIndexes"},
+	    {"description", "return indexes that duplicate or are covered by another index on the same table. 'identical' groups indexes whose key columns, operator classes, collations, sort order, INCLUDE columns and partial predicate all match; 'redundant' reports an index whose key columns are a leading prefix of a wider index that also covers its INCLUDE columns. Comparison is by column expression rather than attribute number, so expression indexes and differing sort orders are handled correctly, and a unique index is never called redundant for being a prefix. Each entry carries size, idx_scan, the backing constraint name, and the replica identity and validity flags, since those decide whether it can be dropped at all"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", {
+		    {"schema", {{"type", "string"}}},
+		    {"table",  {
+			{"type", "string"},
+			{"description", "restrict to one table; omit to check every table in the schema"}
+		      }}
+		  }},
+		{"required", {"schema"}}
 	      }}
 	  },
 	  {
@@ -1208,6 +1308,588 @@ private:
       }
       throw;
     }
+  }
+
+  const json wraparound_status(const std::string& schema, int limit) {
+    Session sess{active_cfg()};
+    pqxx::work& txn = sess.txn();
+
+    // 2^31 - 1000000: the point at which PostgreSQL stops accepting commands
+    // that assign new transaction ids. It is the outage threshold, and is
+    // distinct from autovacuum_freeze_max_age, which is merely where an
+    // anti-wraparound autovacuum is forced.
+    //
+    // TOAST tables are included deliberately. They carry their own
+    // relfrozenxid, are invisible in pg_stat_user_tables, and a TOAST or
+    // catalog relation is very often the one actually holding the horizon
+    // back; excluding them would report the risk as lower than it is.
+    std::string query = R"(
+      SELECT JSONB_BUILD_OBJECT(
+        'limits',
+          (SELECT JSONB_OBJECT_AGG(name, setting::bigint)
+             FROM pg_settings
+            WHERE name IN ('autovacuum_freeze_max_age', 'autovacuum_multixact_freeze_max_age',
+                           'vacuum_freeze_min_age', 'vacuum_freeze_table_age',
+                           'vacuum_multixact_freeze_min_age', 'vacuum_multixact_freeze_table_age',
+                           'vacuum_failsafe_age', 'vacuum_multixact_failsafe_age'))
+          || JSONB_BUILD_OBJECT('wraparound_limit', 2146483647::bigint),
+        'databases',
+          (SELECT JSONB_OBJECT_AGG(d.datname, JSONB_BUILD_OBJECT(
+                    'xid_age', age(d.datfrozenxid),
+                    'xid_percent_of_freeze_max_age',
+                      round(100.0 * age(d.datfrozenxid)
+                            / NULLIF(current_setting('autovacuum_freeze_max_age')::bigint, 0), 1),
+                    'xid_percent_of_wraparound_limit',
+                      round(100.0 * age(d.datfrozenxid) / 2146483647, 3),
+                    'xids_until_wraparound_limit', 2146483647 - age(d.datfrozenxid),
+                    'mxid_age', mxid_age(d.datminmxid),
+                    'mxid_percent_of_freeze_max_age',
+                      round(100.0 * mxid_age(d.datminmxid)
+                            / NULLIF(current_setting('autovacuum_multixact_freeze_max_age')::bigint, 0), 1),
+                    'datfrozenxid', d.datfrozenxid::text,
+                    'datminmxid', d.datminmxid::text))
+             FROM pg_database AS d
+            WHERE d.datallowconn),
+        'tables', COALESCE((
+          SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
+                   'schema', r.schema,
+                   'name', r.name,
+                   'kind', r.kind,
+                   'toast_for', r.toast_for,
+                   'xid_age', r.xid_age,
+                   'xid_percent_of_freeze_max_age',
+                     round(100.0 * r.xid_age / NULLIF(r.freeze_max_age, 0), 1),
+                   'xid_percent_of_wraparound_limit',
+                     round(100.0 * r.xid_age / 2146483647, 3),
+                   'mxid_age', r.mxid_age,
+                   'relfrozenxid', r.relfrozenxid::text,
+                   'freeze_max_age', r.freeze_max_age,
+                   'freeze_max_age_source', r.freeze_max_age_source,
+                   'size', r.size,
+                   'last_vacuum', r.last_vacuum,
+                   'last_autovacuum', r.last_autovacuum,
+                   'n_dead_tup', r.n_dead_tup) ORDER BY r.xid_age DESC)
+          FROM (
+            SELECT n.nspname AS schema,
+                   c.relname AS name,
+                   CASE c.relkind WHEN 'r' THEN 'table'
+                                  WHEN 'm' THEN 'materialized view'
+                                  WHEN 't' THEN 'toast table' END AS kind,
+                   CASE WHEN c.relkind = 't' THEN tn.nspname || '.' || tp.relname END AS toast_for,
+                   age(c.relfrozenxid) AS xid_age,
+                   mxid_age(c.relminmxid) AS mxid_age,
+                   c.relfrozenxid,
+                   COALESCE(o.option_value::bigint,
+                            current_setting('autovacuum_freeze_max_age')::bigint) AS freeze_max_age,
+                   CASE WHEN o.option_value IS NOT NULL THEN 'reloptions' ELSE 'server' END
+                     AS freeze_max_age_source,
+                   pg_relation_size(c.oid) AS size,
+                   s.last_vacuum, s.last_autovacuum, s.n_dead_tup
+            FROM pg_class AS c
+            JOIN pg_namespace AS n ON n.oid = c.relnamespace
+            LEFT JOIN pg_class AS tp ON c.relkind = 't' AND tp.reltoastrelid = c.oid
+            LEFT JOIN pg_namespace AS tn ON tn.oid = tp.relnamespace
+            LEFT JOIN pg_stat_all_tables AS s ON s.relid = c.oid
+            LEFT JOIN LATERAL (SELECT option_value
+                                 FROM pg_options_to_table(c.reloptions)
+                                WHERE option_name = 'autovacuum_freeze_max_age') AS o ON true
+            WHERE c.relkind IN ('r', 'm', 't')
+              AND c.relfrozenxid <> '0'::xid
+              AND ($1 = '' OR COALESCE(tn.nspname, n.nspname) = $1)
+            ORDER BY age(c.relfrozenxid) DESC
+            LIMIT $2
+          ) AS r), '[]'::jsonb)
+      );
+    )";
+
+    pqxx::result res = pqxx_exec(txn, query, pqxx::params{schema, limit});
+
+    if (!res.empty() && !res[0][0].is_null()) {
+      return json::parse(res[0][0].as<std::string>());
+    } else {
+      return {};
+    }
+  }
+
+  const json duplicate_indexes(const std::string& schema, const std::string& table_name) {
+    Session sess{active_cfg()};
+    pqxx::work& txn = sess.txn();
+
+    // Two indexes are interchangeable only if every property the planner cares
+    // about matches, so the comparison key is a per-column signature: the
+    // column or expression text, its operator class, its collation, and its
+    // indoption bits (DESC / NULLS FIRST). Comparing indkey alone would call
+    // (a) and (a DESC) duplicates, and two different expression indexes
+    // identical -- an expression column has attnum 0 in indkey.
+    //
+    // key_columns is the same list without opclass/collation/ordering, and is
+    // what the INCLUDE coverage test compares against: an included column is
+    // covered by a key column of the wider index regardless of how that key is
+    // sorted or compared.
+    std::string query = R"(
+      WITH idx AS (
+        SELECT i.indexrelid,
+               i.indrelid,
+               n.nspname  AS schema,
+               tc.relname AS table_name,
+               ic.relname AS index_name,
+               am.amname  AS access_method,
+               i.indisunique     AS is_unique,
+               i.indisprimary    AS is_primary,
+               i.indisvalid      AS is_valid,
+               i.indisreplident  AS is_replica_identity,
+               con.conname       AS constraint_name,
+               pg_get_expr(i.indpred, i.indrelid, true) AS predicate,
+               pg_get_indexdef(i.indexrelid)  AS definition,
+               pg_relation_size(i.indexrelid) AS size,
+               s.idx_scan,
+               (SELECT ARRAY_AGG(pg_get_indexdef(i.indexrelid, k::int, true) ORDER BY k)
+                  FROM generate_series(1, i.indnkeyatts) AS k) AS key_columns,
+               (SELECT ARRAY_AGG(pg_get_indexdef(i.indexrelid, k::int, true) || ' '
+                                 || COALESCE((SELECT op.opcname FROM pg_opclass AS op
+                                               WHERE op.oid = i.indclass[k - 1]), '?')
+                                 || ' '
+                                 || COALESCE(NULLIF(i.indcollation[k - 1], 0)::regcollation::text, '')
+                                 || ' ' || i.indoption[k - 1]::text
+                                 ORDER BY k)
+                  FROM generate_series(1, i.indnkeyatts) AS k) AS key_signature,
+               (SELECT COALESCE(ARRAY_AGG(pg_get_indexdef(i.indexrelid, k::int, true)
+                                          ORDER BY k), '{}')
+                  FROM generate_series(i.indnkeyatts + 1, i.indnatts) AS k) AS included_columns
+        FROM pg_index AS i
+        JOIN pg_class AS ic ON ic.oid = i.indexrelid
+        JOIN pg_class AS tc ON tc.oid = i.indrelid
+        JOIN pg_namespace AS n ON n.oid = tc.relnamespace
+        JOIN pg_am AS am ON am.oid = ic.relam
+        LEFT JOIN pg_constraint AS con
+               ON con.conindid = i.indexrelid AND con.contype IN ('p', 'u', 'x')
+        LEFT JOIN pg_stat_all_indexes AS s ON s.indexrelid = i.indexrelid
+        WHERE n.nspname = $1
+          AND ($2 = '' OR tc.relname = $2)
+      )
+      SELECT JSONB_BUILD_OBJECT(
+        'identical', COALESCE((
+          SELECT JSONB_AGG(g ORDER BY g->>'table')
+          FROM (
+            SELECT JSONB_BUILD_OBJECT(
+                     'table', a.schema || '.' || a.table_name,
+                     'access_method', a.access_method,
+                     'key_columns', a.key_columns,
+                     'included_columns', a.included_columns,
+                     'predicate', a.predicate,
+                     'indexes', JSONB_AGG(JSONB_BUILD_OBJECT(
+                                  'name', a.index_name,
+                                  'definition', a.definition,
+                                  'size', a.size,
+                                  'idx_scan', a.idx_scan,
+                                  'unique', a.is_unique,
+                                  'primary_key', a.is_primary,
+                                  'constraint', a.constraint_name,
+                                  'replica_identity', a.is_replica_identity,
+                                  'valid', a.is_valid) ORDER BY a.index_name)) AS g
+            FROM idx AS a
+            GROUP BY a.indrelid, a.schema, a.table_name, a.access_method,
+                     a.key_columns, a.key_signature, a.included_columns, a.predicate
+            HAVING COUNT(*) > 1
+          ) AS dup), '[]'::jsonb),
+        'redundant', COALESCE((
+          SELECT JSONB_AGG(red.r ORDER BY red.size DESC)
+          FROM (
+            SELECT DISTINCT ON (a.indexrelid) JSONB_BUILD_OBJECT(
+                     'table', a.schema || '.' || a.table_name,
+                     'index', a.index_name,
+                     'definition', a.definition,
+                     'size', a.size,
+                     'idx_scan', a.idx_scan,
+                     'covered_by', b.index_name,
+                     'covered_by_definition', b.definition,
+                     'covered_by_size', b.size,
+                     'covered_by_idx_scan', b.idx_scan,
+                     'reason',
+                       CASE WHEN array_length(a.key_signature, 1) < array_length(b.key_signature, 1)
+                            THEN 'key columns are a leading prefix of ' || b.index_name
+                            ELSE 'same key columns, and ' || b.index_name ||
+                                 ' also covers the included columns'
+                       END,
+                     'constraint', a.constraint_name,
+                     'replica_identity', a.is_replica_identity,
+                     'valid', a.is_valid) AS r,
+                   a.size
+            FROM idx AS a
+            JOIN idx AS b
+              ON b.indrelid = a.indrelid
+             AND b.indexrelid <> a.indexrelid
+             AND b.access_method = a.access_method
+             AND a.predicate IS NOT DISTINCT FROM b.predicate
+             AND array_length(a.key_signature, 1) <= array_length(b.key_signature, 1)
+             AND b.key_signature[1:array_length(a.key_signature, 1)] = a.key_signature
+             AND a.included_columns <@ (b.key_columns || b.included_columns)
+             -- With equal key lists the wider index must cover something the
+             -- narrower one does not, otherwise the two would report each
+             -- other and the pair belongs in 'identical' anyway.
+             AND (array_length(a.key_signature, 1) < array_length(b.key_signature, 1)
+                  OR NOT (b.included_columns <@ (a.key_columns || a.included_columns)))
+            -- A unique index is never redundant merely for being a prefix: it
+            -- enforces a constraint the wider index does not.
+            WHERE NOT a.is_unique
+            ORDER BY a.indexrelid, b.size
+          ) AS red), '[]'::jsonb)
+      );
+    )";
+
+    pqxx::result res = pqxx_exec(txn, query, pqxx::params{schema, table_name});
+
+    if (!res.empty() && !res[0][0].is_null()) {
+      return json::parse(res[0][0].as<std::string>());
+    } else {
+      return {};
+    }
+  }
+
+  const json checkpoint_stats() {
+    Session sess{active_cfg()};
+    pqxx::work& txn = sess.txn();
+
+    // PostgreSQL 17 split the checkpointer counters out of pg_stat_bgwriter
+    // into pg_stat_checkpointer, renamed them, and moved the backend-written
+    // buffer counts to pg_stat_io. Field names are normalized across both
+    // shapes so a caller never has to branch on the server version; 'source'
+    // says which views produced the numbers.
+    const bool split = sess.server_version() >= 170000;
+
+    // pg_stat_wal lost wal_write/wal_sync and their timings in PostgreSQL 18,
+    // where they moved to pg_stat_io. The remaining four columns exist on
+    // every supported major.
+    const std::string wal_timing = sess.server_version() < 180000
+      ? R"(, 'wal_write', w.wal_write,
+            'wal_sync', w.wal_sync,
+            'wal_write_time_ms', w.wal_write_time,
+            'wal_sync_time_ms', w.wal_sync_time)"
+      : "";
+
+    const std::string checkpointer = split ? R"(
+        'source', 'pg_stat_checkpointer + pg_stat_bgwriter + pg_stat_io',
+        'checkpointer', (SELECT JSONB_BUILD_OBJECT(
+             'checkpoints_timed',        c.num_timed,
+             'checkpoints_requested',    c.num_requested,
+             'checkpoints_total',        c.num_timed + c.num_requested,
+             'timed_percent',            round(100.0 * c.num_timed
+                                               / NULLIF(c.num_timed + c.num_requested, 0), 1),
+             'restartpoints_timed',      c.restartpoints_timed,
+             'restartpoints_requested',  c.restartpoints_req,
+             'restartpoints_done',       c.restartpoints_done,
+             'write_time_ms',            c.write_time,
+             'sync_time_ms',             c.sync_time,
+             'buffers_written',          c.buffers_written,
+             'stats_reset',              c.stats_reset,
+             'seconds_since_reset',      round(EXTRACT(EPOCH FROM now() - c.stats_reset)),
+             'checkpoints_per_hour',     round((c.num_timed + c.num_requested)
+                                               / NULLIF(EXTRACT(EPOCH FROM now() - c.stats_reset)
+                                                        / 3600.0, 0), 2),
+             'mean_seconds_between_checkpoints',
+                                         round(EXTRACT(EPOCH FROM now() - c.stats_reset)
+                                               / NULLIF(c.num_timed + c.num_requested, 0))
+           ) FROM pg_stat_checkpointer AS c),
+        'bgwriter', (SELECT JSONB_BUILD_OBJECT(
+             'buffers_clean',    b.buffers_clean,
+             'maxwritten_clean', b.maxwritten_clean,
+             'buffers_alloc',    b.buffers_alloc,
+             'stats_reset',      b.stats_reset
+           ) FROM pg_stat_bgwriter AS b),
+        -- buffers_backend and buffers_backend_fsync were removed from
+        -- pg_stat_bgwriter in 17; this is the same measurement, per backend
+        -- type, from where it now lives.
+        'backend_io', (SELECT JSONB_OBJECT_AGG(backend_type, JSONB_BUILD_OBJECT(
+             'writes', writes, 'fsyncs', fsyncs, 'extends', extends,
+             'evictions', evictions, 'reads', reads))
+           FROM (SELECT backend_type,
+                        SUM(writes) AS writes, SUM(fsyncs) AS fsyncs,
+                        SUM(extends) AS extends, SUM(evictions) AS evictions,
+                        SUM(reads) AS reads
+                 FROM pg_stat_io
+                 WHERE object = 'relation'
+                 GROUP BY backend_type) AS io),
+    )" : R"(
+        'source', 'pg_stat_bgwriter',
+        'checkpointer', (SELECT JSONB_BUILD_OBJECT(
+             'checkpoints_timed',        b.checkpoints_timed,
+             'checkpoints_requested',    b.checkpoints_req,
+             'checkpoints_total',        b.checkpoints_timed + b.checkpoints_req,
+             'timed_percent',            round(100.0 * b.checkpoints_timed
+                                               / NULLIF(b.checkpoints_timed + b.checkpoints_req, 0), 1),
+             'write_time_ms',            b.checkpoint_write_time,
+             'sync_time_ms',             b.checkpoint_sync_time,
+             'buffers_written',          b.buffers_checkpoint,
+             'stats_reset',              b.stats_reset,
+             'seconds_since_reset',      round(EXTRACT(EPOCH FROM now() - b.stats_reset)),
+             'checkpoints_per_hour',     round((b.checkpoints_timed + b.checkpoints_req)
+                                               / NULLIF(EXTRACT(EPOCH FROM now() - b.stats_reset)
+                                                        / 3600.0, 0), 2),
+             'mean_seconds_between_checkpoints',
+                                         round(EXTRACT(EPOCH FROM now() - b.stats_reset)
+                                               / NULLIF(b.checkpoints_timed + b.checkpoints_req, 0))
+           ) FROM pg_stat_bgwriter AS b),
+        'bgwriter', (SELECT JSONB_BUILD_OBJECT(
+             'buffers_clean',          b.buffers_clean,
+             'maxwritten_clean',       b.maxwritten_clean,
+             'buffers_backend',        b.buffers_backend,
+             'buffers_backend_fsync',  b.buffers_backend_fsync,
+             'buffers_alloc',          b.buffers_alloc,
+             'stats_reset',            b.stats_reset
+           ) FROM pg_stat_bgwriter AS b),
+    )";
+
+    std::string query = R"(
+      SELECT JSONB_BUILD_OBJECT(
+    )" + checkpointer + R"(
+        'wal', (SELECT JSONB_BUILD_OBJECT(
+             'wal_records',      w.wal_records,
+             'wal_fpi',          w.wal_fpi,
+             'wal_bytes',        w.wal_bytes,
+             'wal_buffers_full', w.wal_buffers_full,
+             'stats_reset',      w.stats_reset
+           )" + wal_timing + R"(
+           ) FROM pg_stat_wal AS w),
+        'settings', (SELECT JSONB_OBJECT_AGG(name, JSONB_BUILD_OBJECT(
+             'setting', setting, 'unit', unit))
+           FROM pg_settings
+          WHERE name IN ('checkpoint_timeout', 'checkpoint_completion_target',
+                         'checkpoint_flush_after', 'checkpoint_warning',
+                         'max_wal_size', 'min_wal_size', 'wal_buffers',
+                         'wal_writer_delay', 'wal_writer_flush_after',
+                         'wal_level', 'wal_compression', 'full_page_writes',
+                         'synchronous_commit', 'fsync',
+                         'bgwriter_delay', 'bgwriter_lru_maxpages',
+                         'bgwriter_lru_multiplier', 'bgwriter_flush_after',
+                         'shared_buffers'))
+      );
+    )";
+
+    pqxx::result res = txn.exec(query);
+
+    if (!res.empty() && !res[0][0].is_null()) {
+      return json::parse(res[0][0].as<std::string>());
+    } else {
+      return {};
+    }
+  }
+
+  const json table_io_stats(const std::string& schema, const std::string& table_name, int limit) {
+    Session sess{active_cfg()};
+    pqxx::work& txn = sess.txn();
+
+    // A per-index breakdown is attached only when a single table was named:
+    // over a whole schema it multiplies the payload by the index count without
+    // making the table-level ratios any easier to read.
+    //
+    // Ratios are null rather than 0 when nothing has been read yet, so "no
+    // traffic" is never mistaken for "every read missed the cache".
+    std::string query = R"(
+      SELECT JSONB_OBJECT_AGG(r.schemaname || '.' || r.relname, JSONB_BUILD_OBJECT(
+               'heap_blks_read', r.heap_blks_read,
+               'heap_blks_hit',  r.heap_blks_hit,
+               'heap_hit_percent',
+                 round(100.0 * r.heap_blks_hit
+                       / NULLIF(r.heap_blks_hit + r.heap_blks_read, 0), 2),
+               'idx_blks_read', r.idx_blks_read,
+               'idx_blks_hit',  r.idx_blks_hit,
+               'idx_hit_percent',
+                 round(100.0 * r.idx_blks_hit
+                       / NULLIF(r.idx_blks_hit + r.idx_blks_read, 0), 2),
+               'toast_blks_read', r.toast_blks_read,
+               'toast_blks_hit',  r.toast_blks_hit,
+               'tidx_blks_read',  r.tidx_blks_read,
+               'tidx_blks_hit',   r.tidx_blks_hit,
+               'total_blks_read', r.total_read,
+               'total_blks_hit',  r.total_hit,
+               'total_hit_percent',
+                 round(100.0 * r.total_hit / NULLIF(r.total_hit + r.total_read, 0), 2),
+               'size',       r.size,
+               'seq_scan',   r.seq_scan,
+               'idx_scan',   r.idx_scan,
+               'n_live_tup', r.n_live_tup,
+               'indexes',    r.indexes))
+      FROM (
+        SELECT io.schemaname, io.relname,
+               io.heap_blks_read, io.heap_blks_hit,
+               io.idx_blks_read, io.idx_blks_hit,
+               io.toast_blks_read, io.toast_blks_hit,
+               io.tidx_blks_read, io.tidx_blks_hit,
+               COALESCE(io.heap_blks_read, 0) + COALESCE(io.idx_blks_read, 0)
+                 + COALESCE(io.toast_blks_read, 0) + COALESCE(io.tidx_blks_read, 0) AS total_read,
+               COALESCE(io.heap_blks_hit, 0) + COALESCE(io.idx_blks_hit, 0)
+                 + COALESCE(io.toast_blks_hit, 0) + COALESCE(io.tidx_blks_hit, 0) AS total_hit,
+               pg_total_relation_size(io.relid) AS size,
+               st.seq_scan, st.idx_scan, st.n_live_tup,
+               CASE WHEN $2 <> '' THEN (
+                 SELECT JSONB_OBJECT_AGG(ix.indexrelname, JSONB_BUILD_OBJECT(
+                          'idx_blks_read', ix.idx_blks_read,
+                          'idx_blks_hit',  ix.idx_blks_hit,
+                          'idx_hit_percent',
+                            round(100.0 * ix.idx_blks_hit
+                                  / NULLIF(ix.idx_blks_hit + ix.idx_blks_read, 0), 2),
+                          'idx_scan', si.idx_scan,
+                          'idx_tup_read', si.idx_tup_read,
+                          'idx_tup_fetch', si.idx_tup_fetch,
+                          'size', pg_relation_size(ix.indexrelid)))
+                 FROM pg_statio_all_indexes AS ix
+                 LEFT JOIN pg_stat_all_indexes AS si ON si.indexrelid = ix.indexrelid
+                 WHERE ix.relid = io.relid
+               ) END AS indexes
+        FROM pg_statio_all_tables AS io
+        LEFT JOIN pg_stat_all_tables AS st ON st.relid = io.relid
+        WHERE io.schemaname = $1
+          AND ($2 = '' OR io.relname = $2)
+        ORDER BY COALESCE(io.heap_blks_read, 0) + COALESCE(io.idx_blks_read, 0)
+                 + COALESCE(io.toast_blks_read, 0) + COALESCE(io.tidx_blks_read, 0) DESC
+        LIMIT $3
+      ) AS r;
+    )";
+
+    pqxx::result res = pqxx_exec(txn, query, pqxx::params{schema, table_name, limit});
+
+    if (!res.empty() && !res[0][0].is_null()) {
+      return json::parse(res[0][0].as<std::string>());
+    } else {
+      return {};
+    }
+  }
+
+  // Host RAM and vCPU count are not in any catalog, so they arrive from
+  // outside: a hostCapacity argument (an agent that just inspected the box),
+  // the connections file, or the environment. Whichever is used is named in
+  // 'source', because every derived ratio is only as good as that figure.
+  const json host_capacity(long long ram_mb_arg, int vcpus_arg,
+                           const std::string& storage_arg) {
+    pglicht::HostCapacity cap = active_cfg().capacity;
+    if (ram_mb_arg > 0 || vcpus_arg > 0 || !storage_arg.empty()) {
+      // Arguments win over configuration, and are reported as a distinct
+      // source: a value passed per call is a claim about right now, while the
+      // file may have been written for a machine that has since been resized.
+      pglicht::HostCapacity from_args;
+      from_args.ram_mb  = ram_mb_arg > 0 ? ram_mb_arg : cap.ram_mb;
+      from_args.vcpus   = vcpus_arg  > 0 ? vcpus_arg  : cap.vcpus;
+      from_args.storage = !storage_arg.empty() ? storage_arg : cap.storage;
+      from_args.note    = cap.note;
+      from_args.source  = cap.configured() ? "argument (over " + cap.source + ")" : "argument";
+      cap = from_args;
+    }
+
+    Session sess{active_cfg()};
+    pqxx::work& txn = sess.txn();
+
+    // Byte-valued GUCs are reported in their own unit (8kB pages for
+    // shared_buffers, kB for work_mem, ...), so the multiplier is applied here
+    // rather than leaving every caller to rediscover it. A negative setting
+    // means "derive from another GUC" (autovacuum_work_mem = -1) and yields a
+    // null byte count rather than a negative one.
+    std::string query = R"(
+      WITH host AS (
+        SELECT NULLIF($1, '')::bigint AS ram_bytes,
+               NULLIF($2, '')::int    AS vcpus
+      ),
+      g AS (
+        SELECT name, setting, unit,
+               CASE WHEN setting::bigint < 0 THEN NULL
+                    ELSE setting::bigint * CASE unit
+                                             WHEN 'B'   THEN 1
+                                             WHEN 'kB'  THEN 1024
+                                             WHEN 'MB'  THEN 1048576
+                                             WHEN 'GB'  THEN 1073741824
+                                             WHEN '8kB' THEN 8192
+                                           END
+               END AS bytes
+        FROM pg_settings
+        WHERE vartype = 'integer'
+          AND name IN ('shared_buffers', 'work_mem', 'maintenance_work_mem',
+                       'autovacuum_work_mem', 'temp_buffers', 'wal_buffers',
+                       'effective_cache_size', 'min_wal_size', 'max_wal_size',
+                       'logical_decoding_work_mem',
+                       'max_connections', 'superuser_reserved_connections',
+                       'max_worker_processes', 'max_parallel_workers',
+                       'max_parallel_workers_per_gather',
+                       'max_parallel_maintenance_workers', 'autovacuum_max_workers',
+                       'effective_io_concurrency', 'maintenance_io_concurrency')
+      ),
+      v AS (
+        SELECT (SELECT bytes   FROM g WHERE name = 'shared_buffers')       AS shared_buffers,
+               (SELECT bytes   FROM g WHERE name = 'work_mem')             AS work_mem,
+               (SELECT bytes   FROM g WHERE name = 'maintenance_work_mem') AS maint_work_mem,
+               (SELECT bytes   FROM g WHERE name = 'effective_cache_size') AS effective_cache_size,
+               (SELECT setting::bigint FROM g WHERE name = 'max_connections')        AS max_connections,
+               (SELECT setting::bigint FROM g WHERE name = 'autovacuum_max_workers') AS av_workers
+      )
+      SELECT JSONB_BUILD_OBJECT(
+        'server', JSONB_BUILD_OBJECT(
+          'version', current_setting('server_version'),
+          'database', current_database()),
+        'settings', (SELECT JSONB_OBJECT_AGG(name, JSONB_BUILD_OBJECT(
+                        'setting', setting, 'unit', unit, 'bytes', bytes)) FROM g),
+        'derived', (SELECT JSONB_BUILD_OBJECT(
+          'shared_buffers_percent_of_ram',
+            round(100.0 * v.shared_buffers / NULLIF(host.ram_bytes, 0), 1),
+          'effective_cache_size_percent_of_ram',
+            round(100.0 * v.effective_cache_size / NULLIF(host.ram_bytes, 0), 1),
+          'work_mem_times_max_connections_bytes',
+            v.work_mem * v.max_connections,
+          'work_mem_times_max_connections_percent_of_ram',
+            round(100.0 * v.work_mem * v.max_connections / NULLIF(host.ram_bytes, 0), 1),
+          'maintenance_work_mem_times_autovacuum_workers_bytes',
+            v.maint_work_mem * v.av_workers,
+          'maintenance_work_mem_times_autovacuum_workers_percent_of_ram',
+            round(100.0 * v.maint_work_mem * v.av_workers / NULLIF(host.ram_bytes, 0), 1),
+          'committed_worst_case_bytes',
+            v.shared_buffers + v.work_mem * v.max_connections
+              + v.maint_work_mem * v.av_workers,
+          'committed_worst_case_percent_of_ram',
+            round(100.0 * (v.shared_buffers + v.work_mem * v.max_connections
+                           + v.maint_work_mem * v.av_workers)
+                  / NULLIF(host.ram_bytes, 0), 1),
+          'max_parallel_workers_per_vcpu',
+            round((SELECT setting::numeric FROM g WHERE name = 'max_parallel_workers')
+                  / NULLIF(host.vcpus, 0), 2),
+          'max_worker_processes_per_vcpu',
+            round((SELECT setting::numeric FROM g WHERE name = 'max_worker_processes')
+                  / NULLIF(host.vcpus, 0), 2))
+          FROM v, host),
+        'notes', JSONB_BUILD_ARRAY(
+          'work_mem is a per-node limit, not a per-connection one: a single query '
+          'with several sorts or hash joins can use a multiple of it, and parallel '
+          'workers each get their own. work_mem_times_max_connections is therefore a '
+          'floor on the worst case, not a ceiling.',
+          'shared_buffers is counted once here; the operating system page cache is '
+          'not, which is what effective_cache_size is meant to describe.')
+      );
+    )";
+
+    pqxx::result res = pqxx_exec(
+      txn, query,
+      pqxx::params{cap.ram_mb > 0 ? std::to_string(cap.ram_mb * 1048576LL) : std::string{},
+                   cap.vcpus  > 0 ? std::to_string(cap.vcpus)              : std::string{}});
+
+    json out = (!res.empty() && !res[0][0].is_null())
+      ? json::parse(res[0][0].as<std::string>()) : json::object();
+
+    json host = {{"configured", cap.configured()}};
+    if (cap.ram_mb > 0) {
+      host["ram_mb"]    = cap.ram_mb;
+      host["ram_bytes"] = cap.ram_mb * 1048576LL;
+    }
+    if (cap.vcpus > 0)        host["vcpus"]   = cap.vcpus;
+    if (!cap.storage.empty()) host["storage"] = cap.storage;
+    if (!cap.note.empty())    host["note"]    = cap.note;
+    if (!cap.source.empty())  host["source"]  = cap.source;
+    out["host"] = host;
+
+    if (cap.ram_mb <= 0) {
+      out["hint"] =
+        "no host RAM is configured, so every percent_of_ram field is null. Supply "
+        "ram_mb (and vcpus) as arguments to this tool, set host_ram_mb/host_vcpus "
+        "in the connection's section of the connections file, or export "
+        "PG_LICHT_HOST_RAM_MB/PG_LICHT_HOST_VCPUS. PostgreSQL cannot report the "
+        "host's memory itself, and pg-licht will not guess it";
+    }
+    return out;
   }
 
   // A plan is read-only iff no ModifyTable node appears anywhere in the tree.
@@ -2903,6 +3585,36 @@ private:
 	else if (tool_name == "statementStats") {
 	  int limit = arguments.contains("limit") ? arguments["limit"].get<int>() : 20;
 	  result_content = statement_stats(limit);
+	}
+	else if (tool_name == "wraparoundStatus") {
+	  // No schema default here: wraparound is a whole-database property, and
+	  // silently scoping it to "public" would understate the risk.
+	  std::string target_schema = arguments.contains("schema") ? arguments["schema"].get<std::string>() : "";
+	  int limit = arguments.contains("limit") ? arguments["limit"].get<int>() : 20;
+	  result_content = wraparound_status(target_schema, limit);
+	}
+	else if (tool_name == "checkpointStats") {
+	  result_content = checkpoint_stats();
+	}
+	else if (tool_name == "tableIOStats") {
+	  std::string target_schema = arguments.contains("schema") ? arguments["schema"].get<std::string>() : "public";
+	  std::string target_table  = arguments.contains("table")  ? arguments["table"].get<std::string>()  : "";
+	  int limit = arguments.contains("limit") ? arguments["limit"].get<int>() : 20;
+	  result_content = table_io_stats(target_schema, target_table, limit);
+	}
+	else if (tool_name == "hostCapacity") {
+	  long long ram_mb = arguments.contains("ram_mb") && arguments["ram_mb"].is_number_integer()
+	    ? arguments["ram_mb"].get<long long>() : 0;
+	  int vcpus = arguments.contains("vcpus") && arguments["vcpus"].is_number_integer()
+	    ? arguments["vcpus"].get<int>() : 0;
+	  std::string storage = arguments.contains("storage") && arguments["storage"].is_string()
+	    ? arguments["storage"].get<std::string>() : "";
+	  result_content = host_capacity(ram_mb, vcpus, storage);
+	}
+	else if (tool_name == "duplicateIndexes") {
+	  std::string target_schema = arguments.contains("schema") ? arguments["schema"].get<std::string>() : "public";
+	  std::string target_table  = arguments.contains("table")  ? arguments["table"].get<std::string>()  : "";
+	  result_content = duplicate_indexes(target_schema, target_table);
 	}
 	else if (tool_name == "tableBloat") {
 	  std::string target_schema = arguments.contains("schema") ? arguments["schema"].get<std::string>() : "public";

--- a/cpp/src/server.h
+++ b/cpp/src/server.h
@@ -2,6 +2,7 @@
 
 #include <cctype>
 #include <iostream>
+#include <map>
 #include <set>
 #include <string>
 #include <unistd.h>
@@ -150,11 +151,22 @@ public:
   const json call_extensions() { return extensions(); }
   const json call_database_size() { return database_size(); }
   const json call_server_settings() { return server_settings(); }
-  const json call_activity() { return activity(); }
-  const json call_locks() { return locks(); }
+  const json call_activity() { return activity(0, "", 0, ""); }
+  const json call_activity(int pid, const std::string& query_id,
+                           double min_duration_s, const std::string& state) {
+    return activity(pid, query_id, min_duration_s, state);
+  }
+  const json call_locks() { return locks(0); }
+  const json call_locks(int pid) { return locks(pid); }
   const json call_replication_slots() { return replication_slots(); }
   const json call_database_stats() { return database_stats(); }
-  const json call_statement_stats(int limit) { return statement_stats(limit); }
+  const json call_statement_stats(int limit) {
+    return statement_stats(limit, "", "", 0);
+  }
+  const json call_statement_stats(int limit, const std::string& query_id,
+                                  const std::string& order_by, long long min_calls) {
+    return statement_stats(limit, query_id, order_by, min_calls);
+  }
   const json call_table_bloat(const std::string& schema, const std::string& table_name, bool exact) {
     return table_bloat(schema, table_name, exact);
   }
@@ -169,8 +181,15 @@ public:
     return duplicate_indexes(schema, table_name);
   }
   const json call_checkpoint_stats() { return checkpoint_stats(); }
-  const json call_progress_stats() { return progress_stats(); }
-  const json call_io_stats() { return io_stats(); }
+  const json call_progress_stats() { return progress_stats(0, ""); }
+  const json call_progress_stats(int pid, const std::string& relation) {
+    return progress_stats(pid, relation);
+  }
+  const json call_io_stats() { return io_stats(0, "", "", ""); }
+  const json call_io_stats(int pid, const std::string& backend_type,
+                           const std::string& object, const std::string& context) {
+    return io_stats(pid, backend_type, object, context);
+  }
   const json call_table_io_stats(const std::string& schema, const std::string& table_name, int limit) {
     return table_io_stats(schema, table_name, limit);
   }
@@ -541,18 +560,40 @@ private:
 	  },
 	  {
 	    {"name", "currentActivity"},
-	    {"description", "return current server connections and running queries (pg_stat_activity) across all databases: pid, database, user, application_name, backend_type, state, wait event, and query text"},
+	    {"description", "return current server connections and running queries (pg_stat_activity) across all databases: pid, database, user, application_name, backend_type, state, wait event, query text, transaction and query duration, leader_pid for parallel workers, and the backend's xid and xmin. query_id is returned as a decimal string and is the join key to statementStats and explainQuery, so a statement seen running here can be looked up and planned. All filters are optional and combine; with none the whole view is returned, which on a busy server is mostly idle connections and internal processes"},
 	    {"inputSchema", {
 		{"type", "object"},
-		{"properties", json::object()}
+		{"properties", {
+		    {"pid", {
+			{"type", "integer"},
+			{"description", "a single backend, together with its parallel workers (any backend whose leader_pid is this pid)"}
+		      }},
+		    {"query_id", {
+			{"type", "string"},
+			{"description", "only backends running this query_id, as a decimal string; use it to find who is running a statement identified by statementStats. Requires compute_query_id to be enabled (the default 'auto' enables it when pg_stat_statements is loaded)"}
+		      }},
+		    {"min_duration_s", {
+			{"type", "number"},
+			{"description", "only backends whose current query has been running at least this many seconds. Plain idle backends are excluded, since their query_start dates a statement that already finished"}
+		      }},
+		    {"state", {
+			{"type", "string"},
+			{"description", "only backends in this pg_stat_activity state, e.g. \"active\" or \"idle in transaction\""}
+		      }}
+		  }}
 	      }}
 	  },
 	  {
 	    {"name", "currentLocks"},
-	    {"description", "return current locks (pg_locks) joined with the holding backend's query and user, plus which pids are blocking each waiting lock; use to diagnose lock contention"},
+	    {"description", "return current locks (pg_locks) joined with the holding backend's query and user, plus which pids are blocking each waiting lock; use to diagnose lock contention. Given a pid, returns that backend's locks together with every backend blocking it transitively, each tagged with chain_depth: 0 is the pid asked about, and the largest depth is the backend at the root of the pile-up, which is the one to look at first"},
 	    {"inputSchema", {
 		{"type", "object"},
-		{"properties", json::object()}
+		{"properties", {
+		    {"pid", {
+			{"type", "integer"},
+			{"description", "restrict to this backend and its transitive blockers, resolved through pg_blocking_pids. Omit for every lock in the cluster"}
+		      }}
+		  }}
 	      }}
 	  },
 	  {
@@ -573,11 +614,23 @@ private:
 	  },
 	  {
 	    {"name", "statementStats"},
-	    {"description", "return the slowest tracked queries by total execution time (pg_stat_statements), with calls, timing, row counts, and buffer usage; returns a clear error with setup instructions if the extension is not installed"},
+	    {"description", "return tracked queries from pg_stat_statements under 'statements', with calls, timing, row counts, buffer usage, temporary block I/O and WAL volume, alongside an 'info' block from pg_stat_statements_info whose dealloc counter says whether entries are being evicted -- if it is climbing, this is not the slowest queries in the cluster but the slowest of those that survived eviction. query_id is a decimal string, ready to pass to explainQuery. Returns a clear error with setup instructions if the extension is not installed"},
 	    {"inputSchema", {
 		{"type", "object"},
 		{"properties", {
-		    {"limit", {{"type", "integer"}}}
+		    {"limit", {{"type", "integer"}, {"description", "how many statements to return. Defaults to 20"}}},
+		    {"query_id", {
+			{"type", "string"},
+			{"description", "only statements with this queryid, as a decimal string; their query text is returned whole rather than truncated. pg_stat_statements keeps one entry per user and database, so a queryid can match more than one row"}
+		      }},
+		    {"order_by", {
+			{"type", "string"},
+			{"description", "ranking column: total_exec_time (default), mean_exec_time, max_exec_time, calls, rows, shared_blks_read, temp_blks_written, or wal_bytes. Ranking by total time buries a statement called twice at 40s under one called ten million times at 2ms; mean_exec_time is the other question"}
+		      }},
+		    {"min_calls", {
+			{"type", "integer"},
+			{"description", "ignore statements called fewer times than this, to keep one-off maintenance queries out of a mean_exec_time ranking"}
+		      }}
 		  }}
 	      }}
 	  },
@@ -603,15 +656,41 @@ private:
 	    {"description", "return every long-running maintenance command currently reporting progress (pg_stat_progress_vacuum, _analyze, _create_index, _cluster, _copy, _basebackup), with the phase, the blocks or tuples done against the total, a completion percentage, and how long it has been running. Use it to decide whether a VACUUM will finish before wraparound, or whether a CREATE INDEX is stuck waiting on a locker. The PostgreSQL 17 rename of the vacuum dead-tuple columns is normalized, and 'dead_tuple_unit' says whether the server counts tuples or bytes"},
 	    {"inputSchema", {
 		{"type", "object"},
-		{"properties", json::object()}
+		{"properties", {
+		    {"pid", {
+			{"type", "integer"},
+			{"description", "only the command running in this backend; pair with the pid from currentActivity"}
+		      }},
+		    {"relation", {
+			{"type", "string"},
+			{"description", "only commands operating on this table, named bare or schema-qualified. A base backup has no relation, so this excludes that category entirely"}
+		      }}
+		  }}
 	      }}
 	  },
 	  {
 	    {"name", "ioStats"},
-	    {"description", "return cumulative I/O statistics per backend type, object and context (pg_stat_io, PostgreSQL 16+): reads, writes, extends, hits, evictions, reuses, fsyncs and their timings, with a hit percentage. This is where backend-written buffers, vacuum's ring-buffer reuse, and bulk read/write I/O become visible separately from the aggregate counters. Rows with no activity are omitted. Returns a clear error on PostgreSQL 15 and older, where the view does not exist"},
+	    {"description", "return cumulative I/O statistics under 'io', per backend type, object and context (pg_stat_io, PostgreSQL 16+): reads, writes, extends, hits, evictions, reuses, fsyncs and their timings, with a hit percentage. This is where backend-written buffers, vacuum's ring-buffer reuse, and bulk read/write I/O become visible separately from the aggregate counters in checkpointStats. Rows with no activity are omitted unless a filter was given. Given a pid, reports that one backend instead, via pg_stat_get_backend_io, plus its WAL volume under 'wal' -- a backend can be quiet in I/O and still be generating WAL heavily; that requires PostgreSQL 18, since pg_stat_io itself has no pid column. Returns a clear error on PostgreSQL 15 and older, where the view does not exist"},
 	    {"inputSchema", {
 		{"type", "object"},
-		{"properties", json::object()}
+		{"properties", {
+		    {"pid", {
+			{"type", "integer"},
+			{"description", "report this one backend's I/O and WAL instead of the cluster-wide aggregate. PostgreSQL 18 and newer only"}
+		      }},
+		    {"backend_type", {
+			{"type", "string"},
+			{"description", "only this backend type, e.g. \"client backend\", \"autovacuum worker\", \"checkpointer\""}
+		      }},
+		    {"object", {
+			{"type", "string"},
+			{"description", "only this object class, e.g. \"relation\" or \"temp relation\""}
+		      }},
+		    {"context", {
+			{"type", "string"},
+			{"description", "only this I/O context, e.g. \"normal\", \"vacuum\", \"bulkread\", \"bulkwrite\""}
+		      }}
+		  }}
 	      }}
 	  },
 	  {
@@ -1143,7 +1222,12 @@ private:
     }
   }
 
-  const json activity() {
+  // All four filters are optional and independent; omitting every one returns
+  // the whole of pg_stat_activity, as before. They matter because the
+  // unfiltered view on a busy server is mostly idle connections and internal
+  // processes, and the entry the caller wants is one row in several hundred.
+  const json activity(int pid, const std::string& query_id,
+                      double min_duration_s, const std::string& state) {
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
 
@@ -1190,23 +1274,76 @@ private:
                ))
       FROM pg_stat_activity AS a
       )" + wait_join + R"(
-      WHERE a.pid != pg_backend_pid();
+      WHERE a.pid != pg_backend_pid()
+        -- A pid brings its parallel workers with it. Asking about a leader and
+        -- being shown only the leader hides where the work is actually
+        -- happening, which is the reason for asking in the first place.
+        AND ($1 = '' OR a.pid = $1::int OR a.leader_pid = $1::int)
+        AND ($2 = '' OR a.query_id = $2::bigint)
+        -- Duration is measured on the current query, and plain idle backends
+        -- are excluded: an idle connection's query_start dates its last
+        -- statement, so including them would report every long-idle session as
+        -- a long-running query.
+        AND ($3 = '' OR (a.state IS DISTINCT FROM 'idle'
+                         AND a.query_start IS NOT NULL
+                         AND now() - a.query_start
+                             >= make_interval(secs => $3::double precision)))
+        AND ($4 = '' OR a.state = $4);
     )";
 
-    pqxx::result res = txn.exec(query);
+    pqxx::result res = pqxx_exec(
+      txn, query,
+      pqxx::params{pid > 0 ? std::to_string(pid) : std::string{},
+                   query_id,
+                   min_duration_s > 0 ? std::to_string(min_duration_s) : std::string{},
+                   state});
 
     if (!res.empty() && !res[0][0].is_null()) {
       return json::parse(res[0][0].as<std::string>());
     } else {
-      return {};
+      // An empty object, not null: with filters applied, "no backend matched"
+      // is a normal answer and should read as an empty set rather than as a
+      // missing result.
+      return json::object();
     }
   }
 
-  const json locks() {
+  // With a pid, this returns that backend's locks together with every backend
+  // blocking it, transitively. A flat list of locks is the wrong shape during
+  // a pile-up: what you need is the pid at the root of the chain, and
+  // reconstructing that graph by hand from the full dump is exactly the work
+  // the tool should be doing.
+  const json locks(int pid) {
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
 
-    std::string query = R"(
+    // chain_depth is 0 for the pid asked about, 1 for what blocks it, and so
+    // on; the largest depth is the backend to look at first. The path array is
+    // a cycle guard -- a deadlock is a cycle in this graph, and without it the
+    // recursion would not terminate.
+    const std::string chain_cte = pid > 0 ? R"(
+      WITH RECURSIVE chain(pid, depth, path) AS (
+          SELECT $1::int, 0, ARRAY[$1::int]
+        UNION ALL
+          SELECT b.pid, c.depth + 1, c.path || b.pid
+          FROM chain AS c,
+               LATERAL unnest(pg_blocking_pids(c.pid)) AS b(pid)
+          WHERE NOT b.pid = ANY(c.path)
+            AND c.depth < 16
+      ),
+      chain_min AS (
+          SELECT pid, MIN(depth) AS depth FROM chain GROUP BY pid
+      )
+    )" : "";
+
+    const std::string chain_field = pid > 0 ? ", 'chain_depth', ch.depth" : "";
+    const std::string chain_join  = pid > 0
+      ? "JOIN chain_min AS ch ON ch.pid = l.pid" : "";
+    const std::string order_by = pid > 0
+      ? "ORDER BY ch.depth, l.granted ASC, l.pid"
+      : "ORDER BY l.granted ASC, l.pid";
+
+    std::string query = chain_cte + R"(
       SELECT JSONB_AGG(
                JSONB_BUILD_OBJECT(
                  'pid',              l.pid,
@@ -1219,9 +1356,11 @@ private:
                  'query',            a.query,
                  'user',             a.usename,
                  'application_name', a.application_name
-               ) ORDER BY l.granted ASC, l.pid
+               )" + chain_field + R"(
+               ) )" + order_by + R"(
              )
       FROM pg_locks AS l
+      )" + chain_join + R"(
       LEFT JOIN pg_stat_activity AS a ON a.pid = l.pid
       LEFT JOIN LATERAL (
           SELECT c.relnamespace::regnamespace::text || '.' || c.relname AS relname
@@ -1234,7 +1373,9 @@ private:
       WHERE l.pid != pg_backend_pid();
     )";
 
-    pqxx::result res = txn.exec(query);
+    pqxx::result res = pid > 0
+      ? pqxx_exec(txn, query, pqxx::params{pid})
+      : txn.exec(query);
 
     if (!res.empty() && !res[0][0].is_null()) {
       return json::parse(res[0][0].as<std::string>());
@@ -1365,7 +1506,39 @@ private:
     }
   }
 
-  const json statement_stats(int limit) {
+  const json statement_stats(int limit, const std::string& query_id,
+                             const std::string& order_by, long long min_calls) {
+    // The sort column cannot be a bind parameter, so it is resolved through a
+    // fixed table rather than interpolated. Nothing caller-supplied reaches the
+    // SQL text: an unknown name is rejected here, listing what is accepted.
+    static const std::map<std::string, std::string> ORDERINGS = {
+      {"total_exec_time",   "pss.total_exec_time DESC"},
+      {"mean_exec_time",    "pss.mean_exec_time DESC"},
+      {"max_exec_time",     "pss.max_exec_time DESC"},
+      {"calls",             "pss.calls DESC"},
+      {"rows",              "pss.rows DESC"},
+      {"shared_blks_read",  "pss.shared_blks_read DESC"},
+      {"temp_blks_written", "pss.temp_blks_written DESC"},
+      {"wal_bytes",         "pss.wal_bytes DESC"},
+    };
+    std::string key = order_by.empty() ? "total_exec_time" : order_by;
+    auto ord = ORDERINGS.find(key);
+    if (ord == ORDERINGS.end()) {
+      std::string valid;
+      for (const auto& [k, v] : ORDERINGS) { (void)v; valid += (valid.empty() ? "" : ", ") + k; }
+      throw std::runtime_error("unknown order_by \"" + order_by +
+                               "\"; valid values are: " + valid);
+    }
+
+    if (!query_id.empty()) {
+      bool ok = query_id.size() <= 20;
+      for (size_t i = 0; ok && i < query_id.size(); i++) {
+        if (i == 0 && query_id[i] == '-') { ok = query_id.size() > 1; continue; }
+        if (!std::isdigit(static_cast<unsigned char>(query_id[i]))) ok = false;
+      }
+      if (!ok) throw std::runtime_error("query_id must be a decimal integer string");
+    }
+
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
 
@@ -1397,7 +1570,12 @@ private:
                        -- silently changed between the two tools would be
                        -- looked up and not found.
                        'query_id',         pss.queryid::text,
-                       'query',            LEFT(pss.query, 500),
+                       -- Truncated in a list, whole when one statement was
+                       -- asked for by id: the point of naming a queryid is to
+                       -- get at the statement, and truncation is what makes
+                       -- the list readable, not something the caller wants.
+                       'query',            CASE WHEN $2 = '' THEN LEFT(pss.query, 500)
+                                                ELSE pss.query END,
                        'calls',            pss.calls,
                        'total_exec_ms',    pss.total_exec_time,
                        'mean_exec_ms',     pss.mean_exec_time,
@@ -1418,8 +1596,10 @@ private:
               FROM pg_stat_statements AS pss
               LEFT JOIN pg_roles AS r ON r.oid = pss.userid
               LEFT JOIN pg_database AS d ON d.oid = pss.dbid
-              ORDER BY pss.total_exec_time DESC
-              LIMIT $1
+              WHERE ($2 = '' OR pss.queryid = $2::bigint)
+                AND ($3 = '' OR pss.calls >= $3::bigint)
+              ORDER BY )" + ord->second + R"(
+              LIMIT $1::bigint
           ) sub), '[]'::jsonb),
         'info', (SELECT JSONB_BUILD_OBJECT(
                    'dealloc', i.dealloc, 'stats_reset', i.stats_reset)
@@ -1431,12 +1611,17 @@ private:
     )";
 
     try {
-      pqxx::result res = pqxx_exec(txn, query, pqxx::params{limit});
+      pqxx::result res = pqxx_exec(
+        txn, query,
+        pqxx::params{std::to_string(limit), query_id,
+                     min_calls > 0 ? std::to_string(min_calls) : std::string{}});
 
       if (!res.empty() && !res[0][0].is_null()) {
-        return json::parse(res[0][0].as<std::string>());
+        json out = json::parse(res[0][0].as<std::string>());
+        out["order_by"] = key;
+        return out;
       } else {
-        return {{"statements", json::array()}};
+        return {{"statements", json::array()}, {"order_by", key}};
       }
     } catch (const pqxx::sql_error& e) {
       if (e.sqlstate() == "42P01") { // undefined_table
@@ -1451,9 +1636,35 @@ private:
     }
   }
 
-  const json progress_stats() {
+  const json progress_stats(int pid, const std::string& relation) {
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
+
+    // The relation is matched by name against pg_class rather than by casting
+    // the argument to regclass: a regclass cast of a name that does not exist
+    // raises an error, and "no such table" should come back as an empty result
+    // from a diagnostic tool, not as a failure. Both the bare and the
+    // schema-qualified form are accepted.
+    // pc/pn rather than c/n: the COPY subquery already binds c, and an alias
+    // collision here would silently resolve to the wrong relation.
+    // Deliberately not a raw string. This fragment ends in two parentheses,
+    // and a raw string's terminator is )delimiter" -- so both R"(...))" and
+    // R"SQL(...))SQL" swallow one of them and produce SQL that fails to parse
+    // only when the filter is actually used. Plain literals have no such trap.
+    auto rel_filter = [](const std::string& alias) {
+      return " AND ($2 = '' OR " + alias + ".relid IN ("
+             " SELECT pc.oid FROM pg_class AS pc"
+             " JOIN pg_namespace AS pn ON pn.oid = pc.relnamespace"
+             " WHERE pc.relname = $2 OR pn.nspname || '.' || pc.relname = $2))";
+    };
+    const std::string pid_v  = " AND ($1 = '' OR v.pid = $1::int)";
+    const std::string pid_an = " AND ($1 = '' OR an.pid = $1::int)";
+    const std::string pid_ci = " AND ($1 = '' OR ci.pid = $1::int)";
+    const std::string pid_cl = " AND ($1 = '' OR cl.pid = $1::int)";
+    const std::string pid_c  = " AND ($1 = '' OR c.pid = $1::int)";
+    // A base backup has no relation at all, so a relation filter excludes it
+    // entirely rather than matching everything.
+    const std::string bb_filter = " AND ($1 = '' OR b.pid = $1::int) AND $2 = ''";
 
     // PostgreSQL 17 renamed three pg_stat_progress_vacuum columns:
     // max_dead_tuples -> max_dead_tuple_bytes, num_dead_tuples ->
@@ -1496,7 +1707,8 @@ private:
                    'elapsed_s',         round(EXTRACT(EPOCH FROM now() - a.query_start)::numeric, 1),
                    )" + vacuum_dead + R"())
           FROM pg_stat_progress_vacuum AS v
-          LEFT JOIN pg_stat_activity AS a ON a.pid = v.pid), '[]'::jsonb),
+          LEFT JOIN pg_stat_activity AS a ON a.pid = v.pid
+          WHERE true)" + pid_v + rel_filter("v") + R"(), '[]'::jsonb),
         'analyze', COALESCE((
           SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
                    'pid',                   an.pid,
@@ -1513,7 +1725,8 @@ private:
                    'child_tables_done',     an.child_tables_done,
                    'elapsed_s',             round(EXTRACT(EPOCH FROM now() - a.query_start)::numeric, 1)))
           FROM pg_stat_progress_analyze AS an
-          LEFT JOIN pg_stat_activity AS a ON a.pid = an.pid), '[]'::jsonb),
+          LEFT JOIN pg_stat_activity AS a ON a.pid = an.pid
+          WHERE true)" + pid_an + rel_filter("an") + R"(), '[]'::jsonb),
         'create_index', COALESCE((
           SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
                    'pid',              ci.pid,
@@ -1533,7 +1746,8 @@ private:
                    'current_locker_pid', ci.current_locker_pid,
                    'elapsed_s',        round(EXTRACT(EPOCH FROM now() - a.query_start)::numeric, 1)))
           FROM pg_stat_progress_create_index AS ci
-          LEFT JOIN pg_stat_activity AS a ON a.pid = ci.pid), '[]'::jsonb),
+          LEFT JOIN pg_stat_activity AS a ON a.pid = ci.pid
+          WHERE true)" + pid_ci + rel_filter("ci") + R"(), '[]'::jsonb),
         'cluster', COALESCE((
           SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
                    'pid',                cl.pid,
@@ -1550,7 +1764,8 @@ private:
                    'index_rebuild_count', cl.index_rebuild_count,
                    'elapsed_s',          round(EXTRACT(EPOCH FROM now() - a.query_start)::numeric, 1)))
           FROM pg_stat_progress_cluster AS cl
-          LEFT JOIN pg_stat_activity AS a ON a.pid = cl.pid), '[]'::jsonb),
+          LEFT JOIN pg_stat_activity AS a ON a.pid = cl.pid
+          WHERE true)" + pid_cl + rel_filter("cl") + R"(), '[]'::jsonb),
         'copy', COALESCE((
           SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
                    'pid',            c.pid,
@@ -1566,7 +1781,8 @@ private:
                    'tuples_excluded',  c.tuples_excluded,
                    'elapsed_s',      round(EXTRACT(EPOCH FROM now() - a.query_start)::numeric, 1)))
           FROM pg_stat_progress_copy AS c
-          LEFT JOIN pg_stat_activity AS a ON a.pid = c.pid), '[]'::jsonb),
+          LEFT JOIN pg_stat_activity AS a ON a.pid = c.pid
+          WHERE true)" + pid_c + rel_filter("c") + R"(), '[]'::jsonb),
         'basebackup', COALESCE((
           SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
                    'pid',                b.pid,
@@ -1577,11 +1793,14 @@ private:
                      round(100.0 * b.backup_streamed / NULLIF(b.backup_total, 0), 1),
                    'tablespaces_total',  b.tablespaces_total,
                    'tablespaces_streamed', b.tablespaces_streamed))
-          FROM pg_stat_progress_basebackup AS b), '[]'::jsonb)
+          FROM pg_stat_progress_basebackup AS b
+          WHERE true)" + bb_filter + R"(), '[]'::jsonb)
       );
     )";
 
-    pqxx::result res = txn.exec(query);
+    pqxx::result res = pqxx_exec(
+      txn, query,
+      pqxx::params{pid > 0 ? std::to_string(pid) : std::string{}, relation});
 
     if (!res.empty() && !res[0][0].is_null()) {
       return json::parse(res[0][0].as<std::string>());
@@ -1590,7 +1809,8 @@ private:
     }
   }
 
-  const json io_stats() {
+  const json io_stats(int pid, const std::string& backend_type,
+                      const std::string& object, const std::string& context) {
     Session sess{active_cfg()};
 
     // pg_stat_io arrived in PostgreSQL 16. Saying so plainly beats an
@@ -1602,6 +1822,18 @@ private:
                  "pg_stat_bgwriter counters, which include buffers_backend "
                  "and buffers_backend_fsync on these versions, and "
                  "tableIOStats for per-object cache hit ratios"}
+      };
+    }
+    // Per-backend I/O is not a filter over pg_stat_io -- the view has no pid
+    // column at all. It is a separate function, added in PostgreSQL 18.
+    if (pid > 0 && sess.server_version() < 180000) {
+      return {
+        {"error", "per-backend I/O statistics require PostgreSQL 18 or newer"},
+        {"hint", "pg_stat_io is aggregated across backends and has no pid "
+                 "column; pg_stat_get_backend_io(), which reports one "
+                 "backend, was added in 18. Omit pid for the cluster-wide "
+                 "view, or use currentActivity to see what the backend is "
+                 "doing"}
       };
     }
 
@@ -1616,9 +1848,30 @@ private:
             'extend_bytes', extend_bytes)"
       : "";
 
+    // One backend, or the whole cluster: the row shape is identical either
+    // way, so only the source relation changes.
+    //
+    // Both branches reference $1, which keeps one parameter list across them.
+    // PostgreSQL rejects a bind that supplies more parameters than the
+    // statement uses, so the cluster-wide branch cannot simply leave it out;
+    // the predicate it carries is the invariant that this branch is the one
+    // taken when no pid was given.
+    const std::string source = pid > 0
+      ? "pg_stat_get_backend_io($1::int)" : "pg_stat_io";
+    const std::string pid_guard = pid > 0 ? "" : " AND $1 = ''";
+
     // Rows where nothing has happened at all are dropped: pg_stat_io is a
     // dense matrix of backend_type x object x context, and most combinations
     // are structurally impossible, so an unfiltered dump is mostly nulls.
+    // With an explicit filter the rows are kept regardless, since "this
+    // context did nothing" is then the answer to the question asked.
+    const std::string activity_filter =
+      (backend_type.empty() && object.empty() && context.empty())
+        ? R"(AND (COALESCE(reads, 0) > 0 OR COALESCE(writes, 0) > 0
+                  OR COALESCE(extends, 0) > 0 OR COALESCE(hits, 0) > 0
+                  OR COALESCE(evictions, 0) > 0 OR COALESCE(fsyncs, 0) > 0))"
+        : "";
+
     std::string query = R"(
       SELECT COALESCE(JSONB_AGG(JSONB_BUILD_OBJECT(
                'backend_type', backend_type,
@@ -1641,19 +1894,40 @@ private:
                'stats_reset',  stats_reset
              )" + bytes + R"(
              ) ORDER BY backend_type, object, context), '[]'::jsonb)
-      FROM pg_stat_io
-      WHERE COALESCE(reads, 0) > 0 OR COALESCE(writes, 0) > 0
-         OR COALESCE(extends, 0) > 0 OR COALESCE(hits, 0) > 0
-         OR COALESCE(evictions, 0) > 0 OR COALESCE(fsyncs, 0) > 0;
-    )";
+      FROM )" + source + R"(
+      WHERE ($2 = '' OR backend_type = $2)
+        AND ($3 = '' OR object = $3)
+        AND ($4 = '' OR context = $4)
+      )" + pid_guard + activity_filter + ";";
 
-    pqxx::result res = txn.exec(query);
+    pqxx::result res = pqxx_exec(
+      txn, query,
+      pqxx::params{pid > 0 ? std::to_string(pid) : std::string{},
+                   backend_type, object, context});
 
-    if (!res.empty() && !res[0][0].is_null()) {
-      return json::parse(res[0][0].as<std::string>());
-    } else {
-      return json::array();
+    json out = json::object();
+    if (pid > 0) out["pid"] = pid;
+    out["io"] = (!res.empty() && !res[0][0].is_null())
+      ? json::parse(res[0][0].as<std::string>()) : json::array();
+
+    // WAL is a separate per-backend function, and is the other half of "what
+    // is this backend doing to the disk": a backend can be quiet in pg_stat_io
+    // and still be generating WAL heavily.
+    if (pid > 0) {
+      pqxx::result w = pqxx_exec(
+        txn,
+        R"(SELECT JSONB_BUILD_OBJECT(
+             'wal_records',      wal_records,
+             'wal_fpi',          wal_fpi,
+             'wal_bytes',        wal_bytes,
+             'wal_buffers_full', wal_buffers_full,
+             'stats_reset',      stats_reset)
+           FROM pg_stat_get_backend_wal($1::int))",
+        pqxx::params{std::to_string(pid)});
+      if (!w.empty() && !w[0][0].is_null())
+        out["wal"] = json::parse(w[0][0].as<std::string>());
     }
+    return out;
   }
 
   const json wraparound_status(const std::string& schema, int limit) {
@@ -3950,10 +4224,20 @@ private:
 	  result_content = server_settings();
 	}
 	else if (tool_name == "currentActivity") {
-	  result_content = activity();
+	  int pid = arguments.contains("pid") && arguments["pid"].is_number_integer()
+	    ? arguments["pid"].get<int>() : 0;
+	  std::string qid = arguments.contains("query_id") && arguments["query_id"].is_string()
+	    ? arguments["query_id"].get<std::string>() : "";
+	  double min_dur = arguments.contains("min_duration_s") && arguments["min_duration_s"].is_number()
+	    ? arguments["min_duration_s"].get<double>() : 0;
+	  std::string st = arguments.contains("state") && arguments["state"].is_string()
+	    ? arguments["state"].get<std::string>() : "";
+	  result_content = activity(pid, qid, min_dur, st);
 	}
 	else if (tool_name == "currentLocks") {
-	  result_content = locks();
+	  int pid = arguments.contains("pid") && arguments["pid"].is_number_integer()
+	    ? arguments["pid"].get<int>() : 0;
+	  result_content = locks(pid);
 	}
 	else if (tool_name == "replicationSlots") {
 	  result_content = replication_slots();
@@ -3963,7 +4247,17 @@ private:
 	}
 	else if (tool_name == "statementStats") {
 	  int limit = arguments.contains("limit") ? arguments["limit"].get<int>() : 20;
-	  result_content = statement_stats(limit);
+	  std::string qid;
+	  if (arguments.contains("query_id")) {
+	    if (arguments["query_id"].is_string()) qid = arguments["query_id"].get<std::string>();
+	    else if (arguments["query_id"].is_number_integer())
+	      qid = std::to_string(arguments["query_id"].get<long long>());
+	  }
+	  std::string ord = arguments.contains("order_by") && arguments["order_by"].is_string()
+	    ? arguments["order_by"].get<std::string>() : "";
+	  long long min_calls = arguments.contains("min_calls") && arguments["min_calls"].is_number_integer()
+	    ? arguments["min_calls"].get<long long>() : 0;
+	  result_content = statement_stats(limit, qid, ord, min_calls);
 	}
 	else if (tool_name == "wraparoundStatus") {
 	  // No schema default here: wraparound is a whole-database property, and
@@ -3976,10 +4270,22 @@ private:
 	  result_content = checkpoint_stats();
 	}
 	else if (tool_name == "progressStats") {
-	  result_content = progress_stats();
+	  int pid = arguments.contains("pid") && arguments["pid"].is_number_integer()
+	    ? arguments["pid"].get<int>() : 0;
+	  std::string rel = arguments.contains("relation") && arguments["relation"].is_string()
+	    ? arguments["relation"].get<std::string>() : "";
+	  result_content = progress_stats(pid, rel);
 	}
 	else if (tool_name == "ioStats") {
-	  result_content = io_stats();
+	  int pid = arguments.contains("pid") && arguments["pid"].is_number_integer()
+	    ? arguments["pid"].get<int>() : 0;
+	  std::string bt = arguments.contains("backend_type") && arguments["backend_type"].is_string()
+	    ? arguments["backend_type"].get<std::string>() : "";
+	  std::string ob = arguments.contains("object") && arguments["object"].is_string()
+	    ? arguments["object"].get<std::string>() : "";
+	  std::string cx = arguments.contains("context") && arguments["context"].is_string()
+	    ? arguments["context"].get<std::string>() : "";
+	  result_content = io_stats(pid, bt, ob, cx);
 	}
 	else if (tool_name == "tableIOStats") {
 	  std::string target_schema = arguments.contains("schema") ? arguments["schema"].get<std::string>() : "public";

--- a/cpp/src/server.h
+++ b/cpp/src/server.h
@@ -169,6 +169,8 @@ public:
     return duplicate_indexes(schema, table_name);
   }
   const json call_checkpoint_stats() { return checkpoint_stats(); }
+  const json call_progress_stats() { return progress_stats(); }
+  const json call_io_stats() { return io_stats(); }
   const json call_table_io_stats(const std::string& schema, const std::string& table_name, int limit) {
     return table_io_stats(schema, table_name, limit);
   }
@@ -597,6 +599,22 @@ private:
 	      }}
 	  },
 	  {
+	    {"name", "progressStats"},
+	    {"description", "return every long-running maintenance command currently reporting progress (pg_stat_progress_vacuum, _analyze, _create_index, _cluster, _copy, _basebackup), with the phase, the blocks or tuples done against the total, a completion percentage, and how long it has been running. Use it to decide whether a VACUUM will finish before wraparound, or whether a CREATE INDEX is stuck waiting on a locker. The PostgreSQL 17 rename of the vacuum dead-tuple columns is normalized, and 'dead_tuple_unit' says whether the server counts tuples or bytes"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", json::object()}
+	      }}
+	  },
+	  {
+	    {"name", "ioStats"},
+	    {"description", "return cumulative I/O statistics per backend type, object and context (pg_stat_io, PostgreSQL 16+): reads, writes, extends, hits, evictions, reuses, fsyncs and their timings, with a hit percentage. This is where backend-written buffers, vacuum's ring-buffer reuse, and bulk read/write I/O become visible separately from the aggregate counters. Rows with no activity are omitted. Returns a clear error on PostgreSQL 15 and older, where the view does not exist"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", json::object()}
+	      }}
+	  },
+	  {
 	    {"name", "checkpointStats"},
 	    {"description", "return checkpoint, WAL, and background writer activity (pg_stat_checkpointer and pg_stat_bgwriter on PostgreSQL 17+, pg_stat_bgwriter alone before that, plus pg_stat_wal) with field names normalized across both shapes: timed versus requested checkpoint counts and the ratio between them, write and sync time, buffers written by the checkpointer, by the background writer, and directly by backends, WAL record/FPI/byte counts, and the related settings (checkpoint_timeout, max_wal_size, checkpoint_completion_target, the bgwriter knobs)"},
 	    {"inputSchema", {
@@ -779,6 +797,16 @@ private:
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
 
+    // PostgreSQL 16 additions. n_tup_newpage_upd counts updates that had to
+    // move the row to another page, which is the direct measure of failed HOT
+    // updates -- the usual cause is a too-high fillfactor or an index on a
+    // frequently updated column. last_seq_scan dates the last sequential scan,
+    // which turns a large seq_scan count into something you can act on.
+    const std::string pg16 = sess.server_version() >= 160000
+      ? R"(, 'n_tup_newpage_upd', s.n_tup_newpage_upd,
+            'last_seq_scan', s.last_seq_scan)"
+      : "";
+
     std::string query = R"(
       SELECT JSONB_OBJECT_AGG(c.relname,
               JSONB_BUILD_OBJECT(
@@ -790,7 +818,8 @@ private:
                'n_mod_since_analyze', s.n_mod_since_analyze, 'n_ins_since_vacuum', s.n_ins_since_vacuum,
                'last_vacuum', GREATEST(s.last_vacuum, s.last_autovacuum), 'last_analyze', GREATEST(s.last_analyze, s.last_autoanalyze),
                'reloptions', c.reloptions,
-               'columns', columns, 'index_count', COALESCE(index_count, 0), 'constraint_count', COALESCE(constraint_count, 0)))
+               'columns', columns, 'index_count', COALESCE(index_count, 0), 'constraint_count', COALESCE(constraint_count, 0))" + pg16 + R"(
+               ))
       FROM pg_class AS c
       LEFT JOIN pg_stat_user_tables AS s ON s.relid = c.oid
       LEFT JOIN LATERAL (SELECT JSONB_OBJECT_AGG(a.attname,
@@ -1118,25 +1147,50 @@ private:
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
 
+    // pg_wait_events (PostgreSQL 17+) carries a prose description of every
+    // wait event, which is what turns an opaque name like "BufFileRead" into
+    // something actionable without leaving the tool output.
+    const std::string wait_desc = sess.server_version() >= 170000
+      ? ", 'wait_event_description', we.description" : "";
+    const std::string wait_join = sess.server_version() >= 170000
+      ? R"(LEFT JOIN pg_wait_events AS we
+             ON we.type = a.wait_event_type AND we.name = a.wait_event)"
+      : "";
+
+    // query_id is the join key to pg_stat_statements and explainQuery: without
+    // it there is no route from "this is running now" to "this is its plan".
+    // It is emitted as text because it is a 64-bit value that does not survive
+    // JSON number precision, matching explainQuery's queryid argument.
+    //
+    // It is null unless compute_query_id is on (the default, 'auto', enables it
+    // when pg_stat_statements is loaded); serverSettings reports that GUC.
     std::string query = R"(
-      SELECT JSONB_OBJECT_AGG(pid::text,
+      SELECT JSONB_OBJECT_AGG(a.pid::text,
                JSONB_BUILD_OBJECT(
-                 'database',         datname,
-                 'user',             usename,
-                 'application_name', application_name,
-                 'client_addr',      client_addr::text,
-                 'backend_type',     backend_type,
-                 'state',            state,
-                 'wait_event_type',  wait_event_type,
-                 'wait_event',       wait_event,
-                 'backend_start',    backend_start,
-                 'xact_start',       xact_start,
-                 'query_start',      query_start,
-                 'state_change',     state_change,
-                 'query',            query
+                 'database',         a.datname,
+                 'user',             a.usename,
+                 'application_name', a.application_name,
+                 'client_addr',      a.client_addr::text,
+                 'backend_type',     a.backend_type,
+                 'state',            a.state,
+                 'wait_event_type',  a.wait_event_type,
+                 'wait_event',       a.wait_event,
+                 'backend_start',    a.backend_start,
+                 'xact_start',       a.xact_start,
+                 'query_start',      a.query_start,
+                 'state_change',     a.state_change,
+                 'xact_duration_s',  round(EXTRACT(EPOCH FROM now() - a.xact_start)::numeric, 3),
+                 'query_duration_s', round(EXTRACT(EPOCH FROM now() - a.query_start)::numeric, 3),
+                 'query_id',         a.query_id::text,
+                 'leader_pid',       a.leader_pid,
+                 'backend_xid',      a.backend_xid::text,
+                 'backend_xmin',     a.backend_xmin::text,
+                 'query',            a.query
+               )" + wait_desc + R"(
                ))
-      FROM pg_stat_activity
-      WHERE pid != pg_backend_pid();
+      FROM pg_stat_activity AS a
+      )" + wait_join + R"(
+      WHERE a.pid != pg_backend_pid();
     )";
 
     pqxx::result res = txn.exec(query);
@@ -1195,21 +1249,51 @@ private:
 
     // retained_wal_bytes is the key diagnostic: a lagging or unused slot holds
     // back WAL cleanup indefinitely, a common cause of disk bloat incidents.
+    //
+    // wal_status is the verdict retained_wal_bytes only hints at: 'extended'
+    // means the slot is already past max_wal_size, and 'lost' means the WAL it
+    // needs is gone and the slot is unusable. safe_wal_size is how much more
+    // WAL can be written before that happens, and goes negative once it has.
+    //
+    // The spill and stream counters come from pg_stat_replication_slots
+    // (PostgreSQL 14+), a different view from pg_replication_slots: they show
+    // logical decoding spilling large transactions to disk, which is invisible
+    // in the slot's own row and is a common, silent throughput cliff.
+    const std::string conflicting = sess.server_version() >= 160000
+      ? ", 'conflicting', s.conflicting" : "";
+    const std::string invalidation = sess.server_version() >= 170000
+      ? ", 'invalidation_reason', s.invalidation_reason, 'inactive_since', s.inactive_since"
+      : "";
+
     std::string query = R"(
-      SELECT JSONB_OBJECT_AGG(slot_name,
+      SELECT JSONB_OBJECT_AGG(s.slot_name,
                JSONB_BUILD_OBJECT(
-                 'plugin',              plugin,
-                 'slot_type',           slot_type,
-                 'database',            database,
-                 'temporary',           temporary,
-                 'active',              active,
-                 'active_pid',          active_pid,
-                 'restart_lsn',         restart_lsn::text,
-                 'confirmed_flush_lsn', confirmed_flush_lsn::text,
-                 'retained_wal_bytes',  CASE WHEN restart_lsn IS NOT NULL
-                                           THEN pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) END
+                 'plugin',              s.plugin,
+                 'slot_type',           s.slot_type,
+                 'database',            s.database,
+                 'temporary',           s.temporary,
+                 'two_phase',           s.two_phase,
+                 'active',              s.active,
+                 'active_pid',          s.active_pid,
+                 'restart_lsn',         s.restart_lsn::text,
+                 'confirmed_flush_lsn', s.confirmed_flush_lsn::text,
+                 'wal_status',          s.wal_status,
+                 'safe_wal_size',       s.safe_wal_size,
+                 'retained_wal_bytes',  CASE WHEN s.restart_lsn IS NOT NULL
+                                           THEN pg_wal_lsn_diff(pg_current_wal_lsn(), s.restart_lsn) END,
+                 'spill_txns',          st.spill_txns,
+                 'spill_count',         st.spill_count,
+                 'spill_bytes',         st.spill_bytes,
+                 'stream_txns',         st.stream_txns,
+                 'stream_count',        st.stream_count,
+                 'stream_bytes',        st.stream_bytes,
+                 'total_txns',          st.total_txns,
+                 'total_bytes',         st.total_bytes,
+                 'stats_reset',         st.stats_reset
+               )" + conflicting + invalidation + R"(
                ))
-      FROM pg_replication_slots;
+      FROM pg_replication_slots AS s
+      LEFT JOIN pg_stat_replication_slots AS st ON st.slot_name = s.slot_name;
     )";
 
     pqxx::result res = txn.exec(query);
@@ -1224,6 +1308,19 @@ private:
   const json database_stats() {
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
+
+    // The session counters (PostgreSQL 14+) are what distinguish a database
+    // that is busy from one that is merely holding transactions open:
+    // idle_in_transaction_time and sessions_abandoned name the two failure
+    // modes that the commit/rollback counts alone cannot tell apart.
+    //
+    // parallel_workers_launched falling short of parallel_workers_to_launch
+    // (PostgreSQL 18+) means queries planned for parallelism ran without it,
+    // because max_parallel_workers was exhausted.
+    const std::string parallel = sess.server_version() >= 180000
+      ? R"(, 'parallel_workers_to_launch', parallel_workers_to_launch,
+            'parallel_workers_launched',  parallel_workers_launched)"
+      : "";
 
     std::string query = R"(
       SELECT JSONB_OBJECT_AGG(datname,
@@ -1245,7 +1342,15 @@ private:
                  'checksum_failures', checksum_failures,
                  'blk_read_time',     blk_read_time,
                  'blk_write_time',    blk_write_time,
+                 'session_time',              session_time,
+                 'active_time',               active_time,
+                 'idle_in_transaction_time',  idle_in_transaction_time,
+                 'sessions',                  sessions,
+                 'sessions_abandoned',        sessions_abandoned,
+                 'sessions_fatal',            sessions_fatal,
+                 'sessions_killed',           sessions_killed,
                  'stats_reset',       stats_reset
+               )" + parallel + R"(
                ))
       FROM pg_stat_database
       WHERE datname IS NOT NULL;
@@ -1264,29 +1369,65 @@ private:
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
 
+    // pg_stat_statements_info.dealloc counts how many times the extension has
+    // evicted its least-used entries because pg_stat_statements.max was
+    // exceeded. A climbing dealloc means this list is not the slowest queries
+    // in the cluster but the slowest of those that survived eviction -- a
+    // difference that cannot be inferred from the rows themselves, which is
+    // why it is returned alongside them.
+    const std::string since = sess.server_version() >= 170000
+      ? ", 'stats_since', pss.stats_since, 'minmax_stats_since', pss.minmax_stats_since"
+      : "";
+    const std::string pg18 = sess.server_version() >= 180000
+      ? R"(, 'wal_buffers_full', pss.wal_buffers_full,
+            'parallel_workers_to_launch', pss.parallel_workers_to_launch,
+            'parallel_workers_launched', pss.parallel_workers_launched)"
+      : "";
+
     std::string query = R"(
-      SELECT JSONB_AGG(row_json)
-      FROM (
-          SELECT JSONB_BUILD_OBJECT(
-                   'query_id',         pss.queryid,
-                   'query',            LEFT(pss.query, 500),
-                   'calls',            pss.calls,
-                   'total_exec_ms',    pss.total_exec_time,
-                   'mean_exec_ms',     pss.mean_exec_time,
-                   'min_exec_ms',      pss.min_exec_time,
-                   'max_exec_ms',      pss.max_exec_time,
-                   'rows',             pss.rows,
-                   'shared_blks_hit',  pss.shared_blks_hit,
-                   'shared_blks_read', pss.shared_blks_read,
-                   'user',             r.rolname,
-                   'database',         d.datname
-                 ) AS row_json
-          FROM pg_stat_statements AS pss
-          LEFT JOIN pg_roles AS r ON r.oid = pss.userid
-          LEFT JOIN pg_database AS d ON d.oid = pss.dbid
-          ORDER BY pss.total_exec_time DESC
-          LIMIT $1
-      ) sub;
+      SELECT JSONB_BUILD_OBJECT(
+        'statements', COALESCE((
+          SELECT JSONB_AGG(row_json)
+          FROM (
+              SELECT JSONB_BUILD_OBJECT(
+                       -- As text, not a number: a queryid is 64-bit and does
+                       -- not survive JSON number precision in a client that
+                       -- parses numbers as doubles. explainQuery already takes
+                       -- it as a string for that reason, and a value that
+                       -- silently changed between the two tools would be
+                       -- looked up and not found.
+                       'query_id',         pss.queryid::text,
+                       'query',            LEFT(pss.query, 500),
+                       'calls',            pss.calls,
+                       'total_exec_ms',    pss.total_exec_time,
+                       'mean_exec_ms',     pss.mean_exec_time,
+                       'min_exec_ms',      pss.min_exec_time,
+                       'max_exec_ms',      pss.max_exec_time,
+                       'rows',             pss.rows,
+                       'shared_blks_hit',  pss.shared_blks_hit,
+                       'shared_blks_read', pss.shared_blks_read,
+                       'temp_blks_read',   pss.temp_blks_read,
+                       'temp_blks_written', pss.temp_blks_written,
+                       'wal_records',      pss.wal_records,
+                       'wal_fpi',          pss.wal_fpi,
+                       'wal_bytes',        pss.wal_bytes,
+                       'user',             r.rolname,
+                       'database',         d.datname
+                     )" + since + pg18 + R"(
+                     ) AS row_json
+              FROM pg_stat_statements AS pss
+              LEFT JOIN pg_roles AS r ON r.oid = pss.userid
+              LEFT JOIN pg_database AS d ON d.oid = pss.dbid
+              ORDER BY pss.total_exec_time DESC
+              LIMIT $1
+          ) sub), '[]'::jsonb),
+        'info', (SELECT JSONB_BUILD_OBJECT(
+                   'dealloc', i.dealloc, 'stats_reset', i.stats_reset)
+                 FROM pg_stat_statements_info AS i),
+        -- missing_ok, so a server where the GUC is absent yields null rather
+        -- than an error that would mask the real result.
+        'max', current_setting('pg_stat_statements.max', true)
+      );
     )";
 
     try {
@@ -1295,7 +1436,7 @@ private:
       if (!res.empty() && !res[0][0].is_null()) {
         return json::parse(res[0][0].as<std::string>());
       } else {
-        return json::array();
+        return {{"statements", json::array()}};
       }
     } catch (const pqxx::sql_error& e) {
       if (e.sqlstate() == "42P01") { // undefined_table
@@ -1307,6 +1448,211 @@ private:
         };
       }
       throw;
+    }
+  }
+
+  const json progress_stats() {
+    Session sess{active_cfg()};
+    pqxx::work& txn = sess.txn();
+
+    // PostgreSQL 17 renamed three pg_stat_progress_vacuum columns:
+    // max_dead_tuples -> max_dead_tuple_bytes, num_dead_tuples ->
+    // num_dead_item_ids, and added dead_tuple_bytes. The old and new names
+    // measure different things (tuple counts against bytes), so they are
+    // reported under their own names rather than pretended to be one field,
+    // with 'dead_tuple_unit' saying which the server produced.
+    const bool v17 = sess.server_version() >= 170000;
+    const std::string vacuum_dead = v17
+      ? R"('dead_tuple_unit',     'bytes',
+           'max_dead_tuple_bytes', v.max_dead_tuple_bytes,
+           'dead_tuple_bytes',     v.dead_tuple_bytes,
+           'num_dead_item_ids',    v.num_dead_item_ids,
+           'indexes_total',        v.indexes_total,
+           'indexes_processed',    v.indexes_processed)"
+      : R"('dead_tuple_unit',  'tuples',
+           'max_dead_tuples',  v.max_dead_tuples,
+           'num_dead_tuples',  v.num_dead_tuples)";
+
+    // Percentages are the point of a progress view: "1.2 million of 4 million
+    // blocks" is only useful once it is 30%.
+    std::string query = R"(
+      SELECT JSONB_BUILD_OBJECT(
+        'vacuum', COALESCE((
+          SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
+                   'pid',               v.pid,
+                   'database',          v.datname,
+                   'relation',          v.relid::regclass::text,
+                   'phase',             v.phase,
+                   'heap_blks_total',   v.heap_blks_total,
+                   'heap_blks_scanned', v.heap_blks_scanned,
+                   'heap_blks_vacuumed', v.heap_blks_vacuumed,
+                   'scanned_percent',
+                     round(100.0 * v.heap_blks_scanned / NULLIF(v.heap_blks_total, 0), 1),
+                   'vacuumed_percent',
+                     round(100.0 * v.heap_blks_vacuumed / NULLIF(v.heap_blks_total, 0), 1),
+                   'index_vacuum_count', v.index_vacuum_count,
+                   'query',             a.query,
+                   'started',           a.query_start,
+                   'elapsed_s',         round(EXTRACT(EPOCH FROM now() - a.query_start)::numeric, 1),
+                   )" + vacuum_dead + R"())
+          FROM pg_stat_progress_vacuum AS v
+          LEFT JOIN pg_stat_activity AS a ON a.pid = v.pid), '[]'::jsonb),
+        'analyze', COALESCE((
+          SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
+                   'pid',                   an.pid,
+                   'database',              an.datname,
+                   'relation',              an.relid::regclass::text,
+                   'phase',                 an.phase,
+                   'sample_blks_total',     an.sample_blks_total,
+                   'sample_blks_scanned',   an.sample_blks_scanned,
+                   'scanned_percent',
+                     round(100.0 * an.sample_blks_scanned / NULLIF(an.sample_blks_total, 0), 1),
+                   'ext_stats_total',       an.ext_stats_total,
+                   'ext_stats_computed',    an.ext_stats_computed,
+                   'child_tables_total',    an.child_tables_total,
+                   'child_tables_done',     an.child_tables_done,
+                   'elapsed_s',             round(EXTRACT(EPOCH FROM now() - a.query_start)::numeric, 1)))
+          FROM pg_stat_progress_analyze AS an
+          LEFT JOIN pg_stat_activity AS a ON a.pid = an.pid), '[]'::jsonb),
+        'create_index', COALESCE((
+          SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
+                   'pid',              ci.pid,
+                   'database',         ci.datname,
+                   'relation',         ci.relid::regclass::text,
+                   'index',            NULLIF(ci.index_relid, 0)::regclass::text,
+                   'command',          ci.command,
+                   'phase',            ci.phase,
+                   'blocks_total',     ci.blocks_total,
+                   'blocks_done',      ci.blocks_done,
+                   'blocks_percent',
+                     round(100.0 * ci.blocks_done / NULLIF(ci.blocks_total, 0), 1),
+                   'tuples_total',     ci.tuples_total,
+                   'tuples_done',      ci.tuples_done,
+                   'lockers_total',    ci.lockers_total,
+                   'lockers_done',     ci.lockers_done,
+                   'current_locker_pid', ci.current_locker_pid,
+                   'elapsed_s',        round(EXTRACT(EPOCH FROM now() - a.query_start)::numeric, 1)))
+          FROM pg_stat_progress_create_index AS ci
+          LEFT JOIN pg_stat_activity AS a ON a.pid = ci.pid), '[]'::jsonb),
+        'cluster', COALESCE((
+          SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
+                   'pid',                cl.pid,
+                   'database',           cl.datname,
+                   'relation',           cl.relid::regclass::text,
+                   'command',            cl.command,
+                   'phase',              cl.phase,
+                   'heap_tuples_scanned', cl.heap_tuples_scanned,
+                   'heap_tuples_written', cl.heap_tuples_written,
+                   'heap_blks_total',    cl.heap_blks_total,
+                   'heap_blks_scanned',  cl.heap_blks_scanned,
+                   'scanned_percent',
+                     round(100.0 * cl.heap_blks_scanned / NULLIF(cl.heap_blks_total, 0), 1),
+                   'index_rebuild_count', cl.index_rebuild_count,
+                   'elapsed_s',          round(EXTRACT(EPOCH FROM now() - a.query_start)::numeric, 1)))
+          FROM pg_stat_progress_cluster AS cl
+          LEFT JOIN pg_stat_activity AS a ON a.pid = cl.pid), '[]'::jsonb),
+        'copy', COALESCE((
+          SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
+                   'pid',            c.pid,
+                   'database',       c.datname,
+                   'relation',       NULLIF(c.relid, 0)::regclass::text,
+                   'command',        c.command,
+                   'type',           c.type,
+                   'bytes_processed', c.bytes_processed,
+                   'bytes_total',    c.bytes_total,
+                   'bytes_percent',
+                     round(100.0 * c.bytes_processed / NULLIF(c.bytes_total, 0), 1),
+                   'tuples_processed', c.tuples_processed,
+                   'tuples_excluded',  c.tuples_excluded,
+                   'elapsed_s',      round(EXTRACT(EPOCH FROM now() - a.query_start)::numeric, 1)))
+          FROM pg_stat_progress_copy AS c
+          LEFT JOIN pg_stat_activity AS a ON a.pid = c.pid), '[]'::jsonb),
+        'basebackup', COALESCE((
+          SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
+                   'pid',                b.pid,
+                   'phase',              b.phase,
+                   'backup_total',       b.backup_total,
+                   'backup_streamed',    b.backup_streamed,
+                   'streamed_percent',
+                     round(100.0 * b.backup_streamed / NULLIF(b.backup_total, 0), 1),
+                   'tablespaces_total',  b.tablespaces_total,
+                   'tablespaces_streamed', b.tablespaces_streamed))
+          FROM pg_stat_progress_basebackup AS b), '[]'::jsonb)
+      );
+    )";
+
+    pqxx::result res = txn.exec(query);
+
+    if (!res.empty() && !res[0][0].is_null()) {
+      return json::parse(res[0][0].as<std::string>());
+    } else {
+      return {};
+    }
+  }
+
+  const json io_stats() {
+    Session sess{active_cfg()};
+
+    // pg_stat_io arrived in PostgreSQL 16. Saying so plainly beats an
+    // undefined-table error, and matches how a missing extension is reported.
+    if (sess.server_version() < 160000) {
+      return {
+        {"error", "pg_stat_io requires PostgreSQL 16 or newer"},
+        {"hint", "this server is older; use checkpointStats for the "
+                 "pg_stat_bgwriter counters, which include buffers_backend "
+                 "and buffers_backend_fsync on these versions, and "
+                 "tableIOStats for per-object cache hit ratios"}
+      };
+    }
+
+    pqxx::work& txn = sess.txn();
+
+    // Byte counters replaced the single op_bytes column in PostgreSQL 18;
+    // before that, a block count times op_bytes was the only way to get bytes,
+    // and op_bytes itself is gone in 18. Reporting the byte columns only where
+    // they exist avoids inventing a number on older servers.
+    const std::string bytes = sess.server_version() >= 180000
+      ? R"(, 'read_bytes', read_bytes, 'write_bytes', write_bytes,
+            'extend_bytes', extend_bytes)"
+      : "";
+
+    // Rows where nothing has happened at all are dropped: pg_stat_io is a
+    // dense matrix of backend_type x object x context, and most combinations
+    // are structurally impossible, so an unfiltered dump is mostly nulls.
+    std::string query = R"(
+      SELECT COALESCE(JSONB_AGG(JSONB_BUILD_OBJECT(
+               'backend_type', backend_type,
+               'object',       object,
+               'context',      context,
+               'reads',        reads,
+               'read_time_ms', read_time,
+               'writes',       writes,
+               'write_time_ms', write_time,
+               'writebacks',   writebacks,
+               'writeback_time_ms', writeback_time,
+               'extends',      extends,
+               'extend_time_ms', extend_time,
+               'hits',         hits,
+               'evictions',    evictions,
+               'reuses',       reuses,
+               'fsyncs',       fsyncs,
+               'fsync_time_ms', fsync_time,
+               'hit_percent',  round(100.0 * hits / NULLIF(hits + reads, 0), 2),
+               'stats_reset',  stats_reset
+             )" + bytes + R"(
+             ) ORDER BY backend_type, object, context), '[]'::jsonb)
+      FROM pg_stat_io
+      WHERE COALESCE(reads, 0) > 0 OR COALESCE(writes, 0) > 0
+         OR COALESCE(extends, 0) > 0 OR COALESCE(hits, 0) > 0
+         OR COALESCE(evictions, 0) > 0 OR COALESCE(fsyncs, 0) > 0;
+    )";
+
+    pqxx::result res = txn.exec(query);
+
+    if (!res.empty() && !res[0][0].is_null()) {
+      return json::parse(res[0][0].as<std::string>());
+    } else {
+      return json::array();
     }
   }
 
@@ -1323,6 +1669,24 @@ private:
     // relfrozenxid, are invisible in pg_stat_user_tables, and a TOAST or
     // catalog relation is very often the one actually holding the horizon
     // back; excluding them would report the risk as lower than it is.
+    //
+    // relallfrozen (PostgreSQL 18+) turns an age into an estimate of the work
+    // left to do: an old relfrozenxid on a table that is already 99% frozen is
+    // a very different problem from the same age with nothing frozen.
+    // total_autovacuum_time answers the next question -- whether autovacuum
+    // has been trying and failing to keep up, or has simply never run.
+    const std::string pg18_cols = sess.server_version() >= 180000
+      ? R"(, 'frozen_percent',
+              round(100.0 * r.relallfrozen / NULLIF(r.relpages, 0), 1),
+            'relallfrozen', r.relallfrozen,
+            'total_vacuum_time_ms', r.total_vacuum_time,
+            'total_autovacuum_time_ms', r.total_autovacuum_time)"
+      : "";
+    const std::string pg18_sel = sess.server_version() >= 180000
+      ? R"(, c.relallfrozen, c.relpages,
+            s.total_vacuum_time, s.total_autovacuum_time)"
+      : "";
+
     std::string query = R"(
       SELECT JSONB_BUILD_OBJECT(
         'limits',
@@ -1368,7 +1732,8 @@ private:
                    'size', r.size,
                    'last_vacuum', r.last_vacuum,
                    'last_autovacuum', r.last_autovacuum,
-                   'n_dead_tup', r.n_dead_tup) ORDER BY r.xid_age DESC)
+                   'n_dead_tup', r.n_dead_tup)" + pg18_cols + R"(
+                   ) ORDER BY r.xid_age DESC)
           FROM (
             SELECT n.nspname AS schema,
                    c.relname AS name,
@@ -1384,7 +1749,7 @@ private:
                    CASE WHEN o.option_value IS NOT NULL THEN 'reloptions' ELSE 'server' END
                      AS freeze_max_age_source,
                    pg_relation_size(c.oid) AS size,
-                   s.last_vacuum, s.last_autovacuum, s.n_dead_tup
+                   s.last_vacuum, s.last_autovacuum, s.n_dead_tup)" + pg18_sel + R"(
             FROM pg_class AS c
             JOIN pg_namespace AS n ON n.oid = c.relnamespace
             LEFT JOIN pg_class AS tp ON c.relkind = 't' AND tp.reltoastrelid = c.oid
@@ -1567,6 +1932,12 @@ private:
             'wal_sync_time_ms', w.wal_sync_time)"
       : "";
 
+    // num_done and slru_written are PostgreSQL 18 additions to
+    // pg_stat_checkpointer; the rest of the view is unchanged since 17.
+    const std::string ckpt_pg18 = sess.server_version() >= 180000
+      ? "'checkpoints_done', c.num_done, 'slru_written', c.slru_written,"
+      : "";
+
     const std::string checkpointer = split ? R"(
         'source', 'pg_stat_checkpointer + pg_stat_bgwriter + pg_stat_io',
         'checkpointer', (SELECT JSONB_BUILD_OBJECT(
@@ -1581,6 +1952,7 @@ private:
              'write_time_ms',            c.write_time,
              'sync_time_ms',             c.sync_time,
              'buffers_written',          c.buffers_written,
+             )" + ckpt_pg18 + R"(
              'stats_reset',              c.stats_reset,
              'seconds_since_reset',      round(EXTRACT(EPOCH FROM now() - c.stats_reset)),
              'checkpoints_per_hour',     round((c.num_timed + c.num_requested)
@@ -2033,7 +2405,8 @@ private:
       std::string q = R"(
         SELECT JSONB_BUILD_OBJECT(
                  'query',            pss.query,
-                 'query_id',         pss.queryid,
+                 -- text for the same reason as in statementStats
+                 'query_id',         pss.queryid::text,
                  'calls',            pss.calls,
                  'total_exec_ms',    pss.total_exec_time,
                  'mean_exec_ms',     pss.mean_exec_time,
@@ -3247,6 +3620,12 @@ private:
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
 
+    // Same PostgreSQL 16 additions as listTables: failed HOT updates and the
+    // date of the last sequential scan.
+    const std::string pg16_tbl = sess.server_version() >= 160000
+      ? R"( 'n_tup_newpage_upd', s.n_tup_newpage_upd, 'last_seq_scan', s.last_seq_scan,)"
+      : "";
+
     std::string query = R"(
       SELECT JSONB_BUILD_OBJECT(
                'table', c.relname, 'rows', c.reltuples, 'size', pg_table_size(c.oid), 'indexes_size', pg_indexes_size(c.oid),
@@ -3257,7 +3636,7 @@ private:
                'seq_scan', s.seq_scan, 'idx_scan', s.idx_scan, 'n_live_tup', s.n_live_tup, 'n_dead_tup', s.n_dead_tup,
                'n_mod_since_analyze', s.n_mod_since_analyze, 'n_ins_since_vacuum', s.n_ins_since_vacuum,
                'last_vacuum', GREATEST(s.last_vacuum, s.last_autovacuum), 'last_analyze', GREATEST(s.last_analyze, s.last_autoanalyze),
-               'reloptions', c.reloptions,
+               'reloptions', c.reloptions,)" + pg16_tbl + R"(
                'columns', columns,
                'toast', CASE WHEN c.reltoastrelid != 0 THEN
                           JSONB_BUILD_OBJECT(
@@ -3595,6 +3974,12 @@ private:
 	}
 	else if (tool_name == "checkpointStats") {
 	  result_content = checkpoint_stats();
+	}
+	else if (tool_name == "progressStats") {
+	  result_content = progress_stats();
+	}
+	else if (tool_name == "ioStats") {
+	  result_content = io_stats();
 	}
 	else if (tool_name == "tableIOStats") {
 	  std::string target_schema = arguments.contains("schema") ? arguments["schema"].get<std::string>() : "public";

--- a/cpp/src/test_main.cpp
+++ b/cpp/src/test_main.cpp
@@ -1727,6 +1727,113 @@ TEST_F(PostgresMCPServerTest, ActivityDescribesWaitEventsOnPg17AndLater) {
   EXPECT_EQ(found, expected);
 }
 
+TEST_F(PostgresMCPServerTest, ActivityFiltersByPidAndState) {
+  pqxx::connection other(test_url);
+  pqxx::work t(other);
+  int pid = t.exec("SELECT pg_backend_pid()")[0][0].as<int>();
+
+  json r = srv->call_activity(pid, "", 0, "");
+  ASSERT_EQ(r.size(), 1u) << r.dump(2);
+  ASSERT_TRUE(r.contains(std::to_string(pid)));
+
+  // A state that backend cannot be in, so the filter must exclude it rather
+  // than being ignored.
+  json none = srv->call_activity(pid, "", 0, "no such state");
+  EXPECT_TRUE(none.is_object());
+  EXPECT_TRUE(none.empty()) << none.dump(2);
+
+  t.abort();
+}
+
+TEST_F(PostgresMCPServerTest, ActivityFiltersByMinDuration) {
+  pqxx::connection other(test_url);
+  pqxx::work t(other);
+  int pid = t.exec("SELECT pg_backend_pid()")[0][0].as<int>();
+
+  // That backend is idle in transaction with a query that finished instantly,
+  // so an hour-long threshold must not match it. This is the regression guard
+  // for measuring duration off a stale query_start.
+  json r = srv->call_activity(pid, "", 3600, "");
+  EXPECT_TRUE(r.empty()) << r.dump(2);
+
+  // And a zero-ish threshold does match, so the filter is not simply broken.
+  json any = srv->call_activity(pid, "", 0, "");
+  EXPECT_FALSE(any.empty());
+
+  t.abort();
+}
+
+TEST_F(PostgresMCPServerTest, ActivityFilterExcludesUnrelatedBackends) {
+  pqxx::connection a(test_url), b(test_url);
+  pqxx::work ta(a), tb(b);
+  int pid_a = ta.exec("SELECT pg_backend_pid()")[0][0].as<int>();
+  int pid_b = tb.exec("SELECT pg_backend_pid()")[0][0].as<int>();
+  ASSERT_NE(pid_a, pid_b);
+
+  json r = srv->call_activity(pid_a, "", 0, "");
+  EXPECT_TRUE(r.contains(std::to_string(pid_a)));
+  EXPECT_FALSE(r.contains(std::to_string(pid_b))) << r.dump(2);
+
+  ta.abort();
+  tb.abort();
+}
+
+// --- currentLocks blocking chain ---
+
+TEST_F(PostgresMCPServerTest, LocksResolveTheTransitiveBlockingChain) {
+  // holder takes the table; waiter then asks for a conflicting lock and
+  // blocks. Asking about the waiter must surface the holder, which is the
+  // whole point: a flat lock dump makes you reconstruct that yourself.
+  pqxx::connection holder(test_url);
+  pqxx::work hold(holder);
+  hold.exec("LOCK TABLE grocery.users IN ACCESS EXCLUSIVE MODE");
+  int holder_pid = hold.exec("SELECT pg_backend_pid()")[0][0].as<int>();
+
+  pqxx::connection waiter(test_url);
+  pqxx::work wait_txn(waiter);
+  int waiter_pid = wait_txn.exec("SELECT pg_backend_pid()")[0][0].as<int>();
+
+  pqxx::pipeline p(wait_txn);
+  p.insert("LOCK TABLE grocery.users IN ACCESS EXCLUSIVE MODE");
+
+  json chain;
+  for (int i = 0; i < 40 && chain.is_null(); i++) {
+    json r = srv->call_locks(waiter_pid);
+    if (!r.is_array()) continue;
+    for (const auto& l : r) {
+      if (l.contains("chain_depth") && l["chain_depth"].get<int>() > 0) chain = r;
+    }
+  }
+
+  // Release the holder so the waiter can proceed, whatever the assertions do.
+  hold.abort();
+  try {
+    p.complete();
+  } catch (const pqxx::sql_error&) {
+  }
+  wait_txn.abort();
+
+  if (chain.is_null()) GTEST_SKIP() << "the lock wait could not be observed";
+
+  bool saw_waiter = false, saw_holder = false;
+  for (const auto& l : chain) {
+    int pid = l["pid"].get<int>();
+    if (pid == waiter_pid) {
+      saw_waiter = true;
+      EXPECT_EQ(l["chain_depth"].get<int>(), 0);
+    }
+    if (pid == holder_pid) {
+      saw_holder = true;
+      // Depth 1: one hop up the chain from the backend asked about.
+      EXPECT_EQ(l["chain_depth"].get<int>(), 1);
+    }
+    // Nothing outside the chain may appear.
+    EXPECT_TRUE(pid == waiter_pid || pid == holder_pid) << l.dump(2);
+  }
+  EXPECT_TRUE(saw_waiter) << chain.dump(2);
+  EXPECT_TRUE(saw_holder) << chain.dump(2);
+}
+
 // --- replicationSlots enrichment ---
 
 TEST_F(PostgresMCPServerTest, ReplicationSlotsReportsWalStatusAndSpillCounters) {
@@ -1839,11 +1946,19 @@ TEST_F(PostgresMCPServerTest, ProgressStatsReportsARunningVacuum) {
   pqxx::pipeline p(n);
   p.insert("VACUUM grocery.vacuum_me");
 
-  json found;
+  json found, by_relation, by_pid, by_wrong_relation;
   for (int i = 0; i < 40 && found.is_null(); i++) {
     json r = srv->call_progress_stats();
-    for (const auto& v : r["vacuum"])
-      if (v.value("relation", "") == "grocery.vacuum_me") found = v;
+    for (const auto& v : r["vacuum"]) {
+      if (v.value("relation", "") == "grocery.vacuum_me") {
+        found = v;
+        // Exercise the filters while the command is genuinely in flight;
+        // there is no other moment at which they can be observed working.
+        by_relation = srv->call_progress_stats(0, "vacuum_me");
+        by_pid = srv->call_progress_stats(v["pid"].get<int>(), "");
+        by_wrong_relation = srv->call_progress_stats(0, "grocery.users");
+      }
+    }
   }
 
   // Cancel rather than wait: the vacuum was deliberately slowed to be
@@ -1884,6 +1999,24 @@ TEST_F(PostgresMCPServerTest, ProgressStatsReportsARunningVacuum) {
     EXPECT_TRUE(found.contains("max_dead_tuples"));
     EXPECT_TRUE(found.contains("num_dead_tuples"));
   }
+
+  // The bare relation name matches, and so does the pid.
+  EXPECT_EQ(by_relation["vacuum"].size(), 1u) << by_relation.dump(2);
+  EXPECT_EQ(by_pid["vacuum"].size(), 1u) << by_pid.dump(2);
+  // A different table does not.
+  EXPECT_TRUE(by_wrong_relation["vacuum"].empty()) << by_wrong_relation.dump(2);
+  // A base backup has no relation, so a relation filter excludes that
+  // category rather than matching everything in it.
+  EXPECT_TRUE(by_relation["basebackup"].empty());
+}
+
+TEST_F(PostgresMCPServerTest, ProgressStatsUnknownRelationIsEmptyNotAnError) {
+  // A regclass cast would raise "relation does not exist"; a diagnostic tool
+  // should answer "nothing is running on that" instead.
+  json r = srv->call_progress_stats(0, "no_such_table_anywhere");
+  ASSERT_TRUE(r.contains("vacuum")) << r.dump(2);
+  EXPECT_TRUE(r["vacuum"].empty());
+  EXPECT_TRUE(r["create_index"].empty());
 }
 
 // --- ioStats ---
@@ -1898,9 +2031,10 @@ TEST_F(PostgresMCPServerTest, IoStatsReturnsRowsOrAVersionError) {
     return;
   }
 
-  ASSERT_TRUE(r.is_array()) << r.dump(2);
-  ASSERT_FALSE(r.empty());
-  auto& row = r[0];
+  ASSERT_TRUE(r.contains("io")) << r.dump(2);
+  ASSERT_TRUE(r["io"].is_array());
+  ASSERT_FALSE(r["io"].empty());
+  auto& row = r["io"][0];
   EXPECT_TRUE(row.contains("backend_type"));
   EXPECT_TRUE(row.contains("object"));
   EXPECT_TRUE(row.contains("context"));
@@ -1910,6 +2044,50 @@ TEST_F(PostgresMCPServerTest, IoStatsReturnsRowsOrAVersionError) {
   // The byte counters replaced op_bytes in PostgreSQL 18; before that there
   // is no honest way to report them.
   EXPECT_EQ(row.contains("read_bytes"), pg_server_version_num(test_url) >= 180000);
+}
+
+TEST_F(PostgresMCPServerTest, IoStatsFiltersByBackendTypeAndContext) {
+  if (pg_server_version_num(test_url) < 160000)
+    GTEST_SKIP() << "pg_stat_io requires PostgreSQL 16";
+
+  json r = srv->call_io_stats(0, "checkpointer", "", "");
+  ASSERT_TRUE(r.contains("io")) << r.dump(2);
+  for (const auto& row : r["io"])
+    EXPECT_EQ(row["backend_type"].get<std::string>(), "checkpointer");
+
+  json c = srv->call_io_stats(0, "", "", "vacuum");
+  for (const auto& row : c["io"])
+    EXPECT_EQ(row["context"].get<std::string>(), "vacuum");
+}
+
+TEST_F(PostgresMCPServerTest, IoStatsPerBackendNeedsPg18AndSaysSo) {
+  if (pg_server_version_num(test_url) < 160000)
+    GTEST_SKIP() << "pg_stat_io requires PostgreSQL 16";
+
+  // A live backend of our own, so the pid certainly exists.
+  pqxx::connection victim(test_url);
+  pqxx::work t(victim);
+  int pid = t.exec("SELECT pg_backend_pid()")[0][0].as<int>();
+
+  json r = srv->call_io_stats(pid, "", "", "");
+
+  if (pg_server_version_num(test_url) < 180000) {
+    // pg_stat_io has no pid column at all; the per-backend function is 18+.
+    ASSERT_TRUE(r.contains("error")) << r.dump(2);
+    EXPECT_NE(r["error"].get<std::string>().find("PostgreSQL 18"), std::string::npos);
+    EXPECT_TRUE(r.contains("hint"));
+  } else {
+    EXPECT_EQ(r["pid"].get<int>(), pid);
+    ASSERT_TRUE(r.contains("io")) << r.dump(2);
+    // WAL is a separate function: a backend can be quiet in I/O and still be
+    // writing WAL heavily, so it is reported alongside rather than inferred.
+    ASSERT_TRUE(r.contains("wal")) << r.dump(2);
+    EXPECT_TRUE(r["wal"].contains("wal_records"));
+    EXPECT_TRUE(r["wal"].contains("wal_bytes"));
+    for (const auto& row : r["io"])
+      EXPECT_EQ(row["backend_type"].get<std::string>(), "client backend");
+  }
+  t.abort();
 }
 
 // --- wraparoundStatus ---
@@ -2564,6 +2742,64 @@ TEST_F(PgssMCPServerTest, StatementStatsCarriesEvictionInfoAlongsideTheRows) {
   EXPECT_TRUE(r["info"].contains("dealloc"));
   EXPECT_TRUE(r["info"].contains("stats_reset"));
   EXPECT_TRUE(r.contains("max"));
+}
+
+TEST_F(PgssMCPServerTest, StatementStatsRanksByTheRequestedColumn) {
+  json by_calls = srv->call_statement_stats(50, "", "calls", 0);
+  ASSERT_TRUE(by_calls.contains("statements")) << by_calls.dump(2);
+  EXPECT_EQ(by_calls["order_by"].get<std::string>(), "calls");
+
+  long long prev = -1;
+  for (const auto& s : by_calls["statements"]) {
+    long long c = s["calls"].get<long long>();
+    if (prev >= 0) { EXPECT_LE(c, prev) << by_calls.dump(2); }
+    prev = c;
+  }
+
+  // Ranking by total time buries a statement called twice at 40s under one
+  // called ten million times at 2ms; mean_exec_time is the other question,
+  // and it must produce a genuinely different ordering key.
+  json by_mean = srv->call_statement_stats(50, "", "mean_exec_time", 0);
+  EXPECT_EQ(by_mean["order_by"].get<std::string>(), "mean_exec_time");
+  double prev_mean = -1;
+  for (const auto& s : by_mean["statements"]) {
+    double m = s["mean_exec_ms"].get<double>();
+    if (prev_mean >= 0) { EXPECT_LE(m, prev_mean + 1e-9); }
+    prev_mean = m;
+  }
+}
+
+TEST_F(PgssMCPServerTest, StatementStatsRejectsAnUnknownOrderByColumn) {
+  // The sort column cannot be a bind parameter, so it is resolved through a
+  // fixed table. Anything else must be refused rather than reach the SQL.
+  try {
+    srv->call_statement_stats(5, "", "1; DROP TABLE x", 0);
+    FAIL() << "expected an unknown order_by to be rejected";
+  } catch (const std::exception& e) {
+    std::string msg = e.what();
+    EXPECT_NE(msg.find("unknown order_by"), std::string::npos);
+    EXPECT_NE(msg.find("mean_exec_time"), std::string::npos) << msg;
+  }
+}
+
+TEST_F(PgssMCPServerTest, StatementStatsFiltersByQueryIdAndReturnsFullText) {
+  json all = srv->call_statement_stats(20, "", "", 0);
+  ASSERT_FALSE(all["statements"].empty());
+  std::string qid = all["statements"][0]["query_id"].get<std::string>();
+
+  json one = srv->call_statement_stats(20, qid, "", 0);
+  // Not necessarily a single row: pg_stat_statements keeps one entry per
+  // (user, database) pair, so one queryid can legitimately match several.
+  ASSERT_FALSE(one["statements"].empty()) << one.dump(2);
+  EXPECT_LT(one["statements"].size(), all["statements"].size());
+  for (const auto& s : one["statements"])
+    EXPECT_EQ(s["query_id"].get<std::string>(), qid) << one.dump(2);
+}
+
+TEST_F(PgssMCPServerTest, StatementStatsMinCallsExcludesOneOffStatements) {
+  json r = srv->call_statement_stats(50, "", "mean_exec_time", 1000000000LL);
+  // Nothing in a fresh test database has been called a billion times.
+  EXPECT_TRUE(r["statements"].empty()) << r.dump(2);
 }
 
 TEST_F(PgssMCPServerTest, StatementStatsQueryIdIsTextAndFeedsExplainQuery) {

--- a/cpp/src/test_main.cpp
+++ b/cpp/src/test_main.cpp
@@ -37,6 +37,14 @@ protected:
     const char* env_url = std::getenv("DATABASE_URL");
     base_url = env_url;
 
+    // from_url picks host capacity up from the environment, so a developer who
+    // exports these for their own cluster would otherwise change what the
+    // hostCapacity tests see.
+    ::unsetenv("PG_LICHT_HOST_RAM_MB");
+    ::unsetenv("PG_LICHT_HOST_VCPUS");
+    ::unsetenv("PG_LICHT_HOST_STORAGE");
+    ::unsetenv("PG_LICHT_HOST_NOTE");
+
     try {
       admin_conn = new pqxx::connection(base_url);
 
@@ -244,6 +252,35 @@ protected:
       );
 
       txn.exec("CREATE TEXT SEARCH CONFIGURATION grocery.simple_english (COPY = pg_catalog.english)");
+
+      // A table of its own for duplicateIndexes, so the index counts the other
+      // tests assert on stay untouched. It carries one of every case the
+      // detector has to get right: an exact duplicate, a prefix-redundant
+      // index, and three near-misses that must NOT be reported -- a reversed
+      // sort order, a partial index, and a unique index that happens to be a
+      // prefix of a wider one.
+      txn.exec(
+        "CREATE TABLE grocery.index_zoo ("
+        "  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,"
+        "  a  INT,"
+        "  b  INT,"
+        "  c  TEXT,"
+        "  d  TEXT"
+        ")"
+      );
+      txn.exec("CREATE INDEX zoo_a_b     ON grocery.index_zoo (a, b)");
+      txn.exec("CREATE INDEX zoo_a       ON grocery.index_zoo (a)");
+      txn.exec("CREATE INDEX zoo_a_again ON grocery.index_zoo (a)");
+      txn.exec("CREATE INDEX zoo_a_desc  ON grocery.index_zoo (a DESC)");
+      txn.exec("CREATE INDEX zoo_a_part  ON grocery.index_zoo (a) WHERE b > 0");
+      txn.exec("CREATE UNIQUE INDEX zoo_c_uq ON grocery.index_zoo (c)");
+      txn.exec("CREATE UNIQUE INDEX zoo_c_d_uq ON grocery.index_zoo (c, d)");
+      txn.exec("CREATE INDEX zoo_lower_c  ON grocery.index_zoo (lower(c))");
+      txn.exec("CREATE INDEX zoo_lower_c2 ON grocery.index_zoo (lower(c))");
+
+      // A per-table freeze override, so wraparoundStatus can be checked to
+      // report the storage parameter rather than the server-wide default.
+      txn.exec("ALTER TABLE grocery.index_zoo SET (autovacuum_freeze_max_age = 100000000)");
 
       txn.exec("GRANT USAGE ON SCHEMA grocery TO PUBLIC");
       txn.exec("GRANT SELECT ON grocery.users TO PUBLIC");
@@ -1649,6 +1686,320 @@ TEST_F(PostgresMCPServerTest, TableBloatUnknownTableReturnsEmpty) {
   EXPECT_TRUE(result.empty());
 }
 
+// --- wraparoundStatus ---
+
+namespace {
+
+// The 'tables' array keyed by name, for the assertions below.
+const json* find_table(const json& tables, const std::string& name) {
+  for (const auto& t : tables)
+    if (t.value("name", "") == name) return &t;
+  return nullptr;
+}
+
+}  // namespace
+
+TEST_F(PostgresMCPServerTest, WraparoundStatusReportsLimitsAndDatabases) {
+  json r = srv->call_wraparound_status("", 20);
+  ASSERT_TRUE(r.contains("limits")) << r.dump(2);
+  EXPECT_TRUE(r["limits"].contains("autovacuum_freeze_max_age"));
+  EXPECT_TRUE(r["limits"].contains("autovacuum_multixact_freeze_max_age"));
+  EXPECT_TRUE(r["limits"].contains("vacuum_failsafe_age"));
+  // The hard limit is the outage threshold, and is what the percentages that
+  // actually matter are taken against.
+  EXPECT_EQ(r["limits"]["wraparound_limit"].get<long long>(), 2146483647LL);
+
+  ASSERT_TRUE(r.contains("databases"));
+  ASSERT_TRUE(r["databases"].contains(test_dbname));
+  auto& db = r["databases"][test_dbname];
+  EXPECT_GE(db["xid_age"].get<long long>(), 0);
+  EXPECT_GE(db["mxid_age"].get<long long>(), 0);
+  EXPECT_LT(db["xid_percent_of_wraparound_limit"].get<double>(), 100.0);
+  EXPECT_GT(db["xids_until_wraparound_limit"].get<long long>(), 0);
+}
+
+TEST_F(PostgresMCPServerTest, WraparoundStatusReportsPerTableFreezeOverride) {
+  json r = srv->call_wraparound_status("grocery", 50);
+  ASSERT_TRUE(r.contains("tables"));
+  ASSERT_TRUE(r["tables"].is_array());
+
+  const json* zoo = find_table(r["tables"], "index_zoo");
+  ASSERT_NE(zoo, nullptr) << r["tables"].dump(2);
+  // The fixture sets autovacuum_freeze_max_age on this table, so the effective
+  // limit must come from reloptions rather than the server-wide setting.
+  EXPECT_EQ((*zoo)["freeze_max_age"].get<long long>(), 100000000LL);
+  EXPECT_EQ((*zoo)["freeze_max_age_source"].get<std::string>(), "reloptions");
+
+  const json* users = find_table(r["tables"], "users");
+  ASSERT_NE(users, nullptr);
+  EXPECT_EQ((*users)["freeze_max_age_source"].get<std::string>(), "server");
+  EXPECT_EQ((*users)["kind"].get<std::string>(), "table");
+  EXPECT_TRUE((*users)["toast_for"].is_null());
+}
+
+TEST_F(PostgresMCPServerTest, WraparoundStatusIncludesToastTables) {
+  // A TOAST table carries its own relfrozenxid and is invisible in
+  // pg_stat_user_tables, yet is frequently the relation holding the horizon
+  // back; leaving it out would understate the risk.
+  json r = srv->call_wraparound_status("", 5000);
+  bool found_toast = false;
+  for (const auto& t : r["tables"]) {
+    if (t.value("kind", "") == "toast table") {
+      found_toast = true;
+      EXPECT_FALSE(t["toast_for"].is_null());
+      break;
+    }
+  }
+  EXPECT_TRUE(found_toast);
+}
+
+TEST_F(PostgresMCPServerTest, WraparoundStatusHonoursLimit) {
+  json r = srv->call_wraparound_status("", 3);
+  EXPECT_LE(r["tables"].size(), 3u);
+}
+
+// --- duplicateIndexes ---
+
+namespace {
+
+// Names of every index in an 'identical' group that contains `name`.
+std::vector<std::string> identical_group_of(const json& r, const std::string& name) {
+  for (const auto& g : r["identical"]) {
+    std::vector<std::string> names;
+    for (const auto& i : g["indexes"]) names.push_back(i["name"].get<std::string>());
+    if (std::find(names.begin(), names.end(), name) != names.end()) return names;
+  }
+  return {};
+}
+
+bool is_reported_redundant(const json& r, const std::string& name) {
+  for (const auto& e : r["redundant"])
+    if (e["index"].get<std::string>() == name) return true;
+  return false;
+}
+
+}  // namespace
+
+TEST_F(PostgresMCPServerTest, DuplicateIndexesGroupsExactDuplicates) {
+  json r = srv->call_duplicate_indexes("grocery", "index_zoo");
+  ASSERT_TRUE(r.contains("identical")) << r.dump(2);
+
+  auto group = identical_group_of(r, "zoo_a");
+  ASSERT_EQ(group.size(), 2u) << r["identical"].dump(2);
+  EXPECT_NE(std::find(group.begin(), group.end(), "zoo_a_again"), group.end());
+}
+
+TEST_F(PostgresMCPServerTest, DuplicateIndexesGroupsIdenticalExpressionIndexes) {
+  // Expression columns have attnum 0 in indkey, so a detector comparing indkey
+  // alone would call any two expression indexes duplicates. These two really
+  // are duplicates, and the next test proves two different ones are not.
+  json r = srv->call_duplicate_indexes("grocery", "index_zoo");
+  auto group = identical_group_of(r, "zoo_lower_c");
+  ASSERT_EQ(group.size(), 2u) << r["identical"].dump(2);
+  EXPECT_NE(std::find(group.begin(), group.end(), "zoo_lower_c2"), group.end());
+}
+
+TEST_F(PostgresMCPServerTest, DuplicateIndexesReportsPrefixRedundancy) {
+  json r = srv->call_duplicate_indexes("grocery", "index_zoo");
+  ASSERT_TRUE(r.contains("redundant")) << r.dump(2);
+
+  bool found = false;
+  for (const auto& e : r["redundant"]) {
+    if (e["index"].get<std::string>() == "zoo_a") {
+      found = true;
+      EXPECT_EQ(e["covered_by"].get<std::string>(), "zoo_a_b");
+      EXPECT_NE(e["reason"].get<std::string>().find("leading prefix"), std::string::npos);
+      EXPECT_TRUE(e.contains("size"));
+      EXPECT_TRUE(e.contains("idx_scan"));
+      EXPECT_TRUE(e["valid"].get<bool>());
+      break;
+    }
+  }
+  EXPECT_TRUE(found) << r["redundant"].dump(2);
+}
+
+TEST_F(PostgresMCPServerTest, DuplicateIndexesSkipsDifferentSortOrder) {
+  // (a DESC) cannot serve a query that wants (a, b) in ascending order, so it
+  // is not covered by zoo_a_b however much the column list suggests otherwise.
+  json r = srv->call_duplicate_indexes("grocery", "index_zoo");
+  EXPECT_FALSE(is_reported_redundant(r, "zoo_a_desc")) << r["redundant"].dump(2);
+  EXPECT_TRUE(identical_group_of(r, "zoo_a_desc").empty());
+}
+
+TEST_F(PostgresMCPServerTest, DuplicateIndexesSkipsPartialIndex) {
+  // A partial index covers a different row set entirely.
+  json r = srv->call_duplicate_indexes("grocery", "index_zoo");
+  EXPECT_FALSE(is_reported_redundant(r, "zoo_a_part")) << r["redundant"].dump(2);
+}
+
+TEST_F(PostgresMCPServerTest, DuplicateIndexesNeverCallsAUniqueIndexRedundant) {
+  // zoo_c_uq is a prefix of zoo_c_d_uq, but dropping it would drop the
+  // uniqueness constraint on c, which the wider index does not enforce.
+  json r = srv->call_duplicate_indexes("grocery", "index_zoo");
+  EXPECT_FALSE(is_reported_redundant(r, "zoo_c_uq")) << r["redundant"].dump(2);
+}
+
+TEST_F(PostgresMCPServerTest, DuplicateIndexesFindsNothingOnACleanTable) {
+  json r = srv->call_duplicate_indexes("grocery", "users");
+  EXPECT_TRUE(r["identical"].empty()) << r["identical"].dump(2);
+  EXPECT_TRUE(r["redundant"].empty()) << r["redundant"].dump(2);
+}
+
+TEST_F(PostgresMCPServerTest, DuplicateIndexesWholeSchemaFindsTheZooTable) {
+  json r = srv->call_duplicate_indexes("grocery", "");
+  bool found = false;
+  for (const auto& g : r["identical"])
+    if (g["table"].get<std::string>() == "grocery.index_zoo") found = true;
+  EXPECT_TRUE(found) << r["identical"].dump(2);
+}
+
+// --- checkpointStats ---
+
+TEST_F(PostgresMCPServerTest, CheckpointStatsNormalizesAcrossServerVersions) {
+  json r = srv->call_checkpoint_stats();
+  ASSERT_TRUE(r.contains("source")) << r.dump(2);
+
+  // Whichever view supplied them, the caller sees the same field names.
+  ASSERT_TRUE(r.contains("checkpointer"));
+  auto& c = r["checkpointer"];
+  EXPECT_TRUE(c.contains("checkpoints_timed"));
+  EXPECT_TRUE(c.contains("checkpoints_requested"));
+  EXPECT_TRUE(c.contains("checkpoints_total"));
+  EXPECT_TRUE(c.contains("timed_percent"));
+  EXPECT_TRUE(c.contains("write_time_ms"));
+  EXPECT_TRUE(c.contains("sync_time_ms"));
+  EXPECT_TRUE(c.contains("buffers_written"));
+
+  ASSERT_TRUE(r.contains("bgwriter"));
+  EXPECT_TRUE(r["bgwriter"].contains("buffers_clean"));
+  EXPECT_TRUE(r["bgwriter"].contains("buffers_alloc"));
+
+  ASSERT_TRUE(r.contains("wal"));
+  EXPECT_TRUE(r["wal"].contains("wal_records"));
+  EXPECT_TRUE(r["wal"].contains("wal_bytes"));
+  EXPECT_TRUE(r["wal"].contains("wal_buffers_full"));
+
+  ASSERT_TRUE(r.contains("settings"));
+  EXPECT_TRUE(r["settings"].contains("checkpoint_timeout"));
+  EXPECT_TRUE(r["settings"].contains("max_wal_size"));
+  EXPECT_TRUE(r["settings"].contains("checkpoint_completion_target"));
+}
+
+TEST_F(PostgresMCPServerTest, CheckpointStatsReportsBackendWritesWhereverTheyLive) {
+  json r = srv->call_checkpoint_stats();
+  // Before 17 they are columns of pg_stat_bgwriter; from 17 they moved to
+  // pg_stat_io. Either way the count has to be reachable.
+  if (pg_server_version_num(test_url) >= 170000) {
+    ASSERT_TRUE(r.contains("backend_io")) << r.dump(2);
+    ASSERT_TRUE(r["backend_io"].contains("client backend")) << r["backend_io"].dump(2);
+    EXPECT_TRUE(r["backend_io"]["client backend"].contains("writes"));
+  } else {
+    EXPECT_TRUE(r["bgwriter"].contains("buffers_backend")) << r["bgwriter"].dump(2);
+    EXPECT_TRUE(r["bgwriter"].contains("buffers_backend_fsync"));
+  }
+}
+
+// --- tableIOStats ---
+
+TEST_F(PostgresMCPServerTest, TableIOStatsReportsPerObjectHitRatios) {
+  json r = srv->call_table_io_stats("grocery", "", 50);
+  ASSERT_TRUE(r.contains("grocery.users")) << r.dump(2);
+  auto& u = r["grocery.users"];
+  EXPECT_TRUE(u.contains("heap_blks_read"));
+  EXPECT_TRUE(u.contains("heap_blks_hit"));
+  EXPECT_TRUE(u.contains("heap_hit_percent"));
+  EXPECT_TRUE(u.contains("idx_blks_read"));
+  EXPECT_TRUE(u.contains("idx_hit_percent"));
+  EXPECT_TRUE(u.contains("total_hit_percent"));
+  EXPECT_TRUE(u.contains("size"));
+  // No per-index breakdown for a whole-schema sweep.
+  EXPECT_TRUE(u["indexes"].is_null());
+}
+
+TEST_F(PostgresMCPServerTest, TableIOStatsAddsPerIndexBreakdownForANamedTable) {
+  json r = srv->call_table_io_stats("grocery", "users", 20);
+  ASSERT_EQ(r.size(), 1u);
+  ASSERT_TRUE(r.contains("grocery.users"));
+  auto& idx = r["grocery.users"]["indexes"];
+  ASSERT_TRUE(idx.is_object()) << r.dump(2);
+  ASSERT_TRUE(idx.contains("users_pkey")) << idx.dump(2);
+  EXPECT_TRUE(idx["users_pkey"].contains("idx_blks_read"));
+  EXPECT_TRUE(idx["users_pkey"].contains("idx_hit_percent"));
+  EXPECT_TRUE(idx["users_pkey"].contains("idx_scan"));
+  EXPECT_TRUE(idx["users_pkey"].contains("size"));
+}
+
+TEST_F(PostgresMCPServerTest, TableIOStatsRatioIsNullNotZeroWithoutTraffic) {
+  // An untouched table has read 0 and hit 0. Reporting 0% would read as "every
+  // access missed the cache", which is the opposite of what happened.
+  pqxx::connection c(test_url);
+  pqxx::work t(c);
+  t.exec("CREATE TABLE grocery.never_read (id INT)");
+  t.commit();
+
+  json r = srv->call_table_io_stats("grocery", "never_read", 20);
+  ASSERT_TRUE(r.contains("grocery.never_read")) << r.dump(2);
+  EXPECT_TRUE(r["grocery.never_read"]["heap_hit_percent"].is_null());
+
+  pqxx::work drop(c);
+  drop.exec("DROP TABLE grocery.never_read");
+  drop.commit();
+}
+
+// --- hostCapacity ---
+
+TEST_F(PostgresMCPServerTest, HostCapacitySaysSoWhenNoHardwareWasInjected) {
+  json r = srv->call_host_capacity(0, 0, "");
+  ASSERT_TRUE(r.contains("host")) << r.dump(2);
+  EXPECT_FALSE(r["host"]["configured"].get<bool>());
+  ASSERT_TRUE(r.contains("hint"));
+  EXPECT_NE(r["hint"].get<std::string>().find("PG_LICHT_HOST_RAM_MB"), std::string::npos);
+
+  // The settings are still readable; only the ratios that need RAM are null.
+  ASSERT_TRUE(r["settings"].contains("shared_buffers"));
+  EXPECT_TRUE(r["derived"]["shared_buffers_percent_of_ram"].is_null());
+  // ... and the ones that don't need it are still computed.
+  EXPECT_FALSE(r["derived"]["work_mem_times_max_connections_bytes"].is_null());
+}
+
+TEST_F(PostgresMCPServerTest, HostCapacityComputesRatiosFromInjectedHardware) {
+  json r = srv->call_host_capacity(4096, 8, "local nvme");
+  ASSERT_TRUE(r["host"]["configured"].get<bool>()) << r.dump(2);
+  EXPECT_EQ(r["host"]["ram_mb"].get<long long>(), 4096);
+  EXPECT_EQ(r["host"]["ram_bytes"].get<long long>(), 4096LL * 1048576);
+  EXPECT_EQ(r["host"]["vcpus"].get<int>(), 8);
+  EXPECT_EQ(r["host"]["storage"].get<std::string>(), "local nvme");
+  EXPECT_EQ(r["host"]["source"].get<std::string>(), "argument");
+  EXPECT_FALSE(r.contains("hint"));
+
+  auto& d = r["derived"];
+  EXPECT_FALSE(d["shared_buffers_percent_of_ram"].is_null());
+  EXPECT_GT(d["shared_buffers_percent_of_ram"].get<double>(), 0.0);
+  EXPECT_FALSE(d["max_parallel_workers_per_vcpu"].is_null());
+  EXPECT_FALSE(d["committed_worst_case_percent_of_ram"].is_null());
+}
+
+TEST_F(PostgresMCPServerTest, HostCapacityResolvesByteUnitsPerSetting) {
+  json r = srv->call_host_capacity(0, 0, "");
+  auto& s = r["settings"];
+  // shared_buffers is counted in 8kB pages, work_mem in kB; both must come
+  // back as bytes so a caller never has to know which.
+  ASSERT_TRUE(s["shared_buffers"]["bytes"].is_number());
+  EXPECT_EQ(s["shared_buffers"]["bytes"].get<long long>(),
+            s["shared_buffers"]["setting"].get<std::string>().empty()
+              ? 0 : std::stoll(s["shared_buffers"]["setting"].get<std::string>()) * 8192);
+  ASSERT_TRUE(s["work_mem"]["bytes"].is_number());
+  EXPECT_EQ(s["work_mem"]["bytes"].get<long long>(),
+            std::stoll(s["work_mem"]["setting"].get<std::string>()) * 1024);
+  // max_connections has no unit, so it has no byte count -- null, not zero.
+  EXPECT_TRUE(s["max_connections"]["bytes"].is_null());
+  // A "-1" setting means "derived from another GUC", not a negative size.
+  if (s.contains("autovacuum_work_mem") &&
+      s["autovacuum_work_mem"]["setting"].get<std::string>() == "-1") {
+    EXPECT_TRUE(s["autovacuum_work_mem"]["bytes"].is_null());
+  }
+}
+
 // --- explainQuery ---
 
 TEST_F(PostgresMCPServerTest, ExplainQueryReturnsAPlan) {
@@ -2162,6 +2513,72 @@ TEST(ConnectionConfigTest, FromUrlBuildsASingleDefault) {
   EXPECT_EQ(reg.names().size(), 1u);
   EXPECT_NE(reg.get("default").conninfo.find("application_name=app/1"),
             std::string::npos);
+}
+
+TEST(ConnectionConfigTest, HostCapacityKeysAreParsedAndKeptOutOfTheConninfo) {
+  auto reg = load("[default]\ndbname = one\nhost_ram_mb = 65536\nhost_vcpus = 16\n"
+                  "host_storage = local nvme\nhost_note = shared with the app server\n");
+  const auto& c = reg.get("default");
+  EXPECT_EQ(c.capacity.ram_mb, 65536);
+  EXPECT_EQ(c.capacity.vcpus, 16);
+  EXPECT_EQ(c.capacity.storage, "local nvme");
+  EXPECT_EQ(c.capacity.note, "shared with the app server");
+  EXPECT_EQ(c.capacity.source, "config file");
+  // libpq would reject the whole conninfo over an unknown keyword, so these
+  // must be consumed here rather than passed through.
+  EXPECT_EQ(c.conninfo.find("host_ram_mb"), std::string::npos);
+  EXPECT_EQ(c.conninfo.find("host_vcpus"), std::string::npos);
+  EXPECT_EQ(c.conninfo.find("nvme"), std::string::npos);
+}
+
+TEST(ConnectionConfigTest, HostCapacityIsUnsetWhenNotDeclared) {
+  auto reg = load("[default]\ndbname = one\n");
+  const auto& c = reg.get("default");
+  EXPECT_FALSE(c.capacity.configured());
+  EXPECT_EQ(c.capacity.ram_mb, 0);
+  EXPECT_EQ(c.capacity.source, "");
+}
+
+TEST(ConnectionConfigTest, NonNumericHostRamIsRejectedNamingTheSection) {
+  // "64GB" where megabytes are meant would be off by three orders of
+  // magnitude and silently invalidate every ratio derived from it.
+  try {
+    load("[prod]\ndbname = one\nhost_ram_mb = 64GB\n");
+    FAIL() << "expected a rejection";
+  } catch (const std::exception& e) {
+    std::string msg = e.what();
+    EXPECT_NE(msg.find("prod"), std::string::npos);
+    EXPECT_NE(msg.find("host_ram_mb"), std::string::npos);
+    EXPECT_NE(msg.find("64GB"), std::string::npos);
+  }
+}
+
+TEST(ConnectionConfigTest, ZeroOrNegativeHostVcpusIsRejected) {
+  EXPECT_THROW(load("[default]\ndbname = one\nhost_vcpus = 0\n"), std::exception);
+  EXPECT_THROW(load("[default]\ndbname = one\nhost_vcpus = -4\n"), std::exception);
+}
+
+TEST(ConnectionConfigTest, HostCapacityComesFromTheEnvironmentForASingleConnection) {
+  ::setenv("PG_LICHT_HOST_RAM_MB", "8192", 1);
+  ::setenv("PG_LICHT_HOST_VCPUS", "4", 1);
+  ::setenv("PG_LICHT_HOST_STORAGE", "gp3", 1);
+  auto reg = pglicht::ConnectionRegistry::from_url("dbname=x", "app/1");
+  ::unsetenv("PG_LICHT_HOST_RAM_MB");
+  ::unsetenv("PG_LICHT_HOST_VCPUS");
+  ::unsetenv("PG_LICHT_HOST_STORAGE");
+
+  const auto& c = reg.get("default");
+  EXPECT_EQ(c.capacity.ram_mb, 8192);
+  EXPECT_EQ(c.capacity.vcpus, 4);
+  EXPECT_EQ(c.capacity.storage, "gp3");
+  EXPECT_EQ(c.capacity.source, "environment");
+}
+
+TEST(ConnectionConfigTest, EnvironmentHostCapacityDoesNotLeakIntoTheConninfo) {
+  ::setenv("PG_LICHT_HOST_RAM_MB", "8192", 1);
+  auto reg = pglicht::ConnectionRegistry::from_url("dbname=x", "app/1");
+  ::unsetenv("PG_LICHT_HOST_RAM_MB");
+  EXPECT_EQ(reg.get("default").conninfo.find("8192"), std::string::npos);
 }
 
 TEST(ConnectionConfigTest, FromUrlLeavesUriFormUntouched) {

--- a/cpp/src/test_main.cpp
+++ b/cpp/src/test_main.cpp
@@ -1686,6 +1686,232 @@ TEST_F(PostgresMCPServerTest, TableBloatUnknownTableReturnsEmpty) {
   EXPECT_TRUE(result.empty());
 }
 
+// --- currentActivity enrichment ---
+
+TEST_F(PostgresMCPServerTest, ActivityCarriesQueryIdAsTextForExplainQuery) {
+  // query_id is the join key from a running statement to statementStats and
+  // explainQuery. It must be text: a 64-bit value does not survive JSON
+  // number precision, and explainQuery takes it as a string.
+  pqxx::connection other(test_url);
+  pqxx::work t(other);
+  t.exec("SELECT pg_sleep(0)");
+
+  json r = srv->call_activity();
+  ASSERT_TRUE(r.is_object());
+
+  bool saw_backend = false;
+  for (auto& [pid, b] : r.items()) {
+    (void)pid;
+    ASSERT_TRUE(b.contains("query_id")) << b.dump(2);
+    EXPECT_TRUE(b["query_id"].is_string() || b["query_id"].is_null());
+    EXPECT_TRUE(b.contains("leader_pid"));
+    EXPECT_TRUE(b.contains("backend_xid"));
+    EXPECT_TRUE(b.contains("backend_xmin"));
+    EXPECT_TRUE(b.contains("xact_duration_s"));
+    EXPECT_TRUE(b.contains("query_duration_s"));
+    saw_backend = true;
+  }
+  EXPECT_TRUE(saw_backend);
+  t.abort();
+}
+
+TEST_F(PostgresMCPServerTest, ActivityDescribesWaitEventsOnPg17AndLater) {
+  json r = srv->call_activity();
+  const bool expected = pg_server_version_num(test_url) >= 170000;
+  bool found = false;
+  for (auto& [pid, b] : r.items()) {
+    (void)pid;
+    if (b.contains("wait_event_description")) found = true;
+  }
+  // pg_wait_events, the source of the descriptions, is PostgreSQL 17+.
+  EXPECT_EQ(found, expected);
+}
+
+// --- replicationSlots enrichment ---
+
+TEST_F(PostgresMCPServerTest, ReplicationSlotsReportsWalStatusAndSpillCounters) {
+  pqxx::connection c(test_url);
+  {
+    pqxx::nontransaction n(c);
+    n.exec("SELECT pg_create_physical_replication_slot('pg_licht_probe_slot')");
+  }
+
+  json r = srv->call_replication_slots();
+  ASSERT_TRUE(r.contains("pg_licht_probe_slot")) << r.dump(2);
+  auto& s = r["pg_licht_probe_slot"];
+  EXPECT_EQ(s["slot_type"].get<std::string>(), "physical");
+  // wal_status is the verdict that retained_wal_bytes only hints at:
+  // 'extended' is past max_wal_size, 'lost' means the slot is unusable.
+  EXPECT_TRUE(s.contains("wal_status"));
+  EXPECT_TRUE(s.contains("safe_wal_size"));
+  EXPECT_TRUE(s.contains("two_phase"));
+  // From pg_stat_replication_slots, a different view: logical decoding
+  // spilling to disk is invisible in the slot's own row.
+  EXPECT_TRUE(s.contains("spill_txns"));
+  EXPECT_TRUE(s.contains("spill_bytes"));
+  EXPECT_TRUE(s.contains("total_bytes"));
+
+  if (pg_server_version_num(test_url) >= 160000) {
+    EXPECT_TRUE(s.contains("conflicting"));
+  }
+  if (pg_server_version_num(test_url) >= 170000) {
+    EXPECT_TRUE(s.contains("invalidation_reason"));
+    EXPECT_TRUE(s.contains("inactive_since"));
+  }
+
+  pqxx::nontransaction drop(c);
+  drop.exec("SELECT pg_drop_replication_slot('pg_licht_probe_slot')");
+}
+
+// --- databaseStats enrichment ---
+
+TEST_F(PostgresMCPServerTest, DatabaseStatsIncludesSessionCounters) {
+  json r = srv->call_database_stats();
+  ASSERT_TRUE(r.contains(test_dbname));
+  auto& s = r[test_dbname];
+  // These distinguish a database that is busy from one merely holding
+  // transactions open; the commit/rollback counts cannot tell them apart.
+  EXPECT_TRUE(s.contains("session_time"));
+  EXPECT_TRUE(s.contains("active_time"));
+  EXPECT_TRUE(s.contains("idle_in_transaction_time"));
+  EXPECT_TRUE(s.contains("sessions"));
+  EXPECT_TRUE(s.contains("sessions_abandoned"));
+  EXPECT_TRUE(s.contains("sessions_fatal"));
+  EXPECT_TRUE(s.contains("sessions_killed"));
+
+  const bool pg18 = pg_server_version_num(test_url) >= 180000;
+  EXPECT_EQ(s.contains("parallel_workers_to_launch"), pg18);
+  EXPECT_EQ(s.contains("parallel_workers_launched"), pg18);
+}
+
+// --- listTables / tableDetails version-gated columns ---
+
+TEST_F(PostgresMCPServerTest, TableStatsIncludeFailedHotUpdatesOnPg16AndLater) {
+  const bool pg16 = pg_server_version_num(test_url) >= 160000;
+
+  json tables = srv->call_tables("grocery");
+  ASSERT_TRUE(tables.contains("users"));
+  // n_tup_newpage_upd counts updates that had to move the row to another
+  // page: the direct measure of failed HOT updates.
+  EXPECT_EQ(tables["users"].contains("n_tup_newpage_upd"), pg16);
+  EXPECT_EQ(tables["users"].contains("last_seq_scan"), pg16);
+
+  json detail = srv->call_table("grocery", "users");
+  EXPECT_EQ(detail.contains("n_tup_newpage_upd"), pg16);
+  EXPECT_EQ(detail.contains("last_seq_scan"), pg16);
+}
+
+// --- progressStats ---
+
+TEST_F(PostgresMCPServerTest, ProgressStatsReportsEveryCommandCategory) {
+  json r = srv->call_progress_stats();
+  // All six categories are always present, empty when nothing is running, so
+  // a caller never has to guess whether a missing key means "idle" or
+  // "unsupported on this version".
+  for (const char* k : {"vacuum", "analyze", "create_index", "cluster", "copy", "basebackup"}) {
+    ASSERT_TRUE(r.contains(k)) << r.dump(2);
+    EXPECT_TRUE(r[k].is_array()) << k;
+  }
+}
+
+TEST_F(PostgresMCPServerTest, ProgressStatsReportsARunningVacuum) {
+  // Enough dead tuples, and a slow enough vacuum, that it is still running
+  // when the tool is called.
+  pqxx::connection setup(test_url);
+  {
+    pqxx::work w(setup);
+    w.exec("CREATE TABLE grocery.vacuum_me AS "
+           "SELECT g AS id, repeat('x', 200) AS pad FROM generate_series(1, 60000) g");
+    w.exec("UPDATE grocery.vacuum_me SET pad = pad");
+    w.commit();
+  }
+
+  // A separate connection, so the vacuum runs while this thread polls.
+  pqxx::connection vac(test_url);
+  {
+    pqxx::nontransaction n(vac);
+    n.exec("SET vacuum_cost_delay = 100");
+    n.exec("SET vacuum_cost_limit = 10");
+  }
+  // pqxx has no async exec, so the vacuum is issued on a pipeline and the
+  // tool is called while it is in flight.
+  pqxx::nontransaction n(vac);
+  pqxx::pipeline p(n);
+  p.insert("VACUUM grocery.vacuum_me");
+
+  json found;
+  for (int i = 0; i < 40 && found.is_null(); i++) {
+    json r = srv->call_progress_stats();
+    for (const auto& v : r["vacuum"])
+      if (v.value("relation", "") == "grocery.vacuum_me") found = v;
+  }
+
+  // Cancel rather than wait: the vacuum was deliberately slowed to be
+  // observable, so letting it run to completion would cost the suite a minute
+  // for no extra coverage.
+  if (!found.is_null()) {
+    pqxx::connection killer(test_url);
+    pqxx::nontransaction k(killer);
+    k.exec("SELECT pg_cancel_backend(" + std::to_string(found["pid"].get<int>()) + ")");
+  }
+  try {
+    p.complete();
+  } catch (const pqxx::sql_error&) {
+    // Expected: the cancellation above surfaces here.
+  }
+
+  pqxx::connection cleanup(test_url);
+  pqxx::work drop(cleanup);
+  drop.exec("DROP TABLE grocery.vacuum_me");
+  drop.commit();
+
+  if (found.is_null()) GTEST_SKIP() << "the vacuum finished before it could be observed";
+
+  EXPECT_TRUE(found.contains("phase"));
+  EXPECT_TRUE(found.contains("heap_blks_total"));
+  EXPECT_TRUE(found.contains("scanned_percent"));
+  EXPECT_TRUE(found.contains("elapsed_s"));
+  EXPECT_EQ(found["query"].get<std::string>(), "VACUUM grocery.vacuum_me");
+  // The PostgreSQL 17 rename is normalized behind a unit label rather than
+  // pretended away: the old and new columns measure different things.
+  if (pg_server_version_num(test_url) >= 170000) {
+    EXPECT_EQ(found["dead_tuple_unit"].get<std::string>(), "bytes");
+    EXPECT_TRUE(found.contains("max_dead_tuple_bytes"));
+    EXPECT_TRUE(found.contains("num_dead_item_ids"));
+    EXPECT_TRUE(found.contains("indexes_total"));
+  } else {
+    EXPECT_EQ(found["dead_tuple_unit"].get<std::string>(), "tuples");
+    EXPECT_TRUE(found.contains("max_dead_tuples"));
+    EXPECT_TRUE(found.contains("num_dead_tuples"));
+  }
+}
+
+// --- ioStats ---
+
+TEST_F(PostgresMCPServerTest, IoStatsReturnsRowsOrAVersionError) {
+  json r = srv->call_io_stats();
+
+  if (pg_server_version_num(test_url) < 160000) {
+    ASSERT_TRUE(r.contains("error")) << r.dump(2);
+    EXPECT_NE(r["error"].get<std::string>().find("PostgreSQL 16"), std::string::npos);
+    EXPECT_TRUE(r.contains("hint"));
+    return;
+  }
+
+  ASSERT_TRUE(r.is_array()) << r.dump(2);
+  ASSERT_FALSE(r.empty());
+  auto& row = r[0];
+  EXPECT_TRUE(row.contains("backend_type"));
+  EXPECT_TRUE(row.contains("object"));
+  EXPECT_TRUE(row.contains("context"));
+  EXPECT_TRUE(row.contains("reads"));
+  EXPECT_TRUE(row.contains("writes"));
+  EXPECT_TRUE(row.contains("hit_percent"));
+  // The byte counters replaced op_bytes in PostgreSQL 18; before that there
+  // is no honest way to report them.
+  EXPECT_EQ(row.contains("read_bytes"), pg_server_version_num(test_url) >= 180000);
+}
+
 // --- wraparoundStatus ---
 
 namespace {
@@ -1735,6 +1961,14 @@ TEST_F(PostgresMCPServerTest, WraparoundStatusReportsPerTableFreezeOverride) {
   EXPECT_EQ((*users)["freeze_max_age_source"].get<std::string>(), "server");
   EXPECT_EQ((*users)["kind"].get<std::string>(), "table");
   EXPECT_TRUE((*users)["toast_for"].is_null());
+
+  // relallfrozen and the cumulative vacuum timings are PostgreSQL 18+. They
+  // turn an age into an estimate of the work left: an old relfrozenxid on a
+  // table that is already fully frozen is a different problem entirely.
+  const bool pg18 = pg_server_version_num(test_url) >= 180000;
+  EXPECT_EQ(users->contains("frozen_percent"), pg18);
+  EXPECT_EQ(users->contains("relallfrozen"), pg18);
+  EXPECT_EQ(users->contains("total_autovacuum_time_ms"), pg18);
 }
 
 TEST_F(PostgresMCPServerTest, WraparoundStatusIncludesToastTables) {
@@ -2314,6 +2548,42 @@ TEST_F(PgssMCPServerTest, ParamsTurnARecoveredStatementIntoARealAnalyzedPlan) {
   EXPECT_FALSE(r["generic"].get<bool>());
   EXPECT_TRUE(r["analyzed"].get<bool>());
   EXPECT_TRUE(r["plan"][0].contains("Execution Time"));
+}
+
+TEST_F(PgssMCPServerTest, StatementStatsCarriesEvictionInfoAlongsideTheRows) {
+  json r = srv->call_statement_stats(5);
+  ASSERT_TRUE(r.is_object()) << r.dump(2);
+  ASSERT_TRUE(r.contains("statements"));
+  ASSERT_TRUE(r["statements"].is_array());
+  ASSERT_FALSE(r["statements"].empty());
+
+  // dealloc is what says whether this list is "the slowest queries" or only
+  // "the slowest of those not yet evicted" -- a distinction that cannot be
+  // drawn from the rows themselves.
+  ASSERT_TRUE(r.contains("info")) << r.dump(2);
+  EXPECT_TRUE(r["info"].contains("dealloc"));
+  EXPECT_TRUE(r["info"].contains("stats_reset"));
+  EXPECT_TRUE(r.contains("max"));
+}
+
+TEST_F(PgssMCPServerTest, StatementStatsQueryIdIsTextAndFeedsExplainQuery) {
+  json r = srv->call_statement_stats(5);
+  ASSERT_FALSE(r["statements"].empty());
+  const json& first = r["statements"][0];
+
+  // A queryid is 64-bit. Emitted as a JSON number it would be rounded by any
+  // client that parses numbers as doubles, and the round-tripped value would
+  // then not be found by explainQuery.
+  ASSERT_TRUE(first["query_id"].is_string()) << first.dump(2);
+  std::string qid = first["query_id"].get<std::string>();
+
+  json e = srv->call_explain_query(qid, "", json::array(), false, 0);
+  // Whatever the outcome, it must not be "no entry for that queryid": the id
+  // came straight out of the same view a moment ago.
+  if (e.contains("error")) {
+    EXPECT_EQ(e["error"].get<std::string>().find("no pg_stat_statements entry"),
+              std::string::npos) << e.dump(2);
+  }
 }
 
 TEST_F(PgssMCPServerTest, UnknownQueryIdReturnsHint) {


### PR DESCRIPTION
Seven read-only operations aimed at the failure modes the existing catalog tools could describe but not measure, a sweep of the PostgreSQL 14–18 release notes for statistics features this server was not yet reading, optional `pid`/`query_id` filters that turn the monitoring tools into a drill-down path, and the configuration plumbing `hostCapacity` needs. Takes the operation count from 40 to 47.

Released as **3.0.0** for the two breaking changes below.

## ⚠️ Breaking changes

Both correct something that was *wrong*, not merely absent.

- **`statementStats` returns an object, not an array.** Rows moved under `statements`, joined by an `info` block from `pg_stat_statements_info` and the configured `max`. The reason is `info.dealloc`: it counts how often the extension has evicted its least-used entries, so a non-zero value means the list is not the slowest queries in the cluster but the slowest of those that survived eviction. A caller reading the old array had no way to know it was seeing a truncated picture.

- **`query_id` is text everywhere.** `statementStats` previously returned it as a JSON number. A queryid is 64-bit, so every JavaScript-based MCP client silently rounded it, and the rounded value would then not be found by `explainQuery` — which has always documented the field as a string for exactly this reason.

## New tools

**`wraparoundStatus`** — XID and multixact headroom per database and per table, against *both* thresholds that matter: `autovacuum_freeze_max_age`, where an anti-wraparound autovacuum is forced, and the hard limit of 2 146 483 647, where the cluster stops accepting commands that assign a transaction id. Those are an order of magnitude apart and routinely confused, so both percentages are reported. Per-table freeze storage parameters are resolved, so a table with its own `autovacuum_freeze_max_age` is measured against *its* limit and the output says which applied. TOAST tables are included and labelled: they carry their own `relfrozenxid`, never appear in `pg_stat_user_tables`, and are frequently the relation actually holding the horizon back. On PG18, `frozen_percent` (from `pg_class.relallfrozen`) and cumulative vacuum timings turn an age into an estimate of work remaining.

**`duplicateIndexes`** — `identical` groups indexes matching on key columns, operator classes, collations, sort order, `INCLUDE` columns and partial predicate; `redundant` reports an index whose keys are a leading prefix of a wider index that also covers its `INCLUDE` columns. The comparison key is a per-column signature built from the column *expression*, not `indkey` — comparing attribute numbers would call any two expression indexes identical (an expression column is attnum 0) and would treat `(a DESC)` as covered by `(a, b)`, which it cannot serve. A unique index is never reported as redundant for being a prefix: dropping it would drop a constraint the wider index does not enforce.

**`checkpointStats`** — timed against requested checkpoints and the ratio between them, write and sync time, buffers written by the checkpointer, the background writer, and directly by backends, plus `pg_stat_wal` volume and the governing settings. PG17 split the checkpointer counters into `pg_stat_checkpointer` and moved backend-written buffers to `pg_stat_io`; PG18 dropped four more `pg_stat_wal` columns. All gated and normalized to one set of field names, with `source` naming the views actually read.

**`tableIOStats`** — per-object cache hit ratios from `pg_statio_all_tables`, with the TOAST and TOAST-index pairs and a combined ratio. A named table adds a per-index breakdown. A ratio is null rather than zero for an object with no reads, so "no traffic" is not misread as "every read missed the cache".

**`hostCapacity`** — memory and parallelism settings correlated with host RAM and vCPU count. Every memory setting resolved to bytes whatever unit it is counted in, plus `shared_buffers` and `effective_cache_size` as a percentage of RAM, `work_mem × max_connections`, `maintenance_work_mem × autovacuum_max_workers`, and parallel workers per vCPU. Numbers only, no verdicts — with two factual caveats returned inline, since the worst-case figures are easy to misread.

**`progressStats`** — every running `VACUUM`, `ANALYZE`, `CREATE INDEX`, `CLUSTER`, `COPY` and base backup, with phase, blocks or tuples done against the total, a completion percentage, and elapsed time. The companion to `wraparoundStatus`: an XID age only answers half of "will the vacuum finish in time". PG17's rename of the vacuum dead-tuple columns from counts to bytes is reported under both names with a `dead_tuple_unit` label, because they measure different things.

**`ioStats`** — `pg_stat_io` per backend type, object and context. Where backend writes, vacuum's ring-buffer reuse, and bulk I/O are visible separately from the aggregate counters. Requires PG16, and says so plainly on older servers.

## Targeted lookups

The monitoring tools were all-or-nothing: they returned the whole view, fine on a test box and unusable on a server with several hundred backends. They now take optional filters, all of which preserve the unfiltered shape when omitted. There are only two correlation keys in play, and threading both through turns the tool set into a path rather than a pile:

```
statementStats → query_id → currentActivity(query_id) → pid → currentLocks(pid)
                                                            → progressStats(pid)
                                                            → ioStats(pid)
                                                            → explainQuery(query_id)
```

- **`currentActivity`** — `pid`, `query_id`, `min_duration_s`, `state`. A `pid` brings that backend's parallel workers with it via `leader_pid`; being shown a leader without its workers hides where the work is happening. `min_duration_s` excludes plain idle backends, whose `query_start` dates a statement that already finished.
- **`currentLocks`** — `pid`, resolving the **transitive** blocking chain through `pg_blocking_pids` rather than merely filtering rows. Each row is tagged `chain_depth`, so the backend at the root of a pile-up is identifiable. The recursion carries a path array, because a deadlock is a cycle in that graph.
- **`ioStats`** — `pid`, `backend_type`, `object`, `context`. With a `pid` it reads `pg_stat_get_backend_io` plus per-backend WAL — a different source rather than a filter, since `pg_stat_io` has no pid column. PG18.
- **`statementStats`** — `query_id`, `order_by`, `min_calls`. `order_by` is really a bug fix: the list was hardcoded to `total_exec_time`, burying a statement called twice at 40 s under one called ten million times at 2 ms. The sort column can't be a bind parameter, so it resolves through a fixed table and anything else is rejected — nothing caller-supplied reaches the SQL.
- **`progressStats`** — `pid`, `relation`, matched by name against `pg_class` rather than cast to `regclass`, so an unknown name is an empty result rather than an error.

## Enriched existing tools

From the release-notes sweep:

- **`currentActivity`** gains `query_id` — the join key to `statementStats` and `explainQuery` that was missing, leaving no route from "this is running now" to "this is its plan". Plus `leader_pid`, `backend_xid`/`backend_xmin`, pre-computed durations, and wait event descriptions from `pg_wait_events` (17+).
- **`replicationSlots`** gains `wal_status` and `safe_wal_size` — the verdict `retained_wal_bytes` only hints at, since `lost` means the slot is already unusable — plus the spill/stream counters from `pg_stat_replication_slots`, where logical decoding spilling to disk is otherwise invisible. Plus `two_phase`, `conflicting` (16+), `invalidation_reason`/`inactive_since` (17+).
- **`databaseStats`** gains the session counters that separate a busy database from one merely holding transactions open, plus the parallel worker counters (18+).
- **`statementStats`** gains temp block I/O and WAL volume, `stats_since` (17+), `wal_buffers_full` and parallel worker counters (18+).
- **`listTables` / `tableDetails`** gain `n_tup_newpage_upd` (the direct measure of failed HOT updates) and `last_seq_scan` on 16+.

## Host capacity injection

Total RAM and vCPU count are properties of the host, not the cluster — no catalog holds them, and a backend could not read them portably in any case, since it would read the *client's* host. Three paths, and `hostCapacity` reports which one was used:

- `host_ram_mb` / `host_vcpus` / `host_storage` / `host_note` per section of the connections file. Consumed before conninfo assembly, since libpq would reject the keywords. A non-numeric or non-positive value is rejected at startup naming the section and key — `64GB` where megabytes are meant would be wrong by three orders of magnitude and would silently invalidate every derived ratio.
- `PG_LICHT_HOST_*`, honoured only with the single-connection `DATABASE_URL` form, where there is no ambiguity about which host they describe.
- `ram_mb` / `vcpus` arguments, taking precedence over both — the path for an agent that inspects the host at run time.

Nothing is inferred: with no RAM figure, every ratio needing one is null and the result says how to supply it. `listConnections` echoes the configured capacity so a caller can see which connections still need it.

## Verification

- Full suite run against **PostgreSQL 14, 16 and 18** — 223 tests on 18, 213 on 16, 211 on 14 (the differences are the `pg_stat_statements` fixture, which needs the extension preloaded, and the `pg_stat_io` tests). Both sides of every version gate were exercised on a real server of that major, not just the newest one.
- `ctest` green on all three targets: `mcp_test`, valgrind, `manpage_lint`.
- `progressStats` was checked against a **live, deliberately-slowed VACUUM**, not just the empty view, so the percentage arithmetic and the `pg_stat_activity` join are covered rather than only the column names — and its `pid`/`relation` filters are exercised while that vacuum is in flight.
- `currentLocks(pid)` is tested against a **real lock wait**: one connection takes an ACCESS EXCLUSIVE lock, a second blocks on it, and the test asserts the holder appears at `chain_depth` 1 and that nothing outside the chain leaks in.

Two bugs were found and fixed while testing this last group, both worth knowing about:

- A C++ raw string ending in two parentheses **silently loses one**, because the terminator is `)delimiter"`. This is true of `R"(...))"` *and* `R"SQL(...))SQL"`, which is why my first fix failed identically to the original — the fragment is now plain string literals. It produced SQL that only failed to parse when the filter was actually used.
- An unused `$1` in the cluster-wide `ioStats` branch made PostgreSQL reject the bind outright ("supplies 4 parameters, but requires 3"); both branches now reference it.
- **Not run locally:** `cpp/test/run-pooled-tests.sh` — `pgbouncer` is not installed on the development machine, so the transaction-pooler path is covered by CI only. Nothing in these tools relies on session state.

Tests cover the cases the index detector has to get *wrong* as much as right: a reversed sort order, a partial index, and a unique index that is a prefix of a wider one are each asserted **not** to be reported.

## Review notes

Three judgment calls worth a second opinion:

1. The two breaking changes above, and the 3.0.0 bump they prompted.
2. `wraparoundStatus` includes TOAST tables. Noisier output, but excluding them would understate the risk.
3. `hostCapacity` returns facts and ratios with no recommendations, consistent with `explainQuery`. An alternative would be to flag obviously-wrong values (`shared_buffers` at 2% of RAM, say), but that crosses into heuristics this server has so far avoided.

Docs updated throughout: `pg_licht_mcp(1)` OPERATIONS entries, a **Host capacity** subsection under CONFIGURATION, new ENVIRONMENT variables, and a rewritten COMPATIBILITY section listing every version-gated field by major. README and CHANGES updated. Version bumped to 3.0.0.
