### PR TITLE
v3.2.1: bound the sweep's connect, bound every statement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,107 @@
 # Changelog
 
+## 3.2.1 (2026-08-21)
+
+Three fixes to behaviour shipped in 3.2.0 and earlier. No payload shape
+changed and no configuration file needs an edit, but one default did change:
+every call now runs under a `statement_timeout`.
+
+### Fixed
+
+- **A fan-out sweep did not bound the connection that did its work.** 3.2.0
+  added `with_connect_timeout()` so that "one unreachable host must cost
+  seconds, not whatever the kernel's TCP timeout happens to be", and applied it
+  in `verifyTopology` and in the optional role probe. The connection each
+  member's tool actually opened went through `active_cfg()` instead, which
+  returns the configured conninfo unchanged — and nothing supplies a default
+  `connect_timeout`.
+
+  A member that refuses a connection fails immediately, so this was invisible
+  in testing; a member that *drops* the packets — a decommissioned database, a
+  security group that changed, a host that went away — cost the kernel's
+  SYN-retry budget instead. On a Linux default of six retries that is about
+  two minutes, and sweeps are sequential, so each such member added two minutes
+  to the whole call. A handful of stale sections in a connections file was the
+  difference between a sweep that took seconds and one that took a quarter of
+  an hour.
+
+  There was an inversion in it worth naming: a sweep narrowed with
+  `role: "primary"` was fast, because the role probe *was* bounded and skipped
+  the member before its tool ever ran, while the same sweep without a role
+  filter was slow. Fast when narrowed and slow when not is the opposite of what
+  anyone would predict, which is part of why this took a while to see.
+
+  The sweep now swaps in a bounded copy of the member's config for the whole of
+  that member's turn, so every connection it opens carries the 5-second limit,
+  not just the probe. The regression test uses a TEST-NET-1 address
+  (192.0.2.1, RFC 5737) rather than a refused port, because a refused port
+  never exercises a timeout at all: against the previous code that test takes
+  134 seconds and fails, against this one it takes 5 and passes.
+
+- **Only `explainQuery` bounded how long a statement could run.** `Session`
+  took a `timeout_ms` defaulting to 0 and issued `SET LOCAL statement_timeout`
+  only when it was positive, and `explainQuery` was the sole caller that passed
+  one. Every other operation — all fifty-odd — ran with no upper bound.
+
+  For a catalog read that is academic. It is not academic for the three whose
+  cost scales with the server rather than with the query: `tableBloat` calls
+  `pgstattuple()`, a full sequential scan of the table (and `pgstattuple_approx()`,
+  the default, still reads every page the visibility map does not mark
+  all-visible, which on a write-heavy table is most of them); `indexBloat` reads
+  the whole index for btree and hash; and `bufferCacheContents` scans every
+  buffer in `shared_buffers`. On the machines this server is written for, those
+  are the calls that run for ten minutes, and nothing stopped them.
+
+  Nor could an operator stop them. `statement_timeout` is a GUC rather than a
+  libpq keyword, so it cannot go in a conninfo, and the `options` keyword that
+  could carry it is rejected at parse time — with a message that said pg-licht
+  "sets what it needs per transaction (BEGIN READ ONLY, SET LOCAL
+  statement_timeout) instead". The first half was true and the second was not,
+  so the message blocked the only available workaround by pointing at a setting
+  that was not being applied.
+
+  Every transaction now sets `statement_timeout`, defaulting to 120000ms and
+  configurable per connection with `statement_timeout_ms` (0 restores the old
+  unbounded behaviour), or with `PG_LICHT_STATEMENT_TIMEOUT_MS` on the single
+  `DATABASE_URL` path. It is transaction-scoped for the same reason the
+  read-only guard is: that is the scope a transaction-mode pooler preserves.
+  The `options` message now names the key that actually works.
+
+  A statement that reaches the ceiling is reported as the ceiling being
+  reached, with the value and the key to raise it, rather than as an execution
+  error — the two call for opposite responses and PostgreSQL's own message does
+  not distinguish them for the caller. Testing `sqlstate() == "57014"` is
+  reliable here, unlike the `42501` comparison fixed in 3.2.0: libpqxx has no
+  dedicated class for a cancelled statement, so it arrives as a plain
+  `pqxx::sql_error` that does carry its code. Verified against libpqxx 7.10,
+  the same version that leaves it empty on `insufficient_privilege`.
+
+- **`bufferCacheContents` measured every cached relation to return twenty.**
+  `pg_relation_size()` was called inside the CTE that resolved relation names,
+  so it ran once per relation holding a buffer and the `LIMIT` applied after.
+  Each call is a `stat()`. On a 16GB `shared_buffers` instance with 12,417
+  relations, that was 9,762 syscalls to produce 20 rows; on network storage
+  with a cold dentry cache it is the dominant cost of the tool. The limit is
+  now applied before any fork is measured. Measured at 513ms → 464ms locally,
+  where `stat()` is nearly free; the gap widens with the storage.
+
+  The join to `pg_class` was left alone deliberately. It reads
+  `pg_relation_filenode(c.oid)`, which cannot use
+  `pg_class_tblspc_relfilenode_index`, but a mapped catalog carries
+  `relfilenode = 0` in `pg_class` and can only be resolved through that
+  function — so an index-friendly predicate would drop exactly the relations
+  that are most heavily cached. Measured at ~25ms of 513ms, it is not where the
+  time goes.
+
+### Known limitations
+
+- The cost of `bufferCacheContents` and `bufferCacheSummary` is O(`shared_buffers`)
+  and independent of any argument: `pg_buffercache` materialises one row per
+  buffer before any `WHERE` clause is evaluated, so narrowing the question does
+  not narrow the scan. Measured at 2.1M buffers: 465ms for the contents,
+  5ms for the summary, which uses `pg_buffercache_summary()` and never
+  materialises rows. Prefer the summary for routine checks.
+
 ## 3.2.0 (2026-08-20)
 
 No existing tool's payload shape changed, and a legacy protocol response is

--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ so even a bug that let a query attempt a write would fail rather than succeed si
 That guard is transaction-scoped rather than session-scoped, which is what makes it hold
 behind a connection pooler in transaction mode.
 
+The same transaction sets `statement_timeout`, so no call can occupy a backend
+indefinitely. It defaults to two minutes and is per connection:
+
+```ini
+[billing_prod]
+service              = billing-prod
+statement_timeout_ms = 600000      ; 0 removes the ceiling
+```
+
+Most operations are catalog reads that never approach it. The ones that can are
+those whose cost scales with the server rather than with the query —
+`tableBloat` with `exact: true`, `indexBloat` on a btree or hash index, and
+`bufferCacheContents` — so raise it for a connection where such a scan is the
+point of the call. Reaching it is reported as the ceiling being reached, naming
+the value and the key to change, rather than as an error.
+
 Full rationale, including the guarded exception for `explainQuery`, is in the
 SECURITY CONSIDERATIONS section of `man pg_licht_mcp`.
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(pg_licht_mcp VERSION 3.2.0 LANGUAGES CXX)
+project(pg_licht_mcp VERSION 3.2.1 LANGUAGES CXX)
 
 # Standard bin/ and share/man/ layout, so `cmake --install` produces a tree that
 # can be dropped onto a prefix as-is: the release tarballs are staged this way,

