### PR TITLE
v3.1.0: indexBloat, per-index statistics across access methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 3.1.0 (2026-08-12)
+
+### New tools
+
+- **`indexBloat`** — physical statistics for one index, from whichever `pgstattuple` function fits its access method: `pgstatindex` for btree (tree level, internal/leaf/empty/deleted pages, average leaf density, leaf fragmentation), `pgstatginindex` for GIN (pending list pages and tuples), `pgstathashindex` for hash (bucket, overflow, bitmap and unused pages, live and dead items, free percent).
+
+  The access method is resolved from the catalog rather than asked of the caller. The three functions share no name and no columns, and `pgstatindex` raises a bare "is not a btree index" when pointed at the wrong kind — so a caller made to choose would first have to look the index up, which is the work this tool exists to do. `gist`, `spgist` and `brin` have no `pgstattuple` function at all and are reported as unsupported by name, pointing at `pageinspect`; a partitioned index is reported as having no storage of its own.
+
+  The metrics are deliberately **not** normalized across access methods, unlike `tableBloat`'s exact/approximate pair: `leaf_fragmentation` and `pending_tuples` are not two spellings of one quantity, and shared field names would invent a comparison that does not exist. `access_method` says which set came back.
+
+  GIN's `pending_pages` is returned alongside the `fastupdate` reloption and the effective `gin_pending_list_limit` — the pending list only exists when `fastupdate` is on, and its size is meaningless without the limit it is filling toward. It is also the one variant that is free: `pgstatginindex` reads the metapage only, where the btree and hash functions read the whole index.
+
+  `index_size` and `idx_scan` accompany every result, since a fragmented index that nothing has scanned since the last statistics reset is a candidate for dropping rather than for `REINDEX` — a call that cannot be made from density alone.
+
+### Fixed
+
+- **`tableBloat` now explains a permission failure instead of raising.** Every `pgstattuple` function is installed with `EXECUTE` revoked from `PUBLIC` and granted to `pg_stat_scan_tables`, so a role holding every read privilege on the data is still refused the statistics with SQLSTATE 42501. That surfaced as an unhandled exception reading like an internal fault, sending the caller after a bug rather than after the one grant that fixes it. Both `tableBloat` and `indexBloat` now return the error with the grant named.
+
 ## 3.0.1 (2026-08-12)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Other install channels — deb, rpm, tarball, source — are in [INSTALL.md](INS
 
 ## Tools
 
-47 read-only operations, grouped as schema exploration, catalog search, cluster-wide
+48 read-only operations, grouped as schema exploration, catalog search, cluster-wide
 objects, extensibility and text search, foreign data and replication, monitoring and
 statistics, diagnostics and query planning, and connections. Highlights include
 `tableDetails` (columns, indexes, constraints, foreign keys in both directions, triggers,
@@ -50,8 +50,10 @@ checkpoints, backend-written buffers, WAL volume — normalized across the Postg
 with a completion percentage), `ioStats` (`pg_stat_io` per backend type and context, 16+),
 `tableIOStats` (cache hit ratio per table and per index), `duplicateIndexes` (identical and
 prefix-redundant indexes, compared by column expression, opclass, collation and sort order),
-and `hostCapacity` (memory settings against the host's actual RAM and vCPU count — see
-below).
+`indexBloat` (per-index physical statistics, dispatched on the access method — btree leaf
+density and fragmentation, GIN pending list against the `fastupdate` settings that bound it,
+hash bucket and overflow pages), and `hostCapacity` (memory settings against the host's
+actual RAM and vCPU count — see below).
 
 The monitoring tools take optional `pid` and `query_id` filters, so a symptom can be
 followed to its cause rather than read out of a full dump:
@@ -90,7 +92,7 @@ the tool, which takes precedence over both.
 
 | | |
 |---|---|
-| `man pg_licht_mcp` | configuration, connection strings, all 47 operations, MCP client setup |
+| `man pg_licht_mcp` | configuration, connection strings, all 48 operations, MCP client setup |
 | [INSTALL.md](INSTALL.md) | Homebrew, deb, rpm, tarball, verifying, uninstalling |
 | [BUILD.md](BUILD.md) | building from source, tests, sanitizers, CI, release process |
 | [CHANGES.md](CHANGES.md) | changelog |

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(pg_licht_mcp VERSION 3.0.1 LANGUAGES CXX)
+project(pg_licht_mcp VERSION 3.1.0 LANGUAGES CXX)
 
 # Standard bin/ and share/man/ layout, so `cmake --install` produces a tree that
 # can be dropped onto a prefix as-is: the release tarballs are staged this way,

