### PR TITLE
v3.0.1: find extensions installed outside public

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.0.1 (2026-08-12)
+
+### Fixed
+
+- **Extensions installed outside `public` are now found.** `tableBloat`, `statementStats` and `explainQuery`'s `queryid` path referenced `pgstattuple`, `pgstattuple_approx`, `pg_stat_statements` and `pg_stat_statements_info` unqualified, and so depended on the extension's schema happening to be on the connecting role's `search_path`. It commonly is not: `CREATE EXTENSION ... SCHEMA extensions` is ordinary practice for keeping operator tooling out of an application's schemas, and a hardened cluster keeps extensions out of `public` entirely. The tools reported "pgstattuple is not installed" for an extension that was plainly installed, and the hint told the operator to run a `CREATE EXTENSION` that would then fail as already existing — a dead end.
+
+  Each extension's schema is now read from `pg_extension` and every object reference is qualified with it. A `search_path` could not have fixed this: the server sets no session state, because the target deployment is a transaction-mode pooler that discards it, and PgBouncer rejects a GUC passed through the `options` connection keyword outright.
+
+  The location is resolved once per configured connection and remembered, since one connection addresses one database for the life of the process. Only a positive answer is cached — caching "not installed" would pin that verdict until a restart, so a `CREATE EXTENSION` run in response to the tool's own hint would never be picked up — and a remembered location is discarded whenever the object turns out not to be there, so `ALTER EXTENSION ... SET SCHEMA` is picked up on the next call.
+
+  The test fixtures now install `pgstattuple` and `pg_stat_statements` into a schema that is on no `search_path`, which makes every existing `tableBloat`, `statementStats` and `explainQuery` test a regression test for this: eleven of them fail against the previous code.
+
 ## 3.0.0 (2026-08-06)
 
 ### Breaking

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(pg_licht_mcp VERSION 3.0.0 LANGUAGES CXX)
+project(pg_licht_mcp VERSION 3.0.1 LANGUAGES CXX)
 
 # Standard bin/ and share/man/ layout, so `cmake --install` produces a tree that
 # can be dropped onto a prefix as-is: the release tarballs are staged this way,

--- a/cpp/man/pg_licht_mcp.1
+++ b/cpp/man/pg_licht_mcp.1
@@ -1,7 +1,7 @@
 .\" Copyright (c) 2026 Daniel Cristian.
 .\" Licensed under the Apache License, Version 2.0; see LICENSE.
 .\"
-.Dd August 4, 2026
+.Dd August 12, 2026
 .Dt PG_LICHT_MCP 1
 .Os pg-licht
 .Sh NAME
@@ -210,6 +210,42 @@ connection.
 Arguments shown as
 .Ar name
 are required.
+.Ss Extension schemas
+Operations backed by an extension
+.Pq Ic statementStats , Ic explainQuery No and Ic tableBloat
+locate its objects through
+.Li pg_extension
+and reference them schema-qualified.
+The extension therefore does not have to be installed in
+.Li public ,
+and does not have to be on any
+.Va search_path :
+.Ql "CREATE EXTENSION pgstattuple SCHEMA extensions"
+works exactly as an installation into
+.Li public
+does.
+.Pp
+This cannot be solved with a
+.Va search_path
+instead.
+.Nm
+sets no session state, because the target deployment is a transaction-mode
+pooler that discards it, and PgBouncer rejects a GUC passed through the
+.Va options
+connection keyword outright.
+.Pp
+The location of each extension is resolved once per configured connection and
+remembered for the life of the process, since one connection addresses one
+database.
+It is looked up again after any failure to find the object, so an extension
+installed
+.Pq or moved with Ql "ALTER EXTENSION ... SET SCHEMA"
+while
+.Nm
+is running is picked up on the next call.
+An extension that is absent is reported as not installed, with the hint naming
+the setup steps; see
+.Sx DIAGNOSTICS .
 .Ss Schema exploration
 .Bl -tag -width Ds
 .It Ic listSchemas

