### PR TITLE
v3.1.1: release workflow recovers from a failed re-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,25 @@ jobs:
 
       - name: Create GitHub release
         run: |
+          # Idempotent, so re-running this job after a later step fails does not
+          # dead-end here. `gh release create` errors with "a release with the
+          # same tag name already exists", which aborts the job before the
+          # Homebrew step it was re-run to reach -- the release is made once,
+          # every step after it is not, and only the retry path notices.
+          if gh release view "${{ github.ref_name }}" --repo ${{ github.repository }} >/dev/null 2>&1; then
+            echo "Release ${{ github.ref_name }} exists; refreshing its assets."
+            gh release upload "${{ github.ref_name }}" \
+              --repo ${{ github.repository }} \
+              --clobber \
+              pg_licht_mcp-linux-x86_64.tar.gz \
+              pg_licht_mcp-linux-arm64.tar.gz \
+              pg_licht_mcp-linux-x86_64-debian13.deb \
+              pg_licht_mcp-linux-arm64-debian13.deb \
+              pg_licht_mcp-linux-x86_64-rocky9.rpm \
+              pg_licht_mcp-linux-arm64-rocky9.rpm \
+              pg_licht_mcp-macos-arm64.tar.gz
+            exit 0
+          fi
           gh release create ${{ github.ref_name }} \
             --repo ${{ github.repository }} \
             --title "pg_licht_mcp ${{ github.ref_name }}" \
@@ -211,13 +230,44 @@ jobs:
       - name: Update Homebrew formula
         env:
           TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAP_REPO: sqlambda/homebrew-pg-licht
         run: |