--- a/cpp/man/pg_licht_mcp.1
+++ b/cpp/man/pg_licht_mcp.1
@@ -212,7 +212,7 @@ Arguments shown as
 are required.
 .Ss Extension schemas
 Operations backed by an extension
-.Pq Ic statementStats , Ic explainQuery No and Ic tableBloat
+.Pq Ic statementStats , Ic explainQuery , Ic tableBloat No and Ic indexBloat
 locate its objects through
 .Li pg_extension
 and reference them schema-qualified.
@@ -838,6 +838,69 @@ visibility-map-based approximation.
 Default
 .Dv false .
 .El
+.It Ic indexBloat Ar schema Ar index
+Physical statistics for one index, from whichever
+.Li pgstattuple
+function fits its access method.
+The access method is resolved from the catalog, so the caller does not need to
+know it in advance.
+.Pp
+.Bl -tag -width "spgist" -compact
+.It Li btree
+.Li pgstatindex :
+.Va version , tree_level , root_block_no , internal_pages , leaf_pages ,
+.Va empty_pages , deleted_pages , avg_leaf_density
+and
+.Va leaf_fragmentation .
+Reads the whole index.
+.It Li gin
+.Li pgstatginindex :
+.Va version , pending_pages
+and
+.Va pending_tuples ,
+reported together with the
+.Va fastupdate
+setting and the effective
+.Va pending_list_limit_kb
+that bound them.
+Reads only the metapage, so it is cheap on any size of index.
+.It Li hash
+.Li pgstathashindex :
+.Va version , bucket_pages , overflow_pages , bitmap_pages , unused_pages ,
+.Va live_items , dead_items
+and
+.Va free_percent .
+Reads the whole index.
+.El
+.Pp
+The metrics are deliberately not normalized across access methods, unlike
+.Ic tableBloat Ns 's
+exact and approximate pair:
+.Va leaf_fragmentation
+and
+.Va pending_tuples
+are not two spellings of one quantity.
+.Va access_method
+names which set was returned.
+.Pp
+.Va index_size
+and
+.Va idx_scan
+accompany every result, because they are what the metrics are weighed against:
+a fragmented index that nothing has scanned since the last statistics reset is
+a candidate for dropping rather than for
+.Ql REINDEX .
+.Pp
+.Li gist , spgist
+and
+.Li brin
+have no
+.Li pgstattuple
+function at all and are reported as unsupported by name; their page-level
+detail is in the
+.Li pageinspect
+extension instead.
+A partitioned index has no storage of its own and is reported as such.
 .It Ic checkKey Ar schema Ar table Ar values
 Check whether a row exists by primary key, single or composite.
 Value types are validated against the primary key column types before querying.
@@ -1117,7 +1180,35 @@ The returned hint gives the setup steps.
 An equivalent error is returned for
 .Li pgstattuple
 by
-.Ic tableBloat .
+.Ic tableBloat
+and
+.Ic indexBloat .
+.It Sy permission denied for ...
+Every
+.Li pgstattuple
+function is installed with EXECUTE revoked from
+.Li PUBLIC
+and granted to
+.Li pg_stat_scan_tables ,
+so a role with every read privilege on the data can still be refused the
+statistics.
+The hint names the grant.
+Affects
+.Ic tableBloat
+and
+.Ic indexBloat .
+.It Sy pgstattuple has no statistics function for a ... index
+The index uses
+.Li gist , spgist
+or
+.Li brin ,
+which the extension does not cover.
+The hint names the supported access methods and points at
+.Li pageinspect .
+.It Sy pgstathashindex requires pgstattuple 1.5
+The extension is installed but predates the hash index function.
+Run
+.Ql "ALTER EXTENSION pgstattuple UPDATE" .
 .It Sy SQLSTATE Er 25006
 A statement attempted to write inside the read-only transaction.
 This is the backstop described in

--- a/cpp/src/server.h
+++ b/cpp/src/server.h
@@ -170,6 +170,13 @@ public:
   const json call_table_bloat(const std::string& schema, const std::string& table_name, bool exact) {
     return table_bloat(schema, table_name, exact);
   }