--- a/cpp/src/server.h
+++ b/cpp/src/server.h
@@ -218,6 +218,79 @@ private:
 
   const pglicht::ConnConfig& active_cfg() const { return registry_.get(active_); }
 
+  // Where each extension actually lives, per connection.
+  //
+  // An extension does not have to be in public: CREATE EXTENSION ... SCHEMA
+  // ext is normal practice, and a hardened cluster usually keeps extensions
+  // out of public entirely. Nothing here sets a search_path -- it cannot,
+  // since PgBouncer discards session state and rejects `options` in the
+  // conninfo -- so an unqualified pgstattuple() or pg_stat_statements
+  // resolves only against the *default* search_path of the connecting role,
+  // and a tool that relied on that reported "not installed" for an extension
+  // that was plainly installed. Every extension object is therefore
+  // schema-qualified from pg_extension instead.
+  //
+  // Keyed by connection name because one name is one database for the life of
+  // the process, and the lookup is otherwise an extra round trip per call.
+  std::map<std::string, std::map<std::string, std::string>> ext_schemas_;
+
+  // The schema of an installed extension, already quoted for interpolation
+  // into SQL, or "" when the extension is not installed on this connection.
+  //
+  // Runs inside the caller's transaction, so the answer is consistent with the
+  // query it is about to qualify.
+  std::string extension_schema(pqxx::work& txn, const std::string& extname) {
+    auto& per_conn = ext_schemas_[active_cfg().name];
+    auto it = per_conn.find(extname);
+    if (it != per_conn.end()) return it->second;
+
+    pqxx::result r = pqxx_exec(
+      txn,
+      "SELECT QUOTE_IDENT(n.nspname)"
+      " FROM pg_extension AS e"
+      " JOIN pg_namespace AS n ON n.oid = e.extnamespace"
+      " WHERE e.extname = $1",
+      pqxx::params{extname});
+
+    std::string schema = r.empty() || r[0][0].is_null()
+      ? std::string{} : r[0][0].as<std::string>();
+
+    // Only a positive answer is remembered. Caching "not installed" would pin
+    // that verdict for the life of the process, so a CREATE EXTENSION during
+    // an incident would never be picked up -- exactly when it is most likely
+    // to happen, since the tool's own hint is what prompts it.
+    if (!schema.empty()) per_conn[extname] = schema;
+    return schema;
+  }
+
+  // Drop a remembered schema after a query that used it failed to find the
+  // object. ALTER EXTENSION ... SET SCHEMA is rare, but a cached location that
+  // has moved would otherwise keep failing until a restart; forgetting it here
+  // makes the next call re-resolve. The failed statement has already aborted
+  // this transaction, so the retry cannot happen before then.
+  void forget_extension_schema(const std::string& extname) {
+    auto conn = ext_schemas_.find(active_cfg().name);
+    if (conn != ext_schemas_.end()) conn->second.erase(extname);
+  }
+
+  // The two error shapes for a missing extension, kept next to each other so
+  // the hints stay consistent between the tools that raise them.
+  static json pgss_missing() {
+    return {
+      {"error", "pg_stat_statements is not installed"},
+      {"hint", "Add 'pg_stat_statements' to shared_preload_libraries in "
+               "postgresql.conf, restart PostgreSQL, then run: "
+               "CREATE EXTENSION pg_stat_statements;"}
+    };
+  }
+
+  static json pgstattuple_missing() {
+    return {
+      {"error", "pgstattuple is not installed"},
+      {"hint", "Run: CREATE EXTENSION pgstattuple;"}
+    };
+  }
+
   // Fail fast on an unusable default connection, matching the previous
   // behaviour where the constructor connected eagerly.
   void probe() {
@@ -1542,6 +1615,13 @@ private:
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
 
+    // Qualified with the schema the extension was installed into; see
+    // extension_schema. An empty answer is "not installed", which is the same
+    // outcome the 42P01 catch below reports -- it is checked up front so the
+    // caller gets that answer whatever their search_path looks like.
+    const std::string pgss = extension_schema(txn, "pg_stat_statements");
+    if (pgss.empty()) return pgss_missing();
+
     // pg_stat_statements_info.dealloc counts how many times the extension has
     // evicted its least-used entries because pg_stat_statements.max was
     // exceeded. A climbing dealloc means this list is not the slowest queries
@@ -1593,7 +1673,7 @@ private:
                        'database',         d.datname
                      )" + since + pg18 + R"(
                      ) AS row_json