--- a/cpp/man/pg_licht_mcp.1
+++ b/cpp/man/pg_licht_mcp.1
@@ -237,8 +237,63 @@ The key
 is rejected.
 PgBouncer refuses GUCs in the startup packet, so
 .Nm
-sets what it needs per transaction instead; see
+sets what it needs per transaction instead \(em the read-only guard always, and
+.Va statement_timeout
+from
+.Va statement_timeout_ms
+below; see
 .Sx SECURITY CONSIDERATIONS .
+.Ss The statement ceiling
+Every transaction sets
+.Va statement_timeout ,
+so no single call can run without an upper bound.
+The default is 120000 milliseconds.
+Set it per section:
+.Bd -literal -offset indent
+[prod]
+service              = billing-prod
+statement_timeout_ms = 300000
+
+[wan]
+service              = analytics-eu
+statement_timeout_ms = 15000
+.Ed
+.Pp
+A value of 0 removes the ceiling and leaves the server's own
+.Va statement_timeout
+untouched, which is the behaviour of 3.2.0 and earlier.
+With a single
+.Ev DATABASE_URL ,
+use
+.Ev PG_LICHT_STATEMENT_TIMEOUT_MS
+instead.
+.Pp
+Most operations are catalog reads that finish in milliseconds and never
+approach it.
+The ones that can are those whose cost scales with the server rather than with
+the query:
+.Ic tableBloat
+with
+.Va exact
+true,
+.Ic indexBloat
+on a btree or hash index, and
+.Ic bufferCacheContents ,
+which scans every buffer in
+.Va shared_buffers .
+Raise it for the connection when such a scan is the point of the call.
+.Pp
+A statement that reaches the ceiling is reported as the ceiling being reached,
+with the value and the key to change, rather than as an execution error:
+nothing went wrong, the answer simply needs longer than the connection allows.
+.Pp
+Like the read-only guard, the ceiling is transaction-scoped rather than
+session-scoped, which is what makes it survive a transaction-mode pooler.
+It cannot be carried in the conninfo:
+.Va statement_timeout
+is a GUC rather than a libpq keyword, and the
+.Va options
+keyword that could carry it is the one PgBouncer rejects.
 .Ss Host capacity
 Total RAM and vCPU count belong to the machine, not to the cluster.
 PostgreSQL has no catalog for them, and a backend could not read them portably
@@ -1264,6 +1319,16 @@ Number of vCPUs or cores on the host, under the same rule.
 Free-text storage description, under the same rule.
 .It Ev PG_LICHT_HOST_NOTE
 Free-text note about the host, under the same rule.
+.It Ev PG_LICHT_STATEMENT_TIMEOUT_MS
+Upper bound in milliseconds on any one statement; 0 removes it.
+Defaults to 120000.
+Honoured only with the single-connection
+.Ev DATABASE_URL
+form; with a connections file, use
+.Va statement_timeout_ms
+in the section instead.
+See
+.Sx The statement ceiling .
 .It Ev PGSERVICEFILE
 Path to a libpq service file, used to resolve a
 .Va service
@@ -1636,3 +1701,10 @@ The setting cannot be pushed into the connection string either: PgBouncer
 rejects GUCs in the startup packet outright, which is why the
 .Va options
 configuration key is refused.
+.Pp
+.Va statement_timeout
+is set on the same transaction and for the same reason, so no call can occupy a
+backend indefinitely.
+See
+.Sx The statement ceiling
+for the value and how to change it.

--- a/cpp/src/config.h
+++ b/cpp/src/config.h
@@ -24,6 +24,23 @@
 
 namespace pglicht {
 
+// How long any one statement may run before the server cancels it.
+//
+// Every tool but explainQuery ran unbounded until 3.2.1. Most of them are
+// catalog reads that finish in milliseconds, but tableBloat and indexBloat
+// call pgstattuple functions that read the whole relation, and bufferCacheContents
+// scans every buffer in shared_buffers -- all three grow with the server rather
+// than with the query, so the same call that is instant on a laptop runs for
+// minutes on the machine it was written for. Unbounded is the wrong default
+// there: a diagnostic tool that hangs is worse than one that says it gave up.
+//
+// Two minutes is chosen to be longer than any catalog read can plausibly take
+// and shorter than an operator's patience during an incident. It is a ceiling,
+// not a budget: nothing waits for it in the normal case. Raise it per
+// connection with statement_timeout_ms when a deliberate pgstattuple scan of a
+// large table is the point of the call, or set 0 to restore 3.2.0 behaviour.
+inline constexpr int kDefaultStatementTimeoutMs = 120000;
+
 // Capacity of the machine the server runs on.
 //
 // Total RAM and vCPU count are properties of the host, not of the cluster:
@@ -94,6 +111,17 @@ struct ConnConfig {
   std::vector<std::string> groups;
 
   HostCapacity capacity;
+
+  // statement_timeout for every transaction opened on this connection, in
+  // milliseconds; 0 disables it. Per connection rather than global because the
+  // ceiling that suits a catalog browsed over a WAN link is not the one that
+  // suits a deliberate pgstattuple scan of a 500GB table.
+  //
+  // It is deliberately not part of conninfo: statement_timeout is a GUC, not a
+  // libpq keyword, so libpq would reject the whole string, and the `options`
+  // keyword that could carry it is rejected by PgBouncer. It is applied per
+  // transaction instead, which is the scope a transaction pooler preserves.
+  int statement_timeout_ms = kDefaultStatementTimeoutMs;
 };
 
 namespace detail {
@@ -168,6 +196,40 @@ inline long long positive_int(const std::string& v, const std::string& where) {
   }
 }
 
+// Like positive_int, but 0 is a meaningful value rather than a mistake.
+//
+// Kept separate rather than adding a flag to positive_int: every existing
+// caller describes a quantity where zero means "unset", and letting one of
+// them accept 0 silently would turn a typo into a disabled feature.
+inline long long non_negative_int(const std::string& v, const std::string& where) {
+  if (v.empty())
+    throw std::runtime_error(where + ": expected a non-negative integer, got an empty value");
+  for (char c : v) {
+    if (!std::isdigit(static_cast<unsigned char>(c)))
+      throw std::runtime_error(where + ": expected a non-negative integer, got \"" + v + "\"");
+  }
+  try {
+    return std::stoll(v);
+  } catch (const std::out_of_range&) {
+    throw std::runtime_error(where + ": value out of range: \"" + v + "\"");
+  }
+}
+
+// A statement_timeout in milliseconds, bounded by what PostgreSQL will take.
+//
+// The GUC is an int, so anything past INT_MAX is not a longer timeout but a
+// different number: narrowing it silently would turn "wait essentially forever"
+// into a few seconds, which is the one direction an operator must never be
+// surprised in. 0 is passed through and means no ceiling.
+inline int statement_timeout_ms(const std::string& v, const std::string& where) {
+  const long long ms = non_negative_int(v, where);
+  if (ms > 2147483647LL)
+    throw std::runtime_error(
+      where + ": " + v + "ms exceeds PostgreSQL's maximum statement_timeout "
+      "(2147483647). Use 0 for no ceiling");
+  return static_cast<int>(ms);
+}
+
 }  // namespace detail
 
 // A set of named connections, plus which one is the default.
@@ -193,6 +255,7 @@ public:
     // the variables describe. With a connections file each section declares
     // its own, since the sections may well live on different machines.
     cfg.capacity = capacity_from_env();
+    cfg.statement_timeout_ms = statement_timeout_from_env();
 
     reg.order_.push_back("default");
     reg.conns_["default"] = cfg;
@@ -369,6 +432,17 @@ public:
     return cap;
   }
 