+  const json call_index_bloat(const std::string& schema, const std::string& index_name) {
+    return index_bloat(schema, index_name);
+  }
+  // The tools array as tools/list advertises it, so a query method that exists
+  // but was never registered -- and is therefore unreachable by any client --
+  // fails the suite rather than passing it.
+  const json call_tools_list() { return get_tools_list()["tools"]; }
   const json call_check_key(const std::string& schema, const std::string& table_name, const json& values) {
     return check_key(schema, table_name, values);
   }
@@ -288,6 +295,21 @@ private:
     return {
       {"error", "pgstattuple is not installed"},
       {"hint", "Run: CREATE EXTENSION pgstattuple;"}
+    };
+  }
+
+  // Every pgstattuple function is installed with EXECUTE revoked from PUBLIC
+  // and granted to pg_stat_scan_tables, so a perfectly valid read-only role
+  // gets SQLSTATE 42501 rather than an answer. Left as a raw exception that
+  // reads as an internal failure, it sends the caller looking for a bug
+  // instead of asking for the one grant that fixes it.
+  static json pgstattuple_denied(const std::string& func, const std::string& detail) {
+    return {
+      {"error", "permission denied for " + func},
+      {"hint", "pgstattuple's functions have EXECUTE revoked from PUBLIC and "
+               "granted to pg_stat_scan_tables. Run: GRANT pg_stat_scan_tables "
+               "TO <role>; (or grant EXECUTE on the function directly)"},
+      {"detail", detail}
     };
   }
 
@@ -840,6 +862,19 @@ private:
 		    {"exact",  {{"type", "boolean"}}}
 		  }},
 		{"required", {"schema", "table"}}
+	      }}
+	  },
+	  {
+	    {"name", "indexBloat"},
+	    {"description", "return physical statistics for one index, from whichever pgstattuple function matches its access method: pgstatindex for btree (tree level, leaf/internal/empty/deleted pages, average leaf density, leaf fragmentation), pgstatginindex for GIN (pending list pages and tuples, alongside the fastupdate setting and pending list limit that bound them), pgstathashindex for hash (bucket/overflow/bitmap/unused pages, live and dead items, free percent). The access method is resolved from the catalog, so the caller does not need to know it; gist, spgist and brin are reported as unsupported by name, since pgstattuple has no function for them. Metrics are deliberately NOT normalized across access methods -- 'access_method' says which set came back. Index size and idx_scan travel with the metrics, because a fragmented index nothing has scanned is a candidate for dropping rather than REINDEX. btree and hash read the whole index; GIN reads only the metapage and is always cheap"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", {
+		    {"schema", {{"type", "string"}}},
+		    {"index",  {{"type", "string"},
+				{"description", "the index's own name, not the name of the table it is on"}}}
+		  }},
+		{"required", {"schema", "index"}}
 	      }}
 	  },
 	  {
@@ -3078,6 +3113,217 @@ private:
         forget_extension_schema("pgstattuple");
         return pgstattuple_missing();
       }