-          git clone "https://x-access-token:${TAP_TOKEN}@github.com/sqlambda/homebrew-pg-licht.git" tap
+          # A dead token reaches git as an empty or rejected credential, and git
+          # reports it as "Password authentication is not supported" -- which
+          # reads like the workflow tried to send a password, and sends whoever
+          # is debugging it after the wrong problem entirely. Diagnose it here
+          # instead, before anything is cloned or pushed.
+          if [ -z "$TAP_TOKEN" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN is not set on this repository." \
+                 "Create a fine-grained PAT scoped to ${TAP_REPO} with" \
+                 "Contents: Read and write, then: gh secret set HOMEBREW_TAP_TOKEN"
+            exit 1
+          fi
+          if ! curl -sf -o /dev/null -H "Authorization: Bearer ${TAP_TOKEN}" \
+                 "https://api.github.com/repos/${TAP_REPO}"; then
+            echo "::error::HOMEBREW_TAP_TOKEN cannot read ${TAP_REPO} -- it is" \
+                 "expired, revoked, or not scoped to that repository." \
+                 "Fine-grained PATs default to a 30-day expiry; mint a new one" \
+                 "with Contents: Read and write and re-run this job."
+            exit 1
+          fi
+
+          # The tap is public, so the clone needs no credential. Keeping the
+          # token out of the clone URL also keeps it out of the checkout's
+          # .git/config, where any later `git remote -v` would print it.
+          git clone --depth 1 "https://github.com/${TAP_REPO}.git" tap
           cd tap
           sed -i "s|refs/tags/v[^/]*.tar.gz|refs/tags/${{ github.ref_name }}.tar.gz|" Formula/pg-licht.rb
           sed -i "s/sha256 \"[a-f0-9]\{64\}\"/sha256 \"${{ steps.sha.outputs.sha256 }}\"/" Formula/pg-licht.rb
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add Formula/pg-licht.rb
-          git diff --cached --quiet || git commit -m "Update pg-licht to ${{ github.ref_name }}"
-          git push
+          if git diff --cached --quiet; then
+            echo "Formula already at ${{ github.ref_name }}; nothing to push."
+            exit 0
+          fi
+          git commit -m "Update pg-licht to ${{ github.ref_name }}"
+          # Credential supplied per-invocation rather than stored in the remote,
+          # so it lives only in this process and not on the runner's disk.
+          git push "https://x-access-token:${TAP_TOKEN}@github.com/${TAP_REPO}.git" \
+                   "HEAD:$(git rev-parse --abbrev-ref HEAD)"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## 3.1.0 (2026-08-12)
+## 3.1.1 (2026-08-18)
+
+### Fixed
+
+- **The release workflow no longer dead-ends when it is re-run.** `Create GitHub release` ran `gh release create` unconditionally, and that command fails with "a release with the same tag name already exists" once the release is there. The two steps that follow it — the source checksum and the Homebrew formula update — therefore became unreachable the moment anything after the release creation failed: the release is made once, everything after it is not, and re-running the job to reach those steps fails at the first one instead. Recovering meant deleting a published release, with its download links, to get back to a state the job could run from.
+
+  The step now checks whether the release exists and refreshes its assets with `gh release upload --clobber` instead, so the job is idempotent from the release onward and a re-run resumes at whatever actually failed. This is what stranded 3.1.0's tap update at 3.0.1.
+
+- **The Homebrew tap step says what is wrong with its token.** The step cloned the tap with the token embedded in the URL, so an expired or missing `HOMEBREW_TAP_TOKEN` surfaced as git's generic `remote: Invalid username or token. Password authentication is not supported for Git operations.` That message describes the credential git *fell back to*, not the one the workflow supplied, and it reads like the workflow transmitted a password — sending whoever is debugging it after a leak that never happened rather than after an expiry. Fine-grained tokens default to 30 days, so this is a failure the workflow should expect.
+
+  The token is now checked before anything is cloned: empty is reported as an unset secret, and a token the GitHub API rejects for the tap repository is reported as expired, revoked, or misscoped, each naming the permission to grant. The clone itself dropped the credential — the tap is public and never needed one — which also keeps the token out of the checkout's `.git/config`, and the push supplies it per-invocation rather than storing it in a remote.
+
+## 3.1.0 (2026-08-18)
 
 ### New tools
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(pg_licht_mcp VERSION 3.1.0 LANGUAGES CXX)
+project(pg_licht_mcp VERSION 3.1.1 LANGUAGES CXX)
 
 # Standard bin/ and share/man/ layout, so `cmake --install` produces a tree that
 # can be dropped onto a prefix as-is: the release tarballs are staged this way,


### PR DESCRIPTION
Release-tooling only — no change to the server binary's behaviour, no tool added or altered.

## What broke

Tagging 3.1.0 created the GitHub release, then failed updating the Homebrew tap on an expired `HOMEBREW_TAP_TOKEN`. Re-running the job after replacing the token failed again, this time at `Create GitHub release`:

```
a release with the same tag name already exists: v3.1.0
```

`gh release create` is not idempotent, so once the release exists the step aborts the job before reaching the two steps after it — the source checksum and the tap update. Those steps became unreachable by re-run, and the only way back to a runnable state was deleting a published release along with its download links. The tap is still serving 3.0.1 as a result.

## Changes

**`Create GitHub release` is idempotent.** If the release already exists the step refreshes its assets with `gh release upload --clobber` and continues, so a re-run resumes at whatever actually failed rather than dying at the first step.

**The tap step diagnoses its own token.** Previously the token was embedded in the clone URL, so a bad one surfaced as git's generic `remote: Invalid username or token. Password authentication is not supported for Git operations.` — a message about the credential git fell back to, not the one supplied, which reads like a password was transmitted and sends the reader after a leak rather than an expiry. Fine-grained PATs default to 30 days, so this is an expected failure and worth a real error message.

The token is now validated before anything is cloned, distinguishing an unset secret from one the API rejects for the tap repo, each naming the permission to grant. The clone dropped its credential entirely — the tap is public and never needed one — which also keeps the token out of the checkout's `.git/config`, and the push supplies it per-invocation rather than persisting it in a remote.

## Note

Both 3.1.1 and 3.1.0 are dated 2026-08-18 in `CHANGES.md`; 3.1.0's entry previously read 2026-08-12, which predated its actual release (published `2026-08-18T02:43Z`, tagged `2026-08-17 23:36 -0300`). Say the word if you would rather it read 2026-08-17 to match the tag in local time.

## Verification

`release.yml` parses as YAML and both edited `run:` blocks pass `bash -n`. The workflow changes cannot be exercised before merge — a tag-triggered run uses the workflow as of the tagged commit — so tagging v3.1.1 from `main` after merge is itself the test, and it will carry the tap to 3.1.1 without a manual edit.