+  // The statement ceiling for the single-connection path, where there is no
+  // file to carry statement_timeout_ms. Same reasoning as capacity_from_env:
+  // one connection, so there is no question which one the variable describes.
+  static int statement_timeout_from_env() {
+    const char* v = std::getenv("PG_LICHT_STATEMENT_TIMEOUT_MS");
+    if (v == nullptr) return kDefaultStatementTimeoutMs;
+    const std::string s = detail::trim(v);
+    if (s.empty()) return kDefaultStatementTimeoutMs;
+    return detail::statement_timeout_ms(s, "PG_LICHT_STATEMENT_TIMEOUT_MS");
+  }
+
 private:
   std::map<std::string, ConnConfig> conns_;
   std::vector<std::string> order_;
@@ -531,7 +605,19 @@ private:
         throw std::runtime_error(
           path + ": [" + name + "] sets 'options', which PgBouncer rejects as an "
           "unsupported startup parameter. pg-licht sets what it needs per "
-          "transaction (BEGIN READ ONLY, SET LOCAL statement_timeout) instead");
+          "transaction instead: the read-only guard always, and "
+          "statement_timeout from the 'statement_timeout_ms' key in this "
+          "section (default " + std::to_string(kDefaultStatementTimeoutMs) +
+          "ms, 0 to disable)");
+
+      // The statement ceiling. Consumed here rather than passed through:
+      // statement_timeout is a GUC, so libpq would reject the conninfo, and it
+      // is applied per transaction by Session instead.
+      if (key == "statement_timeout_ms") {
+        cfg.statement_timeout_ms = detail::statement_timeout_ms(
+          val, path + ": [" + name + "] statement_timeout_ms");
+        continue;
+      }
 
       // Host capacity keys describe the machine, not the connection. They are
       // consumed here and never reach the conninfo -- libpq would reject the