+      if (e.sqlstate() == "42501") // insufficient_privilege
+        return pgstattuple_denied("pgstattuple", e.what());
+      throw;
+    }
+  }
+
+  // Compare a pg_extension.extversion against a major.minor floor. Only the
+  // first two components are considered, which is all pgstattuple has ever
+  // used, and an unparsable version is treated as too old rather than assumed
+  // current -- guessing high turns a clear "upgrade the extension" answer into
+  // an undefined-function error.
+  static bool extversion_at_least(const std::string& v, int want_major, int want_minor) {
+    int major = 0, minor = 0;
+    size_t i = 0;
+    if (i >= v.size() || !std::isdigit(static_cast<unsigned char>(v[i]))) return false;
+    while (i < v.size() && std::isdigit(static_cast<unsigned char>(v[i])))
+      major = major * 10 + (v[i++] - '0');
+    if (i < v.size() && v[i] == '.') {
+      i++;
+      while (i < v.size() && std::isdigit(static_cast<unsigned char>(v[i])))
+        minor = minor * 10 + (v[i++] - '0');
+    }
+    return major > want_major || (major == want_major && minor >= want_minor);
+  }
+
+  // Physical statistics for one index, from whichever pgstattuple function
+  // fits its access method.
+  //
+  // The access method is resolved here rather than asked of the caller. The
+  // three functions have nothing in common -- different names, disjoint
+  // column sets, and one of them (pgstatindex) raises a bare "is not a btree
+  // index" when pointed at the wrong kind -- so a caller made to choose would
+  // have to look the index up first, which is the work this tool exists to do.
+  //
+  // The returned metrics are deliberately NOT normalized across access
+  // methods, unlike tableBloat's exact/approx pair: leaf_fragmentation and
+  // pending_tuples are not two spellings of one quantity, and flattening them
+  // into shared field names would invent a comparison that does not exist.
+  // 'access_method' names which set came back.
+  const json index_bloat(const std::string& schema, const std::string& index_name) {
+    Session sess{active_cfg()};
+    pqxx::work& txn = sess.txn();
+
+    const std::string pgst = extension_schema(txn, "pgstattuple");
+    if (pgst.empty()) return pgstattuple_missing();
+
+    // Matched through pg_namespace by name rather than by casting to
+    // regnamespace: the cast raises on a schema that does not exist, and
+    // "no such index" should come back from a diagnostic tool as a stated
+    // result, not as an exception.
+    //
+    // The size and scan count travel with the metrics because they are what
+    // the metrics get weighed against -- a fragmented index nobody has
+    // scanned since the last statistics reset is a candidate for dropping,
+    // not for REINDEX, and that call cannot be made from density alone.
+    const std::string meta_q = R"(
+      SELECT JSONB_BUILD_OBJECT(
+               'oid',           c.oid::text,
+               'relkind',       c.relkind::text,
+               'access_method', COALESCE(am.amname, ''),
+               'schema',        n.nspname,
+               'index',         c.relname,
+               'table',         COALESCE(t.relname, ''),
+               'index_size',    pg_relation_size(c.oid),
+               'idx_scan',      s.idx_scan,
+               -- GIN's pending list is only populated when fastupdate is on,
+               -- and its size is bounded by the reloption if set and by the
+               -- GUC otherwise. pending_pages without them is a number with
+               -- no threshold to read it against.
+               'fastupdate',    (SELECT o.option_value
+                                 FROM pg_options_to_table(c.reloptions) AS o
+                                 WHERE o.option_name = 'fastupdate'),
+               'pending_list_limit_kb',
+                                COALESCE((SELECT o.option_value
+                                          FROM pg_options_to_table(c.reloptions) AS o
+                                          WHERE o.option_name = 'gin_pending_list_limit'),
+                                         current_setting('gin_pending_list_limit', true)),
+               'extension_version',
+                                (SELECT e.extversion FROM pg_extension AS e
+                                 WHERE e.extname = 'pgstattuple')
+             )
+      FROM pg_class AS c
+      JOIN pg_namespace AS n ON n.oid = c.relnamespace
+      LEFT JOIN pg_am AS am ON am.oid = c.relam
+      LEFT JOIN pg_index AS i ON i.indexrelid = c.oid
+      LEFT JOIN pg_class AS t ON t.oid = i.indrelid
+      LEFT JOIN pg_stat_all_indexes AS s ON s.indexrelid = c.oid
+      WHERE n.nspname = $1 AND c.relname = $2;
+    )";
+
+    pqxx::result mres = pqxx_exec(txn, meta_q, pqxx::params{schema, index_name});
+    if (mres.empty() || mres[0][0].is_null()) {
+      return {
+        {"error", "no relation named \"" + schema + "\".\"" + index_name + "\""},
+        {"hint", "indexes are listed per table by tableDetails, and across a "
+                 "schema by duplicateIndexes"}
+      };
+    }
+
+    json meta = json::parse(mres[0][0].as<std::string>());
+    const std::string relkind = json_str(meta, "relkind");
+    const std::string am      = json_str(meta, "access_method");
+
+    // A partitioned index is a catalog entry with no storage of its own; the
+    // pages belong to the per-partition indexes underneath it.
+    if (relkind == "I") {
+      return {
+        {"error", "\"" + schema + "\".\"" + index_name +
+                  "\" is a partitioned index and has no storage of its own"},
+        {"hint", "inspect the index on an individual partition instead; "
+                 "tableDetails on a partition lists them"},
+        {"access_method", am}
+      };
+    }
+    if (relkind != "i") {
+      return {
+        {"error", "\"" + schema + "\".\"" + index_name + "\" is not an index"},
+        {"hint", relkind == "r" || relkind == "m" || relkind == "p"
+                   ? "it looks like a table or materialized view; use tableBloat"
+                   : "indexes are listed per table by tableDetails"}
+      };
+    }
+
+    // gist, spgist and brin have no pgstattuple support at all. Saying so,
+    // and naming what is supported, is the whole difference between a dead
+    // end and a caller who knows to reach for pageinspect.
+    static const std::map<std::string, std::string> FUNCS = {
+      {"btree", "pgstatindex"},
+      {"gin",   "pgstatginindex"},
+      {"hash",  "pgstathashindex"},
+    };
+    auto fn = FUNCS.find(am);
+    if (fn == FUNCS.end()) {
+      return {
+        {"error", "pgstattuple has no statistics function for a " +
+                  (am.empty() ? std::string("(unknown)") : am) + " index"},
+        {"hint", "supported access methods are btree, gin and hash; for gist, "
+                 "spgist and brin the page-level detail is in the pageinspect "
+                 "extension instead"},
+        {"access_method", am}
+      };
+    }
+
+    // pgstathashindex arrived in pgstattuple 1.5. An extension created before
+    // that and never ALTER EXTENSION ... UPDATE'd is a live catalog entry
+    // missing exactly this function, which would otherwise surface as the
+    // extension being absent -- it is not, it is out of date.
+    const std::string extver = json_str(meta, "extension_version");
+    if (fn->second == "pgstathashindex" && !extversion_at_least(extver, 1, 5)) {
+      return {
+        {"error", "pgstathashindex requires pgstattuple 1.5, but version " +
+                  (extver.empty() ? std::string("(unknown)") : extver) +
+                  " is installed"},
+        {"hint", "Run: ALTER EXTENSION pgstattuple UPDATE;"},
+        {"access_method", am}
+      };
+    }
+
+    // Column lists per access method, spelled out rather than SELECT *: the
+    // shape is part of this tool's contract, and a column added by a future
+    // extension version should not silently change it.
+    static const std::map<std::string, std::string> COLUMNS = {
+      {"btree",
+       "'version', s.version, 'tree_level', s.tree_level,"
+       " 'root_block_no', s.root_block_no, 'internal_pages', s.internal_pages,"
+       " 'leaf_pages', s.leaf_pages, 'empty_pages', s.empty_pages,"
+       " 'deleted_pages', s.deleted_pages, 'avg_leaf_density', s.avg_leaf_density,"
+       " 'leaf_fragmentation', s.leaf_fragmentation"},
+      {"gin",
+       "'version', s.version, 'pending_pages', s.pending_pages,"
+       " 'pending_tuples', s.pending_tuples"},
+      {"hash",
+       "'version', s.version, 'bucket_pages', s.bucket_pages,"
+       " 'overflow_pages', s.overflow_pages, 'bitmap_pages', s.bitmap_pages,"
+       " 'unused_pages', s.unused_pages, 'live_items', s.live_items,"
+       " 'dead_items', s.dead_items, 'free_percent', s.free_percent"},
+    };
+
+    // The oid is resolved above and passed back as text, so the function
+    // argument is a bind parameter and not the caller's identifier.
+    const std::string stat_q =
+      "SELECT JSONB_BUILD_OBJECT(" + COLUMNS.at(am) + ")"
+      " FROM " + pgst + "." + fn->second + "($1::oid::regclass) AS s;";
+
+    try {
+      pqxx::result res = pqxx_exec(txn, stat_q, pqxx::params{json_str(meta, "oid")});
+      if (res.empty() || res[0][0].is_null()) return {};
+
+      json out = json::parse(res[0][0].as<std::string>());
+      out["schema"]        = meta["schema"];
+      out["index"]         = meta["index"];
+      out["table"]         = meta["table"];
+      out["access_method"] = am;
+      out["index_size"]    = meta["index_size"];
+      out["idx_scan"]      = meta["idx_scan"];
+      // Only meaningful for GIN, and misleading anywhere else.
+      if (am == "gin") {
+        // fastupdate defaults to on, and the reloption is absent until it is
+        // set explicitly, so a null here is "on" rather than "unknown".
+        out["fastupdate"] = meta["fastupdate"].is_null()
+          ? json("on") : meta["fastupdate"];
+        out["pending_list_limit_kb"] = meta["pending_list_limit_kb"];
+      }
+      return out;
+    } catch (const pqxx::sql_error& e) {
+      if (e.sqlstate() == "42883") { // undefined_function
+        forget_extension_schema("pgstattuple");
+        return pgstattuple_missing();
+      }
+      if (e.sqlstate() == "42501") // insufficient_privilege
+        return pgstattuple_denied(fn->second, e.what());
       throw;
     }
   }