-              FROM pg_stat_statements AS pss
+              FROM )" + pgss + R"(.pg_stat_statements AS pss
               LEFT JOIN pg_roles AS r ON r.oid = pss.userid
               LEFT JOIN pg_database AS d ON d.oid = pss.dbid
               WHERE ($2 = '' OR pss.queryid = $2::bigint)
@@ -1603,7 +1683,7 @@ private:
           ) sub), '[]'::jsonb),
         'info', (SELECT JSONB_BUILD_OBJECT(
                    'dealloc', i.dealloc, 'stats_reset', i.stats_reset)
-                 FROM pg_stat_statements_info AS i),
+                 FROM )" + pgss + R"(.pg_stat_statements_info AS i),
         -- missing_ok, so a server where the GUC is absent yields null rather
         -- than an error that would mask the real result.
         'max', current_setting('pg_stat_statements.max', true)
@@ -1625,12 +1705,10 @@ private:
       }
     } catch (const pqxx::sql_error& e) {
       if (e.sqlstate() == "42P01") { // undefined_table
-        return {
-          {"error", "pg_stat_statements is not installed"},
-          {"hint", "Add 'pg_stat_statements' to shared_preload_libraries in "
-                   "postgresql.conf, restart PostgreSQL, then run: "
-                   "CREATE EXTENSION pg_stat_statements;"}
-        };
+        // The view was there when its schema was resolved, so it has since
+        // moved or been dropped; forget the location and report it missing.
+        forget_extension_schema("pg_stat_statements");
+        return pgss_missing();
       }
       throw;
     }
@@ -2674,6 +2752,11 @@ private:
     json stats = nullptr;
 
     if (!queryid.empty()) {
+      // Schema-qualified from pg_extension rather than left to search_path;
+      // see extension_schema.
+      const std::string pgss = extension_schema(txn, "pg_stat_statements");
+      if (pgss.empty()) return pgss_missing();
+
       // Full, untruncated text: recovering it is the whole point of the
       // queryid path, so this deliberately omits statementStats' LEFT(query,500).
       std::string q = R"(
@@ -2696,7 +2779,7 @@ private:
                  'database_oid',     pss.dbid::text,
                  'is_current_db',    COALESCE(d.datname = current_database(), false)
                )
-        FROM pg_stat_statements AS pss
+        FROM )" + pgss + R"(.pg_stat_statements AS pss
         LEFT JOIN pg_roles AS r ON r.oid = pss.userid
         LEFT JOIN pg_database AS d ON d.oid = pss.dbid
         WHERE pss.queryid = $1::bigint
@@ -2718,12 +2801,8 @@ private:
         stats = json::parse(res[0][0].as<std::string>());
       } catch (const pqxx::sql_error& e) {
         if (e.sqlstate() == "42P01") { // undefined_table
-          return {
-            {"error", "pg_stat_statements is not installed"},
-            {"hint", "Add 'pg_stat_statements' to shared_preload_libraries in "
-                     "postgresql.conf, restart PostgreSQL, then run: "
-                     "CREATE EXTENSION pg_stat_statements;"}
-          };
+          forget_extension_schema("pg_stat_statements");
+          return pgss_missing();
         }
         throw;
       }
@@ -2932,6 +3011,13 @@ private:
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
 
+    // Schema-qualified from pg_extension rather than left to search_path; see
+    // extension_schema. pgstattuple is the extension most often installed
+    // somewhere other than public, since it is an operator's tool rather than
+    // part of any application's schema.
+    const std::string pgst = extension_schema(txn, "pgstattuple");
+    if (pgst.empty()) return pgstattuple_missing();
+
     // pgstattuple() does a full sequential scan (real I/O on large tables);
     // pgstattuple_approx() uses the visibility map for a cheap estimate.
     // Field names are normalized across both so callers don't need to branch