--- a/cpp/src/server.h
+++ b/cpp/src/server.h
@@ -54,7 +54,11 @@ inline pqxx::result pqxx_exec(pqxx::work& txn, const std::string& sql, P&& param
 //   FATAL: unsupported startup parameter in options: default_transaction_read_only
 class Session {
 public:
-  explicit Session(const pglicht::ConnConfig& cfg, int timeout_ms = 0)
+  // timeout_ms overrides the connection's configured statement ceiling; omit it
+  // and the connection's own value applies. Only explainQuery passes one, since
+  // it is the one tool whose caller states how long it is willing to wait.
+  explicit Session(const pglicht::ConnConfig& cfg,
+                   std::optional<int> timeout_ms = std::nullopt)
     : conn_(cfg.conninfo), txn_(conn_) {
     // Must be the first statement in the transaction. This is the real write
     // backstop: it catches writes a query plan cannot reveal, such as a
@@ -75,13 +79,28 @@ public:
     if (!role.empty() && !role[0][0].is_null())
       in_recovery_ = role[0][0].as<bool>();
     last_observed_role() = this->role();
-    if (timeout_ms > 0) {
-      // set_config(..., is_local => true) is SET LOCAL: transaction-scoped,
-      // and binds the value as a parameter instead of concatenating it.
+
+    // The statement ceiling. Costs one round trip, which is why it is worth
+    // saying what it buys: without it every tool but explainQuery ran with no
+    // upper bound at all, and the three that scale with the server rather than
+    // the query (tableBloat, indexBloat, bufferCacheContents) could run for as
+    // long as the relation or shared_buffers took to read.
+    //
+    // It cannot ride along in the batch above: set_config(..., is_local => true)
+    // is SET LOCAL, transaction-scoped like the read-only guard, and binds the
+    // value as a parameter rather than concatenating it -- and a parameterised
+    // statement cannot be batched with others in one PQexec.
+    statement_timeout_ms_ = timeout_ms.value_or(cfg.statement_timeout_ms);
+    last_statement_timeout_ms() = statement_timeout_ms_;
+    if (statement_timeout_ms_ > 0) {
       pqxx_exec(txn_, "SELECT set_config('statement_timeout', $1, true)",
-                pqxx::params{std::to_string(timeout_ms)});
+                pqxx::params{std::to_string(statement_timeout_ms_)});
     }
   }
+
+  // The ceiling this session applied, so a cancellation can be reported as the
+  // limit being reached rather than as an unexplained error. 0 means none.
+  int statement_timeout_ms() const { return statement_timeout_ms_; }
 
   pqxx::work& txn() { return txn_; }
 
@@ -115,6 +134,17 @@ public:
     return r;
   }
 
+  // The ceiling the most recently constructed Session applied.
+  //
+  // Exists for the same reason and on the same terms as last_observed_role():
+  // exactly one tool call is ever in flight, and each opens one Session. The
+  // reader is the handler that turns a cancellation into a message, which runs
+  // after the Session has been destroyed and so cannot ask it directly.
+  static int& last_statement_timeout_ms() {
+    static int ms = 0;
+    return ms;
+  }
+
   // Server version as an integer (e.g. 160004 for 16.4), from the startup
   // handshake -- no round trip. Used to gate catalog columns and SQL features
   // that don't exist on older majors; correct per connection, which matters
@@ -131,6 +161,7 @@ private:
   pqxx::connection conn_;
   pqxx::work txn_;
   std::optional<bool> in_recovery_;
+  int statement_timeout_ms_ = 0;
 };
 
 class PostgresMCPServer {
@@ -310,11 +341,24 @@ private:
   // Bounded connect for the tools that sweep every configured connection.
   static constexpr int kSweepConnectTimeoutSeconds = 5;
 
+  // The current sweep member's config, carrying the bounded connect.
+  //
+  // Set only while fan_out is running a member, so every query method goes on
+  // reading active_cfg() without learning that a sweep exists -- the same
+  // reason the sweep loop itself lives above dispatch. Without this the bound
+  // reached only the optional role probe, and the connection that did the
+  // actual work waited out the kernel's TCP timeout instead: sweeps are
+  // sequential, so each unreachable member cost the whole sweep about two
+  // minutes on a Linux default of six SYN retries.
+  std::optional<pglicht::ConnConfig> sweep_cfg_;
+
   static std::string app_name() {
     return std::string("pg-licht-cpp/") + PGLICHT_VERSION;
   }
 
-  const pglicht::ConnConfig& active_cfg() const { return registry_.get(active_); }
+  const pglicht::ConnConfig& active_cfg() const {
+    return sweep_cfg_ ? *sweep_cfg_ : registry_.get(active_);
+  }
 
   // Where each extension actually lives, per connection.
   //
@@ -408,6 +452,41 @@ private:
   // (write attempted in a read-only transaction). None of these queries write,
   // so the two cannot be confused here -- but a future caller that does write
   // must not reuse this pattern to report a grant.
+
+  // A statement the server cancelled because it hit statement_timeout.
+  //
+  // Reported as the ceiling being reached rather than as a raw error, because
+  // the two call for opposite responses: an error means something is wrong,
+  // while this means the answer needs longer than the caller allowed -- and the
+  // caller cannot tell which from the message PostgreSQL sends.
+  //
+  // Unlike insufficient_privilege (see above), a cancellation really does carry
+  // its SQLSTATE. libpqxx has no dedicated class for 57014, so it arrives as a
+  // plain pqxx::sql_error with sqlstate() == "57014" -- verified against
+  // libpqxx 7.10, the same version whose empty sqlstate() on
+  // insufficient_privilege made the code comparison there unusable. Testing the
+  // code is right here for exactly the reason it was wrong there, so the two
+  // must not be made to look alike.
+  static bool is_statement_timeout(const pqxx::sql_error& e) {
+    return e.sqlstate() == "57014";
+  }
+
+  static json statement_timeout_error(int timeout_ms, const std::string& detail) {
+    return {
+      {"error", "statement cancelled after " + std::to_string(timeout_ms) +
+                "ms (statement_timeout)"},
+      {"hint", "This is a ceiling, not a failure: the statement was still "
+               "running when it was reached. Raise it for this connection with "
+               "'statement_timeout_ms' in the connections file (or "
+               "PG_LICHT_STATEMENT_TIMEOUT_MS with a single DATABASE_URL), or "
+               "set 0 to remove it. tableBloat with exact=true, indexBloat on a "
+               "btree or hash index, and bufferCacheContents all scale with the "
+               "relation or with shared_buffers rather than with the query, so "
+               "they are the calls that reach it"},
+      {"timeout_ms", timeout_ms},
+      {"detail", detail}
+    };
+  }
 
   // pg_buffercache's two failure shapes. The grant is the interesting one: a
   // valid read-only role missing a monitoring grant is a different problem
@@ -1467,7 +1546,7 @@ private:
 	  },
 	  {
 	    {"name", "bufferCacheContents"},
-	    {"description", "return which relations own shared_buffers, aggregated per relation and fork and ranked by buffers held: cached bytes, percent of that fork resident, percent of shared_buffers consumed, dirty buffers, average usagecount and pins. Never raw per-buffer rows. Answers which relation is driving checkpoint writeback (pair with checkpointStats), whether the visibility-map fork is resident enough for index-only scans to pay off, and -- on a multi-tenant instance -- which database's working set is displacing the others. Only buffers belonging to this database and the shared catalogs can be resolved to names; buffers held by other databases on the same instance are visible to PostgreSQL but deliberately not reported here. Requires the pg_buffercache extension and a role with pg_monitor"},
+	    {"description", "return which relations own shared_buffers, aggregated per relation and fork and ranked by buffers held: cached bytes, percent of that fork resident, percent of shared_buffers consumed, dirty buffers, average usagecount and pins. Never raw per-buffer rows. Answers which relation is driving checkpoint writeback (pair with checkpointStats), whether the visibility-map fork is resident enough for index-only scans to pay off, and -- on a multi-tenant instance -- which database's working set is displacing the others. Only buffers belonging to this database and the shared catalogs can be resolved to names; buffers held by other databases on the same instance are visible to PostgreSQL but deliberately not reported here. Cost is O(shared_buffers) and does not vary with the limit or with anything else asked: pg_buffercache materialises one row per buffer before any filter applies, so narrowing the question does not narrow the scan. Around 0.5s per 16GB of shared_buffers, and it is subject to the connection's statement_timeout like every other call. bufferCacheSummary reads the same memory through a function that returns one row and is roughly a hundred times cheaper, so prefer it for anything routine. Requires the pg_buffercache extension and a role with pg_monitor"},
 	    {"inputSchema", {
 		{"type", "object"},
 		{"properties", {
@@ -4119,19 +4198,25 @@ private:
         SELECT n.nspname                                 AS schema,
                c.relname                                 AS relation,
                c.relkind                                 AS relkind,
+               c.oid                                     AS reloid,
+               buf.relforknumber,
                CASE buf.relforknumber WHEN 0 THEN 'main' WHEN 1 THEN 'fsm'
                                       WHEN 2 THEN 'vm'   WHEN 3 THEN 'init' END AS fork,
                buf.buffers, buf.dirty, buf.avg_usagecount, buf.pins,
-               buf.buffers * current_setting('block_size')::bigint AS cached_bytes,
-               CASE buf.relforknumber
-                 WHEN 0 THEN pg_relation_size(c.oid, 'main')
-                 WHEN 1 THEN pg_relation_size(c.oid, 'fsm')
-                 WHEN 2 THEN pg_relation_size(c.oid, 'vm')
-                 WHEN 3 THEN pg_relation_size(c.oid, 'init')
-               END                                       AS fork_bytes
+               buf.buffers * current_setting('block_size')::bigint AS cached_bytes
           FROM buf
           JOIN pg_class     AS c ON pg_relation_filenode(c.oid) = buf.relfilenode
           JOIN pg_namespace AS n ON n.oid = c.relnamespace
+      -- Ranking needs only the buffer counts, so the limit is applied before
+      -- any fork is measured. pg_relation_size() is a stat() per call, and
+      -- computing it inside `named` meant one syscall per *cached relation* to
+      -- return `limit` rows -- on a large instance thousands of them, and on
+      -- network storage with a cold dentry cache that is the dominant cost of
+      -- the whole tool. The join stays above the limit so the ranking is still
+      -- over relations that actually resolve, which keeps the result identical
+      -- to what a caller got before.
+      ), top AS (
+        SELECT * FROM named ORDER BY buffers DESC LIMIT $1
       )
       SELECT JSONB_AGG(x ORDER BY x.buffers DESC) FROM (
         SELECT schema, relation, relkind, fork, buffers, dirty, pins,
@@ -4143,9 +4228,15 @@ private:
                      NULLIF((SELECT setting::bigint FROM pg_settings
                               WHERE name = 'shared_buffers'), 0), 2)
                  AS percent_of_shared_buffers
-          FROM named
-         ORDER BY buffers DESC
-         LIMIT $1
+          FROM top
+          CROSS JOIN LATERAL (
+            SELECT CASE top.relforknumber
+                     WHEN 0 THEN pg_relation_size(top.reloid, 'main')
+                     WHEN 1 THEN pg_relation_size(top.reloid, 'fsm')
+                     WHEN 2 THEN pg_relation_size(top.reloid, 'vm')
+                     WHEN 3 THEN pg_relation_size(top.reloid, 'init')
+                   END AS fork_bytes
+          ) AS sz
       ) AS x;
     )";
 
@@ -5432,12 +5523,24 @@ private:
     }
 
     json out = json::array();
+
+    // Clearing on the way out has to survive an exception escaping the loop:
+    // a sweep config left behind would silently redirect the next
+    // single-connection call, which is the kind of bug that only shows up
+    // after the call that caused it has been forgotten.
+    struct SweepScope {
+      std::optional<pglicht::ConnConfig>& slot;
+      ~SweepScope() { slot.reset(); }
+    } sweep_scope{sweep_cfg_};
+
     for (const auto& m : members) {
       // Reset first: a member that never connects must not inherit the
       // previous member's role.
       Session::last_observed_role() = "unknown";
       active_ = m;
       const auto& cfg = registry_.get(m);
+      // Every connect this member makes is bounded, not just the role probe.
+      sweep_cfg_ = with_connect_timeout(cfg, kSweepConnectTimeoutSeconds);
 
       json entry = {{"connection", m}};
       if (!cfg.instance.empty())          entry["instance"] = cfg.instance;
@@ -5450,6 +5553,16 @@ private:
         } else {
           entry["result"] = result;
         }
+      } catch (const pqxx::sql_error& e) {
+        // A member that ran out of time is a finding about that member, not a
+        // failure of the sweep -- and it is the member most worth looking at,
+        // so it must not be flattened into the same string as a refused
+        // connection.
+        if (is_statement_timeout(e))
+          entry["error"] = statement_timeout_error(
+            Session::last_statement_timeout_ms(), e.what());
+        else
+          entry["error"] = e.what();
       } catch (const std::exception& e) {
         // One unreachable host must not fail the sweep: a partial answer
         // during an incident beats an exception.
@@ -5893,6 +6006,23 @@ private:
 	    {"isError", false}
           });
 