@@ -4399,6 +4645,11 @@ private:
 	  std::string target_table  = arguments.contains("table")  ? arguments["table"].get<std::string>()  : "";
 	  bool exact = arguments.contains("exact") ? arguments["exact"].get<bool>() : false;
 	  result_content = table_bloat(target_schema, target_table, exact);
+	}
+	else if (tool_name == "indexBloat") {
+	  std::string target_schema = arguments.contains("schema") ? arguments["schema"].get<std::string>() : "public";
+	  std::string target_index  = arguments.contains("index")  ? arguments["index"].get<std::string>()  : "";
+	  result_content = index_bloat(target_schema, target_index);
 	}
 	else if (tool_name == "checkKey") {
 	  std::string target_schema = arguments.contains("schema") ? arguments["schema"].get<std::string>() : "public";

--- a/cpp/src/test_main.cpp
+++ b/cpp/src/test_main.cpp
@@ -292,6 +292,31 @@ protected:
       // report the storage parameter rather than the server-wide default.
       txn.exec("ALTER TABLE grocery.index_zoo SET (autovacuum_freeze_max_age = 100000000)");
 
+      // One index per access method indexBloat has to tell apart. They live on
+      // index_zoo rather than on users so the index counts asserted elsewhere
+      // stay put. The GIN index carries explicit fastupdate and
+      // gin_pending_list_limit settings, since those are what make its
+      // pending_pages readable and the tool reports them alongside.
+      txn.exec("CREATE TABLE grocery.index_ams (id INT, doc TEXT, tags TEXT[], box_col BOX)");
+      txn.exec("INSERT INTO grocery.index_ams(id, doc, tags, box_col)"
+               " SELECT g, 'doc ' || g, ARRAY['t' || (g % 7), 'all'],"
+               "        BOX(POINT(g, g), POINT(g + 1, g + 1))"
+               " FROM generate_series(1, 500) AS g");
+      txn.exec("CREATE INDEX ams_btree ON grocery.index_ams (id)");
+      txn.exec("CREATE INDEX ams_gin   ON grocery.index_ams USING gin (tags)"
+               " WITH (fastupdate = on, gin_pending_list_limit = 128)");
+      txn.exec("CREATE INDEX ams_hash  ON grocery.index_ams USING hash (id)");
+      // gist has no pgstattuple function at all; the tool must say so by name
+      // rather than fail with a bare error from the wrong function.
+      txn.exec("CREATE INDEX ams_gist  ON grocery.index_ams USING gist (box_col)");
+      txn.exec("ANALYZE grocery.index_ams");
+
+      // A partitioned index is a catalog entry with no storage of its own.
+      txn.exec("CREATE TABLE grocery.index_parted (id INT, val TEXT) PARTITION BY RANGE (id)");
+      txn.exec("CREATE TABLE grocery.index_parted_p1 PARTITION OF grocery.index_parted"
+               " FOR VALUES FROM (0) TO (100)");
+      txn.exec("CREATE INDEX parted_id_idx ON grocery.index_parted (id)");
+
       txn.exec("GRANT USAGE ON SCHEMA grocery TO PUBLIC");
       txn.exec("GRANT SELECT ON grocery.users TO PUBLIC");
       txn.exec("GRANT EXECUTE ON FUNCTION grocery.get_user_count() TO PUBLIC");
@@ -1694,6 +1719,106 @@ TEST_F(PostgresMCPServerTest, TableBloatExactReturnsExpectedFields) {
 TEST_F(PostgresMCPServerTest, TableBloatUnknownTableReturnsEmpty) {
   json result = srv->call_table_bloat("grocery", "does_not_exist", false);
   EXPECT_TRUE(result.empty());
+}
+
+// --- indexBloat ---
+//
+// pgstattuple lives in the "extensions" schema in this fixture (see
+// SetUpTestSuite), so every one of these also exercises schema qualification:
+// none of the three functions is reachable through the default search_path.
+
+TEST_F(PostgresMCPServerTest, IndexBloatBtreeReturnsPgstatindexFields) {
+  json r = srv->call_index_bloat("grocery", "ams_btree");
+  ASSERT_FALSE(r.contains("error")) << r.dump(2);
+  EXPECT_EQ(r["access_method"].get<std::string>(), "btree");
+  EXPECT_EQ(r["index"].get<std::string>(), "ams_btree");
+  EXPECT_EQ(r["table"].get<std::string>(), "index_ams");
+  EXPECT_EQ(r["schema"].get<std::string>(), "grocery");
+  for (const char* f : {"version", "tree_level", "root_block_no", "internal_pages",
+                        "leaf_pages", "empty_pages", "deleted_pages",
+                        "avg_leaf_density", "leaf_fragmentation"})
+    EXPECT_TRUE(r.contains(f)) << f << " missing from " << r.dump(2);
+  EXPECT_GT(r["index_size"].get<long long>(), 0);
+  EXPECT_GT(r["leaf_pages"].get<long long>(), 0);
+  // GIN-only fields must not leak onto a btree result.
+  EXPECT_FALSE(r.contains("pending_pages"));
+  EXPECT_FALSE(r.contains("fastupdate"));
+}
+
+TEST_F(PostgresMCPServerTest, IndexBloatGinReturnsPendingListWithItsBounds) {
+  json r = srv->call_index_bloat("grocery", "ams_gin");
+  ASSERT_FALSE(r.contains("error")) << r.dump(2);
+  EXPECT_EQ(r["access_method"].get<std::string>(), "gin");
+  ASSERT_TRUE(r.contains("pending_pages")) << r.dump(2);
+  ASSERT_TRUE(r.contains("pending_tuples"));
+  EXPECT_TRUE(r.contains("version"));
+  EXPECT_GE(r["pending_pages"].get<long long>(), 0);
+
+  // pending_pages is only interpretable against the settings that bound it,
+  // so the tool reports them alongside; both were set explicitly on this index.
+  EXPECT_EQ(r["fastupdate"].get<std::string>(), "on");
+  EXPECT_EQ(r["pending_list_limit_kb"].get<std::string>(), "128");
+
+  // btree-only fields must not leak onto a GIN result.
+  EXPECT_FALSE(r.contains("leaf_fragmentation"));
+  EXPECT_FALSE(r.contains("avg_leaf_density"));
+}
+
+TEST_F(PostgresMCPServerTest, IndexBloatHashReturnsBucketAndOverflowPages) {
+  json r = srv->call_index_bloat("grocery", "ams_hash");
+  ASSERT_FALSE(r.contains("error")) << r.dump(2);
+  EXPECT_EQ(r["access_method"].get<std::string>(), "hash");
+  for (const char* f : {"version", "bucket_pages", "overflow_pages", "bitmap_pages",
+                        "unused_pages", "live_items", "dead_items", "free_percent"})
+    EXPECT_TRUE(r.contains(f)) << f << " missing from " << r.dump(2);
+  EXPECT_GT(r["bucket_pages"].get<long long>(), 0);
+  EXPECT_FALSE(r.contains("leaf_pages"));
+}
+
+// The point of resolving the access method from the catalog: a gist index
+// must produce a stated answer naming what is supported, not the bare
+// "relation is not a btree index" that pgstatindex would raise.
+TEST_F(PostgresMCPServerTest, IndexBloatUnsupportedAccessMethodIsNamed) {
+  json r = srv->call_index_bloat("grocery", "ams_gist");
+  ASSERT_TRUE(r.contains("error")) << r.dump(2);
+  EXPECT_NE(r["error"].get<std::string>().find("gist"), std::string::npos);
+  EXPECT_EQ(r["access_method"].get<std::string>(), "gist");
+  ASSERT_TRUE(r.contains("hint"));
+  EXPECT_NE(r["hint"].get<std::string>().find("pageinspect"), std::string::npos);
+}
+
+TEST_F(PostgresMCPServerTest, IndexBloatPartitionedIndexHasNoStorageOfItsOwn) {
+  json r = srv->call_index_bloat("grocery", "parted_id_idx");
+  ASSERT_TRUE(r.contains("error")) << r.dump(2);
+  EXPECT_NE(r["error"].get<std::string>().find("partitioned index"), std::string::npos);
+  EXPECT_TRUE(r.contains("hint"));
+}
+
+TEST_F(PostgresMCPServerTest, IndexBloatOnATableSaysToUseTableBloat) {
+  json r = srv->call_index_bloat("grocery", "users");
+  ASSERT_TRUE(r.contains("error")) << r.dump(2);
+  EXPECT_NE(r["error"].get<std::string>().find("is not an index"), std::string::npos);
+  EXPECT_NE(r["hint"].get<std::string>().find("tableBloat"), std::string::npos);
+}
+
+// An unknown name is a stated result, not an exception -- and an unknown
+// schema must behave the same, which a ::regnamespace cast would not.
+TEST_F(PostgresMCPServerTest, IndexBloatUnknownIndexAndSchemaAreReportedNotThrown) {
+  json r = srv->call_index_bloat("grocery", "does_not_exist");
+  ASSERT_TRUE(r.contains("error")) << r.dump(2);
+  EXPECT_NE(r["error"].get<std::string>().find("no relation named"), std::string::npos);
+
+  json s = srv->call_index_bloat("no_such_schema", "does_not_exist");
+  ASSERT_TRUE(s.contains("error")) << s.dump(2);
+  EXPECT_NE(s["error"].get<std::string>().find("no relation named"), std::string::npos);
+}
+
+TEST_F(PostgresMCPServerTest, IndexBloatIsRegisteredAsATool) {
+  json tools = srv->call_tools_list();
+  bool found = false;
+  for (const auto& t : tools)
+    if (t.value("name", "") == "indexBloat") found = true;
+  EXPECT_TRUE(found) << "indexBloat missing from tools/list";
 }
 
 // --- currentActivity enrichment ---


### PR DESCRIPTION
Adds `indexBloat`, covering `pgstatginindex` along with the other two index functions in `pgstattuple`.

## Why not a `pgstatginindex` tool

`pgstatginindex` returns three columns. A tool that thin, which also requires the caller to know the access method *before* calling it, is the wrong unit — the three functions share no name and no columns, and `pgstatindex` raises a bare `relation "x" is not a btree index` when pointed at the wrong kind. A caller made to choose would have to look the index up first, which is the work the tool exists to do.

So the access method is resolved from the catalog and dispatched on:

| AM | Function | Returned | Cost |
|---|---|---|---|
| btree | `pgstatindex` | `tree_level`, `root_block_no`, `internal_pages`, `leaf_pages`, `empty_pages`, `deleted_pages`, `avg_leaf_density`, `leaf_fragmentation` | whole index |
| gin | `pgstatginindex` | `pending_pages`, `pending_tuples`, plus `fastupdate` and `pending_list_limit_kb` | metapage only |
| hash | `pgstathashindex` | `bucket_pages`, `overflow_pages`, `bitmap_pages`, `unused_pages`, `live_items`, `dead_items`, `free_percent` | whole index |

`gist`, `spgist` and `brin` are reported as unsupported **by name**, pointing at `pageinspect`. A partitioned index is reported as having no storage of its own, and a table is redirected to `tableBloat`.

## Two deliberate choices

**Metrics are not normalized across access methods.** `tableBloat` normalizes its exact/approximate pair so callers need not branch — correct there, wrong here. `leaf_fragmentation` and `pending_tuples` are not two spellings of one quantity, and shared field names would invent a comparison that does not exist. `access_method` says which set came back, and the tests assert that GIN fields never appear on a btree result or vice versa.

**GIN's pending list ships with its bounds.** `pending_pages` only exists when `fastupdate` is on, and its size is meaningless without the limit it is filling toward, so the reloption and the effective `gin_pending_list_limit` come back with it. This is the signal that's otherwise invisible: nothing in `pg_stat_user_indexes` shows a pending-list backlog, and it's what quietly degrades GIN search latency between autovacuums.

`index_size` and `idx_scan` accompany every result — a fragmented index nothing has scanned since the last stats reset is a candidate for dropping, not `REINDEX`, and that call can't be made from density alone.

## Bug fixed along the way

Every `pgstattuple` function is installed `REVOKE EXECUTE ... FROM PUBLIC` / `GRANT ... TO pg_stat_scan_tables`. A role holding every read privilege on the data is still refused with SQLSTATE 42501, which `tableBloat` did not catch — it surfaced as an unhandled exception reading like an internal fault, sending the caller after a bug rather than after the one grant that fixes it. Both tools now return the error with the grant named.

`pgstathashindex` also only exists from pgstattuple 1.5, so an extension created earlier and never `ALTER EXTENSION ... UPDATE`d is version-checked and told to update, rather than reported as absent.

## Testing

8 new tests, 231 total, passing directly and through the transaction-mode pooler. The fixture gains one index per access method plus a gist index and a partitioned index; since `pgstattuple` lives in the `extensions` schema there, all of these also exercise the schema qualification from #5.

One gap the unit tests could not close: they construct the server directly, so nothing covered `tools/list` registration or `handle_request` dispatch. Added a registration test, and verified the whole path end to end over the real stdio protocol against a throwaway cluster — a 24k-row table where the GIN index reports a populated pending list:

```json
{ "access_method": "gin", "index": "t_gin", "table": "t",
  "pending_pages": 10, "pending_tuples": 4000,
  "fastupdate": "on", "pending_list_limit_kb": "4096",
  "index_size": 163840, "idx_scan": 0, "version": 2 }
```