@@ -2952,7 +3038,7 @@ private:
                  'free_percent',       bt.free_percent
                )
              END
-      FROM pgstattuple(
+      FROM )" + pgst + R"(.pgstattuple(
              (SELECT oid FROM pg_class WHERE relnamespace = $1::regnamespace AND relname = $2)
            ) AS bt;
     )" : R"(
@@ -2971,7 +3057,7 @@ private:
                  'free_percent',       bt.approx_free_percent
                )
              END
-      FROM pgstattuple_approx(
+      FROM )" + pgst + R"(.pgstattuple_approx(
              (SELECT oid FROM pg_class WHERE relnamespace = $1::regnamespace AND relname = $2)
            ) AS bt;
     )";
@@ -2986,10 +3072,11 @@ private:
       }
     } catch (const pqxx::sql_error& e) {
       if (e.sqlstate() == "42883") { // undefined_function
-        return {
-          {"error", "pgstattuple is not installed"},
-          {"hint", "Run: CREATE EXTENSION pgstattuple;"}
-        };
+        // The extension was there when its schema was resolved, so it has
+        // since moved or been dropped; forget the location so the next call
+        // looks it up again.
+        forget_extension_schema("pgstattuple");
+        return pgstattuple_missing();
       }
       throw;
     }

--- a/cpp/src/test_main.cpp
+++ b/cpp/src/test_main.cpp
@@ -204,7 +204,17 @@ protected:
       txn.exec("ALTER TABLE grocery.bare_notes ADD COLUMN price grocery.positive_amount");
 
       txn.exec("CREATE EXTENSION IF NOT EXISTS postgres_fdw");