+      } catch (const pqxx::sql_error& e) {
+	// Hitting the ceiling is reported as a result rather than an execution
+	// error: nothing went wrong, the answer just needs longer than this
+	// connection allows, and the caller can act on that.
+	if (is_statement_timeout(e)) {
+	  send_response(req["id"], {
+	      {"content", {{{"type", "text"},
+			    {"text", statement_timeout_error(
+			       Session::last_statement_timeout_ms(), e.what()).dump(2)}}}},
+	      {"isError", true}
+	    });
+	} else {
+	  send_response(req["id"], {
+	      {"content", {{{"type", "text"}, {"text", std::string("Execution error: ") + e.what()}}}},
+	      {"isError", true}
+	    });
+	}
       } catch (const std::exception& e) {
 	send_response(req["id"], {
 	    {"content", {{{"type", "text"}, {"text", std::string("Execution error: ") + e.what()}}}},

--- a/cpp/src/test_main.cpp
+++ b/cpp/src/test_main.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <chrono>
 #include <cstdlib>
 #include <unistd.h>
 #include <sstream>
@@ -3109,7 +3110,13 @@ TEST(ConnectionConfigTest, OptionsKeyIsRejectedWithPgBouncerExplanation) {
     load("[default]\ndbname = one\noptions = -c statement_timeout=1000\n");
     FAIL() << "expected 'options' to be rejected";
   } catch (const std::exception& e) {
-    EXPECT_NE(std::string(e.what()).find("PgBouncer"), std::string::npos);
+    std::string msg = e.what();
+    EXPECT_NE(msg.find("PgBouncer"), std::string::npos);
+    // Rejecting the only obvious workaround obliges the message to name the
+    // supported one. Until 3.2.1 it claimed a SET LOCAL statement_timeout that
+    // only explainQuery ever issued, which sent the reader looking for a
+    // setting that was not being applied.
+    EXPECT_NE(msg.find("statement_timeout_ms"), std::string::npos) << msg;
   }
 }
 
@@ -3235,6 +3242,75 @@ TEST(ConnectionConfigTest, FromUrlLeavesUriFormUntouched) {
   // libpq parses URI forms itself; appending keywords would corrupt them.
   auto reg = pglicht::ConnectionRegistry::from_url("postgresql://h/db", "app/1");
   EXPECT_EQ(reg.get("default").conninfo, "postgresql://h/db");
+}
+
+// --- the statement ceiling ---
+
+TEST(ConnectionConfigTest, StatementTimeoutDefaultsWhenNotDeclared) {
+  auto reg = load("[default]\ndbname = one\n");
+  EXPECT_EQ(reg.get("default").statement_timeout_ms,
+            pglicht::kDefaultStatementTimeoutMs);
+}
+
+TEST(ConnectionConfigTest, StatementTimeoutIsPerConnectionAndKeptOutOfTheConninfo) {
+  // The ceiling that suits a catalog browsed over a WAN link is not the one
+  // that suits a deliberate pgstattuple scan, so it is declared per section.
+  auto reg = load("[fast]\ndbname = one\nstatement_timeout_ms = 5000\n"
+                  "[slow]\ndbname = two\nstatement_timeout_ms = 900000\n");
+  EXPECT_EQ(reg.get("fast").statement_timeout_ms, 5000);
+  EXPECT_EQ(reg.get("slow").statement_timeout_ms, 900000);
+  // statement_timeout is a GUC, not a libpq keyword: passed through, it would
+  // make libpq reject the entire conninfo.
+  EXPECT_EQ(reg.get("fast").conninfo.find("statement_timeout"), std::string::npos);
+  EXPECT_EQ(reg.get("slow").conninfo.find("900000"), std::string::npos);
+}
+
+TEST(ConnectionConfigTest, ZeroStatementTimeoutDisablesTheCeiling) {
+  // Unlike the capacity keys, 0 is a value here rather than a typo: it is how
+  // an operator restores the unbounded behaviour of 3.2.0 and earlier.
+  auto reg = load("[default]\ndbname = one\nstatement_timeout_ms = 0\n");
+  EXPECT_EQ(reg.get("default").statement_timeout_ms, 0);
+}
+
+TEST(ConnectionConfigTest, NonNumericStatementTimeoutIsRejectedNamingTheSection) {
+  try {
+    load("[prod]\ndbname = one\nstatement_timeout_ms = 30s\n");
+    FAIL() << "expected a rejection";
+  } catch (const std::exception& e) {
+    std::string msg = e.what();
+    EXPECT_NE(msg.find("prod"), std::string::npos);
+    EXPECT_NE(msg.find("statement_timeout_ms"), std::string::npos);
+    EXPECT_NE(msg.find("30s"), std::string::npos);
+  }
+}
+
+TEST(ConnectionConfigTest, AnOversizedStatementTimeoutIsRejectedRatherThanNarrowed) {
+  // statement_timeout is an int GUC. Narrowing past INT_MAX would turn "wait
+  // essentially forever" into a few seconds, which is the one direction an
+  // operator must never be surprised in.
+  try {
+    load("[prod]\ndbname = one\nstatement_timeout_ms = 99999999999\n");
+    FAIL() << "expected a rejection";
+  } catch (const std::exception& e) {
+    std::string msg = e.what();
+    EXPECT_NE(msg.find("2147483647"), std::string::npos) << msg;
+    EXPECT_NE(msg.find("prod"), std::string::npos) << msg;
+  }
+}
+
+TEST(ConnectionConfigTest, StatementTimeoutComesFromTheEnvironmentForASingleConnection) {
+  ::setenv("PG_LICHT_STATEMENT_TIMEOUT_MS", "7500", 1);
+  auto reg = pglicht::ConnectionRegistry::from_url("dbname=x", "app/1");
+  ::unsetenv("PG_LICHT_STATEMENT_TIMEOUT_MS");
+  EXPECT_EQ(reg.get("default").statement_timeout_ms, 7500);
+  EXPECT_EQ(reg.get("default").conninfo.find("7500"), std::string::npos);
+}
+
+TEST(ConnectionConfigTest, StatementTimeoutFallsBackToTheDefaultWithoutTheEnvironment) {
+  ::unsetenv("PG_LICHT_STATEMENT_TIMEOUT_MS");
+  auto reg = pglicht::ConnectionRegistry::from_url("dbname=x", "app/1");
+  EXPECT_EQ(reg.get("default").statement_timeout_ms,
+            pglicht::kDefaultStatementTimeoutMs);
 }
 
 // --- connection topology ---
@@ -3677,6 +3753,28 @@ TEST_F(PostgresMCPServerTest, BufferCacheContentsRanksRelationsAndResolvesMapped
     << "no mapped catalog resolved; the relfilenode join is wrong: " << r.dump(2);
 }
 
+TEST_F(PostgresMCPServerTest, BufferCacheContentsStillMeasuresTheForksItReturns) {
+  // 3.2.1 moved pg_relation_size() below the limit, so it is called for the
+  // rows returned instead of once per cached relation. The measurement must
+  // still be there: dropping it would turn a cost fix into a payload change.
+  json r = srv->call_buffer_cache_contents(5);
+  ASSERT_FALSE(r.contains("error")) << r.dump(2);
+  ASSERT_FALSE(r["relations"].empty()) << r.dump(2);
+
+  bool measured = false;
+  for (const auto& row : r["relations"]) {
+    ASSERT_TRUE(row.contains("fork_bytes")) << row.dump(2);
+    ASSERT_TRUE(row.contains("cached_bytes")) << row.dump(2);
+    ASSERT_TRUE(row.contains("percent_of_shared_buffers")) << row.dump(2);
+    if (!row["fork_bytes"].is_null() && row["fork_bytes"].get<long long>() > 0) {
+      measured = true;
+      // A fork that holds buffers has a size, and the ratio derived from it.
+      EXPECT_FALSE(row["percent_of_fork_cached"].is_null()) << row.dump(2);
+    }
+  }
+  EXPECT_TRUE(measured) << "no fork was measured at all: " << r.dump(2);
+}
+
 TEST_F(PostgresMCPServerTest, BufferCacheContentsResolvesSharedCatalogs) {
   // reldatabase 0 is the shared catalogs. Filtering them out along with other
   // databases' buffers would drop pg_database and pg_authid entirely.
@@ -3824,6 +3922,61 @@ TEST(SessionRoleTest, ObservesTheReplicaSideOnAStandby) {
   EXPECT_TRUE(s.in_recovery());
 }
 
+// --- the statement ceiling ---
+
+TEST_F(PostgresMCPServerTest, SessionAppliesTheConfiguredStatementTimeout) {
+  // Transaction-scoped, like the read-only guard and for the same reason: a
+  // transaction pooler discards session state but preserves this.
+  auto reg = pglicht::ConnectionRegistry::from_url(test_url, "pg-licht-test");
+  ASSERT_EQ(reg.get("default").statement_timeout_ms,
+            pglicht::kDefaultStatementTimeoutMs);
+
+  Session s{reg.get("default")};
+  EXPECT_EQ(s.statement_timeout_ms(), pglicht::kDefaultStatementTimeoutMs);
+  pqxx::result r = s.txn().exec("SHOW statement_timeout");
+  EXPECT_EQ(r[0][0].as<std::string>(), "2min");
+}
+
+TEST_F(PostgresMCPServerTest, AZeroStatementTimeoutLeavesTheServerDefaultAlone) {
+  // 0 must not be spelled as "0ms": setting it explicitly would override a
+  // server that deliberately configures its own ceiling.
+  auto reg = pglicht::ConnectionRegistry::from_url(test_url, "pg-licht-test");
+  pglicht::ConnConfig cfg = reg.get("default");
+  cfg.statement_timeout_ms = 0;
+
+  Session s{cfg};
+  EXPECT_EQ(s.statement_timeout_ms(), 0);
+  pqxx::result r = s.txn().exec(
+    "SELECT current_setting('statement_timeout') = boot_val "
+    "  FROM pg_settings WHERE name = 'statement_timeout'");
+  EXPECT_TRUE(r[0][0].as<bool>()) << "the session set a timeout it should not have";
+}
+
+TEST_F(PostgresMCPServerTest, AnExceededCeilingArrivesAsSqlstate57014) {
+  // The whole reporting path turns on this code being readable. It is the
+  // mirror image of the insufficient_privilege case fixed in 3.2.0, where
+  // libpqxx leaves sqlstate() empty: here there is no dedicated exception
+  // class, so it arrives as a plain sql_error that does carry its code.
+  auto reg = pglicht::ConnectionRegistry::from_url(test_url, "pg-licht-test");
+  Session s{reg.get("default"), 100};
+  ASSERT_EQ(s.statement_timeout_ms(), 100);
+  try {
+    s.txn().exec("SELECT pg_sleep(3)");
+    FAIL() << "expected the statement to be cancelled";
+  } catch (const pqxx::sql_error& e) {
+    EXPECT_EQ(e.sqlstate(), "57014") << e.what();
+  }
+}
+
+TEST_F(PostgresMCPServerTest, AnExplicitTimeoutOverridesTheConnectionCeiling) {
+  // explainQuery is the one caller that states how long it will wait.
+  auto reg = pglicht::ConnectionRegistry::from_url(test_url, "pg-licht-test");
+  Session s{reg.get("default"), 250};
+  EXPECT_EQ(s.statement_timeout_ms(), 250);
+  pqxx::result r = s.txn().exec("SHOW statement_timeout");
+  EXPECT_EQ(r[0][0].as<std::string>(), "250ms");
+}
+
 TEST_F(PostgresMCPServerTest, RoleIsObservedFreshlyForEverySession) {
   // Nothing caches it: two sessions each ask. A cached role would go stale at
   // a failover, which is exactly when it would be read.
@@ -3860,8 +4013,19 @@ protected:
     return section("default", test_url, extra);
   }
   // A connection that cannot be reached: port 1 refuses immediately.
+  //
+  // Immediately is the point -- this exercises the error path, not the timeout
+  // path. For a host that never answers at all, use blackholed() below; the two
+  // fail in different ways and only the second is bounded by connect_timeout.
   static std::string unreachable(const std::string& name) {
     return "[" + name + "]\nhost = 127.0.0.1\nport = 1\ndbname = nowhere\n";
+  }
+  // A connection whose packets go nowhere. 192.0.2.0/24 is TEST-NET-1
+  // (RFC 5737): reserved for documentation, routed nowhere, so a SYN to it is
+  // dropped rather than refused. That is the case a connect timeout exists
+  // for, and the one a decommissioned or firewalled database presents.
+  static std::string blackholed(const std::string& name, const std::string& extra) {
+    return "[" + name + "]\nhost = 192.0.2.1\nport = 5432\ndbname = nowhere\n" + extra;
   }
   static std::string standby_url_or_empty() {
     const char* u = std::getenv("STANDBY_URL");
@@ -4308,6 +4472,66 @@ TEST_F(TopologyFixture, AnUnreachableMemberDoesNotFailTheSweep) {
   ASSERT_TRUE(p["members"][1].contains("error")) << p.dump(2);
   // A member that never connected must not inherit the previous member's role.
   EXPECT_EQ(p["members"][1]["role"], "unknown");
+}
+
+TEST_F(TopologyFixture, ASweepBoundsTheConnectThatDoesTheWork) {
+  // Until 3.2.1 the bounded connect reached only verifyTopology and the
+  // optional role probe. The connection each member's tool actually opened
+  // went through active_cfg() unbounded, so a blackholed member cost the
+  // kernel's SYN-retry budget -- six retries, about 127 seconds, on a Linux
+  // default -- and sweeps are sequential, so every such member added that to
+  // the whole call.
+  //
+  // The bound is 5 seconds. The assertion is deliberately loose: what it has
+  // to separate is "bounded" from "waiting on the kernel", and any figure
+  // between the two settles that without turning a slow CI runner into a
+  // failure.
+  auto s = server_from(ini_with("group = prod\n") + blackholed("gone", "group = prod\n"));
+
+  const auto start = std::chrono::steady_clock::now();
+  json p = rpc_payload(rpc_call(*s, "listSchemas", {{"group", "prod"}}));
+  const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+      std::chrono::steady_clock::now() - start).count();
+
+  ASSERT_EQ(p["members"].size(), 2u) << p.dump(2);
+  EXPECT_TRUE(p["members"][0].contains("result")) << p.dump(2);
+  ASSERT_TRUE(p["members"][1].contains("error")) << p.dump(2);
+  EXPECT_LT(elapsed, 60) << "the sweep waited on the kernel rather than on "
+                            "connect_timeout: " << elapsed << "s";
+}
+
+TEST_F(TopologyFixture, AnExceededCeilingIsReportedAsTheCeilingNotAnExecutionError) {
+  // A ceiling reached and a query that failed call for opposite responses, and
+  // PostgreSQL's own message does not distinguish them for the caller. 1ms is
+  // below what any catalog read takes, so the tool's own query trips it -- the
+  // read-only guard and set_config both run before it takes effect.
+  auto s = server_from(ini_with("statement_timeout_ms = 1\n"));
+  json r = rpc_call(*s, "listTables", {{"schema", "grocery"}});
+
+  const std::string text = r["result"]["content"][0]["text"].get<std::string>();
+  if (!r["result"]["isError"].get<bool>())
+    GTEST_SKIP() << "the catalog read finished inside 1ms: " << text;
+
+  json p = json::parse(text);
+  ASSERT_TRUE(p.is_object()) << text;
+  EXPECT_NE(p.value("error", "").find("statement_timeout"), std::string::npos) << text;
+  EXPECT_EQ(p.value("timeout_ms", 0), 1) << text;
+  // The hint has to name the knob, or the caller has no way to act on it.
+  EXPECT_NE(p.value("hint", "").find("statement_timeout_ms"), std::string::npos) << text;
+}
+
+TEST_F(TopologyFixture, ASweepLeavesNoBoundedConfigBehindIt) {
+  // The sweep swaps in a connection config carrying the bounded connect. If it
+  // survived the call, the next single-connection call would silently inherit
+  // it -- a bug that only shows up long after the call that caused it.
+  auto s = server_from(ini_with("group = prod\n") +
+                       section("twin", test_url, "group = prod\n"));
+  rpc_payload(rpc_call(*s, "listSchemas", {{"group", "prod"}}));
+
+  json r = rpc_call(*s, "listConnections", json::object());
+  ASSERT_FALSE(r["result"]["isError"].get<bool>()) << r.dump(2);
+  json p = rpc_payload(r);
+  EXPECT_FALSE(p.contains("members")) << p.dump(2);
 }
 
 TEST_F(TopologyFixture, MoreThanOneTargetIsRejected) {

--- a/cpp/test/connections.example.ini
+++ b/cpp/test/connections.example.ini
@@ -27,11 +27,16 @@ instance          = pg-prod-01
 replication_group = app-ha
 group             = prod, app
 
+; statement_timeout_ms is the ceiling on any one call, 120000 by default.
+; Raised here because a deliberate `tableBloat exact:true` on this database is
+; a pgstattuple scan of the whole table, which is the point of the call rather
+; than a runaway. 0 removes the ceiling entirely.
 [billing_prod]
-service           = billing-prod
-instance          = pg-prod-01
-replication_group = billing-ha
-group             = prod, billing
+service              = billing-prod
+instance             = pg-prod-01
+replication_group    = billing-ha
+group                = prod, billing
+statement_timeout_ms = 600000
 
 ; A replica of app_prod: the same data on a different server, keeping its own
 ; statistics counters. duplicateIndexes and indexBloat report idx_scan, so an
@@ -44,11 +49,14 @@ group             = prod, app, reporting
 
 ; A group may span instances and replication groups. This is how an agent asks
 ; "how are our dev servers today?" without knowing any connection name.
+; Lowered instead: a dev box reached over a WAN link should give up quickly
+; rather than tie up a backend while someone browses the catalog.
 [app_dev]
-host    = dev-db
-port    = 5432
-dbname  = app
-group   = dev, app
+host                 = dev-db
+port                 = 5432
+dbname               = app
+group                = dev, app
+statement_timeout_ms = 15000
 
 [billing_dev]
 host    = dev-db


### PR DESCRIPTION
Three fixes to behaviour shipped in 3.2.0 and earlier, found while investigating a report of extreme slowness on a topology sweep and a query that ran for more than ten minutes.

No payload shape changed and no configuration file needs an edit, but **one default did change**: every call now runs under a `statement_timeout`.

## 1. A fan-out sweep did not bound the connection that did its work

3.2.0 added `with_connect_timeout()` with the comment *"one unreachable host must cost seconds, not whatever the kernel's TCP timeout happens to be"*, and applied it in `verifyTopology` and in the optional role probe. The connection each member's tool actually opened went through `active_cfg()` instead, which returns the configured conninfo unchanged — and nothing supplies a default `connect_timeout`.

A member that *refuses* a connection fails immediately, so this was invisible in testing. A member that *drops* the packets — a decommissioned database, a security group that changed — cost the kernel's SYN-retry budget instead: about two minutes on a Linux default of six retries. Sweeps are sequential, so each such member added that to the whole call.

There is an inversion in it worth naming: a sweep narrowed with `role: "primary"` was **fast**, because the role probe *was* bounded and skipped the member before its tool ever ran, while the same sweep without a role filter was **slow**. Fast when narrowed and slow when not is the opposite of what anyone would predict.

The sweep now swaps in a bounded copy of the member's config for the whole of that member's turn, cleared by a scope guard so an exception cannot leave it behind.

**The regression test uses a TEST-NET-1 address (192.0.2.1, RFC 5737) rather than a refused port**, because a refused port never exercises a timeout at all. Verified both ways:

| | |
|---|---|
| against the previous code | **134 seconds**, test fails |
| against this branch | **5 seconds**, test passes |

## 2. Only `explainQuery` bounded how long a statement could run

`Session` took a `timeout_ms` defaulting to 0 and issued `SET LOCAL statement_timeout` only when it was positive; `explainQuery` was the sole caller that passed one. Every other operation — all fifty-odd — ran with no upper bound.

Academic for a catalog read. Not academic for the three whose cost scales with the server rather than with the query:

- `tableBloat` calls `pgstattuple()`, a full sequential scan (and `pgstattuple_approx()`, the default, still reads every page the visibility map does not mark all-visible)
- `indexBloat` reads the whole index for btree and hash
- `bufferCacheContents` scans every buffer in `shared_buffers`

Nor could an operator impose a bound. `statement_timeout` is a GUC rather than a libpq keyword, so it cannot go in a conninfo, and the `options` keyword that could carry it is rejected at parse time — with a message saying pg-licht *"sets what it needs per transaction (BEGIN READ ONLY, SET LOCAL statement_timeout) instead"*. The first half was true and the second was not, so the message blocked the only available workaround by pointing at a setting that was not being applied.

Every transaction now sets it:

```ini
[billing_prod]
service              = billing-prod
statement_timeout_ms = 600000      ; default 120000; 0 restores 3.2.0 behaviour
```

or `PG_LICHT_STATEMENT_TIMEOUT_MS` on the single `DATABASE_URL` path. Transaction-scoped for the same reason the read-only guard is. The `options` message now names the key that works.

Reaching the ceiling is reported as the ceiling being reached, not as an execution error — the two call for opposite responses and PostgreSQL's own message does not distinguish them:

```json
{
  "error": "statement cancelled after 1ms (statement_timeout)",
  "hint": "This is a ceiling, not a failure: the statement was still running when it was reached. Raise it for this connection with 'statement_timeout_ms' ...",
  "timeout_ms": 1
}
```

Testing `sqlstate() == "57014"` is reliable here, unlike the `42501` comparison fixed in 3.2.0: libpqxx has no dedicated class for a cancelled statement, so it arrives as a plain `pqxx::sql_error` that *does* carry its code. Verified against libpqxx 7.10 — the same version that leaves it empty on `insufficient_privilege`. There is a test asserting exactly this, so the two cases cannot drift into looking alike.

## 3. `bufferCacheContents` measured every cached relation to return twenty

`pg_relation_size()` was called inside the CTE that resolved relation names, so it ran once per relation holding a buffer and the `LIMIT` applied after. Each call is a `stat()`. On a 16GB `shared_buffers` instance with 12,417 relations that was **9,762 syscalls to produce 20 rows**; on network storage with a cold dentry cache it is the dominant cost of the tool.

The limit now applies before any fork is measured — 513ms → 464ms locally, where `stat()` is nearly free, and the gap widens with the storage. The join stays above the limit so the ranking is still over relations that resolve, keeping the result identical.

**The `pg_class` join was left alone deliberately.** It reads `pg_relation_filenode(c.oid)`, which cannot use `pg_class_tblspc_relfilenode_index` — but a mapped catalog carries `relfilenode = 0` in `pg_class` and can only be resolved through that function, so an index-friendly predicate would drop exactly the relations that are most heavily cached. It measures at ~25ms of 513ms; it is not where the time goes.

The tool description now states the cost out loud: O(`shared_buffers`) regardless of what is asked, because `pg_buffercache` materialises one row per buffer before any filter applies. It points at `bufferCacheSummary`, which uses `pg_buffercache_summary()` and measured ~100× cheaper (5ms vs 465ms at 2.1M buffers).

## Measurement setup

Findings 2 and 3 were measured on a purpose-built PG 18.4 instance: `shared_buffers = 16GB` (2,097,152 buffers), 700k in use, 12,417 relations, 10GB of data. Finding 1 was measured against the live blackhole path.

## Testing

- **15 new tests.**
- `cpp/test/run-pooled-tests.sh` — **323/323 passing directly, 322 passing through PgBouncer** (`pool_mode=transaction`, `server_reset_query=DISCARD ALL`) with 1 skipped (the `pg_monitor` denial test needs a non-superuser role). The rig's `pg_basebackup` standby also covered the replica-side role tests.

  This run is the one that matters for fix 2: the new `statement_timeout` is transaction-scoped *precisely* so it survives a transaction-mode pooler, and that is the property this script exists to verify. It does.
- Clean under `-Werror` and under `ASAN_UNDEFINED`.
- Man page lints clean under `mandoc -Tlint -Wwarning`.
- End-to-end smoke test over stdio against a real server, both normal and at the ceiling.

`PgssMCPServerTest.QueryIdFromADroppedDatabaseIsReportedNotCrashed` fails on my day-to-day cluster but **passes on the clean rig**, so it is environmental (leftover `pg_stat_statements` state) rather than a defect. Nothing to do here.

## Not in this PR

Splitting statistics out of `tableDetails` / `listTables` / `searchTables`. Measured separately: structure-only is ~7× faster (1.1ms vs 7.4ms) and 57–62% smaller, it would let the structure half be correctly classified `per_server: false` for sweeps, and it would take `most_common_vals` — literal column values — out of the tool agents call most. But it is a payload-shape change to three tools, which is a major by the precedent 3.0.0 set. Proposed for 4.0.0.