-      txn.exec("CREATE EXTENSION IF NOT EXISTS pgstattuple");
+
+      // Deliberately NOT in public, and in a schema that is on nobody's
+      // search_path: "extensions" is the usual convention for keeping an
+      // operator's tooling out of the application's schemas, and an
+      // unqualified pgstattuple() cannot resolve here. Every tableBloat test
+      // below is therefore also a regression test for schema qualification --
+      // they all failed with "pgstattuple is not installed" when the tool
+      // relied on name resolution.
+      txn.exec("CREATE SCHEMA extensions");
+      txn.exec("COMMENT ON SCHEMA extensions IS 'operator tooling, off the default search_path'");
+      txn.exec("CREATE EXTENSION IF NOT EXISTS pgstattuple SCHEMA extensions");
       txn.exec(
         "CREATE SERVER grocery_remote FOREIGN DATA WRAPPER postgres_fdw"
         " OPTIONS (host 'localhost', dbname 'probe', port '5432')"
@@ -2632,8 +2642,13 @@ protected:
 
       pqxx::connection c(url);
       {
+        // In a schema of its own, off the default search_path, for the same
+        // reason as pgstattuple in the main fixture: statementStats and
+        // explainQuery's queryid path have to find the view by catalog
+        // lookup, not by hoping it is in public.
         pqxx::work t(c);
-        t.exec("CREATE EXTENSION pg_stat_statements");
+        t.exec("CREATE SCHEMA extensions");
+        t.exec("CREATE EXTENSION pg_stat_statements SCHEMA extensions");
         t.commit();
       }
       {
@@ -2643,7 +2658,7 @@ protected:
         // shared_preload_libraries". Probe the view itself so the suite skips
         // in that case instead of failing every test body.
         pqxx::work t(c);
-        t.exec("SELECT 1 FROM pg_stat_statements LIMIT 1");
+        t.exec("SELECT 1 FROM extensions.pg_stat_statements LIMIT 1");
         t.commit();
       }
       {
@@ -2682,7 +2697,7 @@ protected:
     pqxx::connection c(url);
     pqxx::work t(c);
     pqxx::result r = t.exec(
-      "SELECT queryid::text FROM pg_stat_statements "
+      "SELECT queryid::text FROM extensions.pg_stat_statements "
       "WHERE query ILIKE 'SELECT count(*) FROM pg_class%' "
       "AND dbid = (SELECT oid FROM pg_database WHERE datname = current_database()) "
       "ORDER BY total_exec_time DESC LIMIT 1");
@@ -2855,7 +2870,7 @@ TEST_F(PgssMCPServerTest, QueryIdFromADroppedDatabaseIsReportedNotCrashed) {
     pqxx::connection c(url);
     pqxx::work t(c);
     pqxx::result r = t.exec(
-      "SELECT queryid::text FROM pg_stat_statements "
+      "SELECT queryid::text FROM extensions.pg_stat_statements "
       "WHERE query ILIKE '%zzz_victim_marker%' ORDER BY total_exec_time DESC LIMIT 1");
     if (!r.empty()) qid = r[0][0].as<std::string>();
   }


### PR DESCRIPTION
## The bug

`tableBloat`, `statementStats` and `explainQuery`'s `queryid` path referenced their extension objects unqualified:

| Tool | Objects |
|---|---|
| `tableBloat` | `pgstattuple()`, `pgstattuple_approx()` |
| `statementStats` | `pg_stat_statements`, `pg_stat_statements_info` |
| `explainQuery` (`queryid` path) | `pg_stat_statements` |

Those are the only extension-provided objects in the server — every other relation it reads is a core catalog in `pg_catalog`, which is always implicitly on the search path. Verified by extracting every `FROM`/`JOIN` target in `server.h`.

An unqualified reference resolves only against the connecting role's *default* `search_path`, since nothing sets one. So `CREATE EXTENSION pgstattuple SCHEMA extensions` — ordinary practice for keeping operator tooling out of an application's schemas, and the norm on a cluster that keeps `public` clean — made the tool answer:

```json
{"error": "pgstattuple is not installed",
 "hint": "Run: CREATE EXTENSION pgstattuple;"}
```

for an extension that was plainly installed, with a hint pointing at a command that would fail as already existing. A dead end for the operator, during exactly the kind of incident these tools exist for.

## The fix

Each extension's schema is read from `pg_extension` (via `QUOTE_IDENT`) and every object reference is qualified with it.

A `search_path` could not have fixed this. The server sets no session state — the target deployment is a transaction-mode pooler that discards it — and PgBouncer rejects a GUC passed through the `options` connection keyword outright.

Locations are resolved **once per configured connection** and remembered, since one connection addresses one database for the life of the process. Two properties of that cache are deliberate:

- **Only a positive answer is cached.** Caching "not installed" would pin that verdict until a restart, so a `CREATE EXTENSION` run in response to the tool's own hint would never be picked up — the case most likely to happen.
- **A remembered location is discarded whenever the object turns out not to be there**, so `ALTER EXTENSION ... SET SCHEMA` is picked up on the next call. It cannot be retried within the same call: the failed statement has already aborted the transaction.

Resolution runs inside the caller's own transaction, so the schema is consistent with the query it qualifies. A genuinely absent extension is now detected up front and returns the same "not installed" shape as before, rather than depending on catching SQLSTATE 42883/42P01 — those catches remain as the backstop.

## Testing

The fixtures now install `pgstattuple` and `pg_stat_statements` into an `extensions` schema that is on no `search_path`, which turns every existing `tableBloat`, `statementStats` and `explainQuery` test into a regression test for this. Confirmed by reverting `server.h` alone: **11 tests fail** against the previous code.

With the fix, 223 tests pass both directly and through the transaction-mode pooler (`cpp/test/run-pooled-tests.sh`, PostgreSQL 18).

## Also in this PR

- `pg_licht_mcp(1)`: a new **Extension schemas** subsection under `OPERATIONS` documenting the resolution, why a `search_path` is not an option here, and the caching behaviour.
- `CHANGES.md` entry and version bump to 3.0.1.
