### PR TITLE
v4.0.0: statistics split from structure, structured output, resources and prompts

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -232,8 +232,10 @@ jobs:
         # PgBouncer issues as server_reset_query -- so without the reset one
         # caller's hypothetical index reshapes the next caller's plans. The
         # test for that passes vacuously on a direct connection.
-        run: .github/scripts/apt-pgdg.sh libpq5 postgresql-${{ matrix.pg }} \
-                                         postgresql-${{ matrix.pg }}-hypopg pgbouncer
+        # One line on purpose: this is a plain scalar, where a trailing
+        # backslash is not a continuation -- YAML folds the lines with a space
+        # and the backslash reaches the shell as an argument.
+        run: .github/scripts/apt-pgdg.sh libpq5 postgresql-${{ matrix.pg }} postgresql-${{ matrix.pg }}-hypopg pgbouncer
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -130,6 +130,11 @@ jobs:
       # The suite reads cpp/test/connections.example.ini through a path baked
       # in at compile time, so the source tree has to be present even though
       # nothing here is compiled.
+      #
+      # These jobs talk to the stock postgres:NN image, which carries contrib
+      # but not hypopg, so the evaluateIndex tests skip here and are covered by
+      # the pooled job instead -- which is also the only place their pooling
+      # behaviour means anything.
       - uses: actions/checkout@v4
 
       - name: Install runtime dependencies
@@ -218,7 +223,17 @@ jobs:
         # bundled contrib extensions (pg_stat_statements, postgres_fdw,
         # pgstattuple, pg_buffercache) the fixtures install; pgbouncer is the
         # companion pooler.
-        run: .github/scripts/apt-pgdg.sh libpq5 postgresql-${{ matrix.pg }} pgbouncer
+        #
+        # hypopg is third-party rather than contrib, and it is installed only
+        # here. That is deliberate: this is the one job that runs behind a
+        # transaction-mode pooler, and the pooler is the only place the
+        # evaluateIndex reset bracket can be proved. A hypothetical index
+        # survives ROLLBACK, a new transaction and DISCARD ALL -- which is what
+        # PgBouncer issues as server_reset_query -- so without the reset one
+        # caller's hypothetical index reshapes the next caller's plans. The
+        # test for that passes vacuously on a direct connection.
+        run: .github/scripts/apt-pgdg.sh libpq5 postgresql-${{ matrix.pg }} \
+                                         postgresql-${{ matrix.pg }}-hypopg pgbouncer
 
       - uses: actions/download-artifact@v4
         with:
@@ -230,6 +245,11 @@ jobs:
           # Pin the cluster to the matrix version rather than letting the script
           # autodetect the newest one the runner happens to have installed.
           PG_BINDIR: /usr/lib/postgresql/${{ matrix.pg }}/bin
+          # The hypopg tests skip themselves when the extension is absent, which
+          # is right for a developer machine and wrong here: this job installs
+          # it, so a skip means something broke rather than something is
+          # missing. Turn the skip into a failure.
+          PGLICHT_REQUIRE_HYPOPG: "1"
         run: |
           chmod +x cpp/build/pg_licht_mcp_test
           cpp/test/run-pooled-tests.sh

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,458 @@
 # Changelog
 
+## 4.0.0 (2026-09-02)
+
+A breaking release, and the first since 3.0.0. It closes the roadmap: the
+statistics split, structured output, and the resources and prompts that were
+waiting on both. No configuration file needs an edit, and the connection
+registry and CLI flags are untouched.
+
+Two themes. The first is **volatility** — separating what changes only on DDL
+from what changes continuously, which is what makes the sweep classification
+correct and makes resources possible at all. The second is **one format per
+client**: a client that negotiated `2025-06-18` now receives `structuredContent`
+and no text block, which cuts 27–46% off the bytes of a typical call.
+
+The reason for the break is not the fields. `listTables`, `searchTables` and
+`tableDetails` each returned two unrelated kinds of thing in one payload — the
+shape of an object, which changes when someone issues DDL, and readings taken
+off it, which change continuously — and that made all three
+`per_server: true` in the sweep classification. A `replication_group` sweep of
+`tableDetails` therefore re-ran the entire structural payload (columns,
+constraints, triggers, policies, view definitions) once per replica to get
+byte-identical results back. Structure is replicated verbatim by definition;
+only the counters legitimately differ. Splitting the tools is what lets the
+classification be correct, and the classification is keyed on tool *name*, so
+no argument or flag could have fixed it.
+
+### Breaking
+
+- **`listTables`, `searchTables` and `tableDetails` return structure only.**
+  Every reading moved out. Where each field went:
+
+  | field | was on | now on |
+  |---|---|---|
+  | `rows` | all three | `tableStats`, `listTableStats` |
+  | `size` | `listTables`, `searchTables` (from `relpages`) | `tableStats`, `listTableStats` as **`size_estimate`** |
+  | `size`, `indexes_size` | `tableDetails` (measured) | `tableSize` |
+  | `seq_scan`, `idx_scan` | all three | `tableStats`, `listTableStats` |
+  | `n_live_tup`, `n_dead_tup` | all three | `tableStats`, `listTableStats` |
+  | `n_mod_since_analyze`, `n_ins_since_vacuum` | all three | `tableStats`, `listTableStats` |
+  | `last_vacuum`, `last_analyze` | all three | `tableStats`, `listTableStats` |
+  | `n_tup_newpage_upd`, `last_seq_scan` (16+) | all three | `tableStats`, `listTableStats` |
+  | `columns.*.null_frac`, `avg_width`, `n_distinct`, `physical_order_correlation`, `most_common_vals`, `most_common_freqs` | `tableDetails` | `tableStats` |
+  | `indexes.*.index_uses`, `last_use` | `tableDetails` | `tableStats` |
+  | `indexes.*.size` | `tableDetails` | `tableSize` |
+  | `toast.size`, `toast.index_size` | `tableDetails` | `tableSize` |
+
+  `toast.name` stays on `tableDetails`, so it still answers whether a table
+  stores anything out of line. `reloptions` stays: it is DDL.
+
+- **`size` is now `size_estimate` on the statistics tools, and it is not the
+  same number.** It is `relpages * 8192`, which is only as fresh as the last
+  vacuum or analyze — on a table that has doubled since, it is half the truth.
+  The rename is deliberate: the old field had the same name in `listTables`
+  (estimated) and `tableDetails` (measured), and callers had no way to tell.
+  An `estimated_from` timestamp now carries the reading that produced it, and
+  `tableSize` is where a measured number comes from.
+
+- **`tableDetails` no longer returns sampled column values.**
+  `most_common_vals` is literal data out of the column — on a customers table,
+  customer names — and it was returned by the tool an agent calls most often
+  to inspect structure, which the README describes as querying the catalog
+  "to inspect the structure (lower risk to leak data)". It is now on
+  `tableStats` alone, and that tool's description says what it contains.
+
+- **Every tool payload is a JSON object.** `structuredContent` may only be an
+  object, so two shapes that were legal before are not any more:
+
+  - **`listConnections` returns `{connections: [...]}`** and **`currentLocks`
+    returns `{locks: [...]}`**, where both previously returned a bare array.
+    This is the same fix, for the same reason, that 3.0.0 applied to
+    `statementStats`.
+  - **An empty result is `{}`, not `null`.** Any tool whose query matched no
+    rows previously returned JSON `null`. Beyond being unrepresentable as
+    structured content, `{}` is the better answer: `null` reads as "the tool
+    failed", `{}` says "nothing there".
+
+### Output format
+
+- **A client that negotiated `2025-06-18` or later receives `structuredContent`
+  and no `content` text block.** A client on an earlier revision receives the
+  text block and no `structuredContent`. Never both.
+
+  The spec suggests serving both for backwards compatibility, and this
+  deliberately does not. Sending both serialises the same payload twice in one
+  response, and a client that feeds tool results into a model's context may
+  inject both — doubling the tokens on every call. The compatibility that
+  suggestion protects is already covered by the negotiated revision: a client
+  that cannot read `structuredContent` does not ask for a revision that has it.
+  This is the rule 3.2.0 settled on for `annotations` and `title` — a
+  protocol-revision feature reaches only a client that negotiated the revision
+  defining it.
+
+  If you have a client that advertises `2025-06-18` but only reads `content`,
+  pin it to `2025-03-26` and it keeps working unchanged.
+
+- **The text block is serialised compactly.** It was pretty-printed with
+  two-space indentation, which measured 18–39% of the payload across real
+  catalog reads and which no consumer reads — every one parses the text as
+  JSON. Combined with dropping the duplicate block, a modern client's wire
+  bytes fall by 27–46%:
+
+  | call | 3.2.1 | 4.0.0 | saved |
+  |---|---:|---:|---:|
+  | `listTables pg_catalog` | 163,225 B | 88,312 B | 45.9% |
+  | `tableDetails pg_catalog.pg_class` | 8,656 B | 5,158 B | 40.4% |
+  | `listTableStats pg_catalog` | 58,502 B | 40,040 B | 31.6% |
+  | `listFunctions pg_catalog` | 1,126,238 B | 819,030 B | 27.3% |
+
+- **Errors stay a text block in both eras.** `structuredContent` is the format
+  for a tool's answer; an error is a message about why there is no answer, and
+  the spec pairs `isError` with `content`.
+
+- **`outputSchema` is declared for all 58 tools**, to clients that negotiated
+  `2025-06-18`. The schemas are deliberately permissive — they type the keys
+  that are unconditional, mark nothing `required`, and allow additional
+  properties. This is the design, not a shortcut: payloads here are
+  version-conditional (`tableStats` gains two fields on PostgreSQL 16), every
+  tool may answer `{error, hint}` when an extension is absent, and a client
+  that validates against a schema turns any drift into a failed call. A schema
+  that can describe but never reject is the only safe kind here. A test walks
+  real payloads from 35 tools against their declared schema on every run, which
+  already caught one wrong type before release.
+
+### Caching hints and pagination
+
+Both are required or supported by revision `2026-07-28` and were previously
+absent. Both are gated on `resultType: "complete"` — that is, on the modern
+era — for the same reason `resultType` itself is.
+
+- **`ttlMs` and `cacheScope`** now accompany every result the caching utility
+  names as cacheable: `server/discover`, `tools/list`, `prompts/list`,
+  `resources/list`, `resources/templates/list` and `resources/read`. The spec
+  says a client SHOULD treat a result with no `ttlMs` as immediately stale, so
+  their absence meant **`tools/list` — about 93 kB once 58 tools carry
+  descriptions, annotations, titles and output schemas — was re-fetched
+  whenever a client needed the tool list.** That payload is entirely static,
+  and it grew in this release.
+
+  | result | `ttlMs` | `cacheScope` |
+  |---|---:|---|
+  | `server/discover` | 1 h | `public` |
+  | `tools/list` | 1 h | `private` |
+  | `prompts/list` | 1 h | `public` |
+  | `resources/templates/list` | 1 h | `public` |
+  | `resources/list` | 1 min | `private` |
+  | `resources/read` | 1 min | `private` |
+
+  An hour for anything compiled in or read from the config at startup: none of
+  it can change while the process lives, and no `listChanged` capability is
+  declared, so there is no mechanism by which it could. A minute for anything
+  read from a live catalog — structure changes only on DDL, which is the
+  premise of serving it as a resource, but DDL does happen.
+
+  `tools/list` is `private` rather than `public` for two independent reasons.
+  Its content varies by negotiated revision (`annotations`, `title` and
+  `outputSchema` are each gated) while the cache key is the method and its
+  params, and the revision travels in `_meta`; and the `connection` property
+  description carries the operator's configured default connection name.
+  Neither belongs in a cache a shared gateway may serve to another caller. A
+  private cache still gives the calling client the full benefit, which is where
+  the saving actually lands.
+
+- **Pagination** (`cursor` in, `nextCursor` out) on `tools/list`,
+  `prompts/list`, `resources/list` and `resources/templates/list`. An invalid
+  cursor is rejected with `-32602`.
+
+  The page size is deliberately larger than any list this server currently
+  produces, so **nothing is truncated for a client that ignores `nextCursor`**
+  — 58 tools, 8 prompts and 5 templates are each a single page. The list that
+  can genuinely outgrow a page is `resources/list`, which is connections ×
+  schemas, and that is the case pagination exists for. Cursors are opaque and
+  stable.
+
+### New: resources, prompts and completions
+
+These were blocked on the statistics split, and are the reason it went first.
+Before it, `listTables` and `tableDetails` carried `n_dead_tup`, `last_vacuum`
+and `idx_scan` — serving them as documents would have invited a client to pin a
+number that moves under it.
+
+- **Resources** (`resources/list`, `resources/templates/list`,
+  `resources/read`) serve structure as documents under a per-connection URI
+  scheme:
+
+  ```
+  pglicht://{conn}/schemas
+  pglicht://{conn}/schema/{schema}
+  pglicht://{conn}/schema/{schema}/table/{table}
+  pglicht://{conn}/schema/{schema}/{functions,enums,types}
+  pglicht://{conn}/server/{roles,extensions,settings}
+  ```
+
+  `resources/list` is bounded: it enumerates connections and their schemas, and
+  exposes tables, functions, enums and types through templates instead — a
+  database with 10 000 tables would otherwise produce a 10 000-entry response
+  on a call clients make eagerly. Enumerating schemas costs one connection per
+  configured connection; one that cannot be reached is skipped rather than
+  failing the list. The topology axes are deliberately absent from the URI
+  space: a resource names exactly one object in one database, and partial
+  failure across members can only be reported per member, which belongs to
+  tools.
+
+  Readings stay tools. `currentActivity`, `currentLocks`, `statementStats`,
+  `progressStats`, `tableStats`, `tableSize`, `tableBloat`, `indexBloat`,
+  `wraparoundStatus`, `explainQuery` and both buffer-cache tools are
+  measurements, and the model must decide when to take them.
+
+- **Prompts** (`prompts/list`, `prompts/get`) — eight templates, each encoding
+  an order of investigation that is easy to get wrong. Static text with
+  argument substitution; they touch no database until the model acts on them.
+
+  | prompt | arguments |
+  |---|---|
+  | `diagnose-slow-query` | `query_id?`, `min_duration_s?` |
+  | `triage-lock-contention` | `connection?` |
+  | `bloat-and-vacuum-review` | `schema?` |
+  | `buffer-cache-review` | `connection?` |
+  | `capacity-check` | `connection?` |
+  | `replication-slot-review` | `connection?` |
+  | `plan-schema-change` | `change`, `schema?`, `table?` |
+  | `explain-and-fix` | `sql`, `params?` |
+
+  **`diagnose-slow-query` is the hub.** A slow statement can end in a plan fix,
+  a vacuum change, an index, or a schema change, so it now branches: if the
+  plan shows a sequential scan where an index exists, or an index scan fetching
+  far more heap pages than it returns rows, it routes to `tableBloat` and
+  `indexBloat`; if bloat is confirmed it routes to `bloat-and-vacuum-review`
+  rather than reaching for a REINDEX; and if the answer is DDL it routes to
+  `plan-schema-change`, because an index that is *correct* and an index that is
+  *safe to create on a live server* are different questions.
+
+  **`replication-slot-review`** is the runbook for the failure mode that
+  presents as something else: an unconsumed slot holds back the xmin horizon so
+  vacuum cannot remove dead tuples anywhere in the cluster, and pins WAL until
+  the disk fills. Both get diagnosed as bloat or as a disk problem. It reads
+  `wal_status` (`reserved` / `extended` / `unreserved` / `lost`), establishes
+  whose slot it is before proposing anything, weighs `max_slot_wal_keep_size`
+  against the disk, and treats dropping a slot as irreversible for its
+  consumer.
+
+  **`plan-schema-change`** answers "how should I apply this DDL here?" by
+  measuring the table rather than by prescribing a method. It deliberately
+  contains **no DDL recipes**. A model already knows what
+  `CREATE INDEX CONCURRENTLY` is; what it cannot know is this table's row
+  count, measured size, existing indexes and what is holding a lock right now,
+  and those are the only things that decide the answer.
+
+  The reason is that a recipe is wrong at one end of the scale. The same
+  statement that is instant on one table is an outage on another: a table with
+  no rows can be rewritten in place and nobody notices, while the same rewrite
+  at a billion rows is hours under an exclusive lock. Partitioning is the
+  extreme case — trivial before there is data, a migration with a cutover
+  after it. Reaching for the safest-at-scale approach on a small table is
+  machinery nobody needs; reaching for the simple one on a large table is the
+  outage.
+
+  So the prompt sends the model to measure — and to measure **every object the
+  change touches, not only the one named**. A statement that names one table
+  routinely locks more than one: a foreign key locks the table it references as
+  well as the table it is added to, a partitioned table means the parent and
+  every partition, and the object you did not name is often the busier one.
+  The readings are `tableStats` for rows and `most_common_vals`, `tableSize`
+  for what a rewrite would move, `tableDetails` for the indexes and constraints
+  that multiply it and for foreign keys in both directions, `currentActivity`
+  and `currentLocks` for the oldest transaction and anything already queued on
+  any of those objects, `replicationSlots` if it rewrites — then asks it to classify the change as metadata-only, a scan,
+  or a full rewrite, and to state **the size at which its answer would flip**,
+  so the reasoning can be checked against a different table later. It also
+  insists that lock *level* settles nothing on its own: a strong lock held for
+  a millisecond is safe and a weak one held for an hour may not be, and
+  duration comes from the measurements.
+
+  **`diagnose-slow-query` and `explain-and-fix` now choose the *kind* of fix
+  rather than defaulting to DDL.** Both end by classifying the remedy as one of
+  four — a query rewrite, a statistics fix, a configuration change, or DDL —
+  and preferring them in that order, because that is the order of what they
+  cost: an `ANALYZE` is free and instant, a rewrite costs a deploy and nothing
+  in the database, configuration changes the behaviour of every other query
+  too, and an index is a write cost paid by every `INSERT` and `UPDATE` for as
+  long as it exists to buy speed for one read pattern. They must say why the
+  cheaper options were rejected rather than passing over them.
+
+  They then verify what can be verified, which is an asymmetry this server can
+  actually exploit: a rewrite is checkable on the spot — call `explainQuery` on
+  the rewritten statement and show the plan changed — while an index's benefit
+  is a prediction, and must be presented as one. Index creation is handed to
+  `plan-schema-change`, because whether an index is *correct* and whether it is
+  *safe to build on this server* are different questions.
+
+  **Every prompt whose core tools are privilege-gated now opens by calling
+  `checkPrivileges`.** A restricted role gets null statistics rather than an
+  error, so a plan built on tools that will not answer looks like it worked.
+
+- **Completions** (`completion/complete`) for the `conn`, `schema` and `table`
+  variables that appear in prompt arguments and resource templates, backed by
+  the queries that already exist. A completion is a convenience, so an argument
+  it does not know or a catalog it cannot read returns an empty list rather
+  than an error.
+
+- The `resources`, `prompts` and `completions` capabilities are declared in
+  both `initialize` and `server/discover`, so a modern client does not see a
+  smaller server than a legacy one.
+
+### New tools
+
+- **`evaluateIndex`** — plan a statement as if the indexes were different,
+  using [hypopg](https://github.com/HypoPG/hypopg). `create` takes
+  `CREATE INDEX` statements to plan against without building them; `hide` takes
+  the names of existing indexes to plan *without*, which is how to ask whether
+  an index is safe to drop — the question `duplicateIndexes` raises and cannot
+  settle, since neither redundancy nor a zero `idx_scan` proves the planner
+  would not miss it.
+
+  Nothing is built, no lock is taken, no catalog row is written, and the
+  statement is never executed: hypopg cannot serve `EXPLAIN ANALYZE`, so this
+  is plan-only and strictly safer than `explainQuery` with `analyze`. It
+  returns the plan and total cost before and after, and **for each index
+  whether the planner actually used it** — a proposed index the planner ignores
+  is the common case, and a cost figure alone hides it.
+
+  Measured on hypopg 1.4.3: a candidate index on a 200k-row table moved the
+  plan from a Seq Scan at cost 4970 to a Bitmap Index Scan at 2709; hiding a
+  primary key moved it the other way, 8.44 → 4970, which is the answer to "can
+  I drop this".
+
+  **The reset bracket is not optional, and this is the finding worth carrying
+  forward.** A hypothetical index lives in backend-local memory for the whole
+  session and is cleared by none of the things that would be expected to clear
+  it — measured: not `ROLLBACK`, not a new transaction, and **not `DISCARD
+  ALL`**, which is exactly what PgBouncer issues as `server_reset_query`. Only
+  `hypopg_reset()` removes it. Behind a transaction-mode pooler that would
+  leave one caller's hypothetical index on the backend, silently reshaping the
+  next caller's plans. So `hypopg_reset()` runs on the way in, protecting this
+  call from whatever a previous one left, and again on the way out through a
+  scope guard that survives an exception. A test asserts a second call's
+  baseline is unchanged — it can only fail behind the pooler, and passes
+  trivially without one.
+
+  `hide` needs hypopg 1.4.0+ and is gated on the extension version, not the
+  server version — the same treatment `pg_buffercache` needed, for the same
+  reason: the two move independently.
+
+- **`checkPrivileges`** — which tools the current role can actually use on this
+  connection, and how the rest fall short.
+
+  Most of this server works for any role that can connect, because the catalog
+  is world-readable. Measured on PostgreSQL 18: a bare `LOGIN` role with no
+  grants runs **47 of 58 tools** at full fidelity; the monitoring role takes
+  that to **54**; the three that remain are exactly the three that read row
+  data (`tableStats` histograms, `checkKey`, `explainQuery`).
+
+  The reason to ask once rather than discover it tool by tool is that the
+  discovery is misleading. `tableStats` on a role without `SELECT` returns
+  every column present with null statistics — byte-for-byte what a table that
+  was never analyzed looks like. `statementStats` returns rows whose query text
+  is `<insufficient privilege>`, with no count of what was hidden.
+
+  Three deliberate choices in the payload:
+
+  - **Tools absent from both lists are fully available**, and `available` is a
+    count rather than a list. Enumerating 53 working tool names would be most
+    of the payload, and the exceptions are the answer.
+  - **No role memberships and no `GRANT` statements.** Which predefined role
+    gates a tool is PostgreSQL's business; the caller needs to know what works.
+    And emitting DDL would contradict what this server tells every client about
+    itself — plans verbatim, no heuristics, no generated DDL. Naming a grant in
+    the hint of a tool that *failed* is diagnosis; listing grants beside every
+    unavailable tool is a standing recommendation to escalate privilege, which
+    is not this server's to make.
+  - **`denied` means the tool cannot answer at all; `degraded` means it answers
+    less.** The three row-data tools are always `degraded`, never `denied`,
+    because privilege there is per object — a role without blanket read access
+    may still hold `SELECT` on some tables and not others. Reporting them as
+    unavailable would be as wrong as reporting them as available.
+
+  It distinguishes an absent extension from a missing privilege, because those
+  send an operator to different fixes — the same defect the `42501` handling
+  corrected in 3.2.0.
+
+- **`tableStats`** and **`listTableStats`** — the readings, from
+  `pg_stat_user_tables`, `pg_stats` and the `pg_class` counters that ANALYZE
+  maintains. No relation is opened and no file is measured, so they cost a
+  catalog scan and nothing else. `tableStats` adds the per-column histograms
+  and per-index scan counts; `listTableStats` omits the histograms, because
+  `default_statistics_target` sample values for every column of every table in
+  a schema is a payload nobody asked for.
+
+  Both are `{per_database: true, per_server: true, primary_authoritative:
+  true}`: scan counts and dead tuples are each server's own, and vacuum only
+  runs on a primary. This is the half of the split that is worth sweeping, and
+  the reason to do it.
+
+- **`tableSize`** and **`listTableSizes`** — measured size, and the only place
+  a measured number now comes from. `tableSize` reports the main fork, table
+  size including TOAST and the free space and visibility maps, index size,
+  grand total, the TOAST relation, and each index individually;
+  `listTableSizes` reports table, index and total size for every relation in a
+  schema.
+
+  These are separate tools rather than a flag because of what they cost, and
+  the cost is not what it looks like. `pg_table_size()` and its relatives are
+  not physical reads — they `stat()` one file per 1 GB segment and read no
+  blocks. What makes them worth gating is the lock: each opens the relation
+  with `AccessShareLock`, so a table being rewritten by an `ALTER TABLE` holds
+  the call behind `AccessExclusiveLock` until `statement_timeout_ms` fires.
+  Across a schema that means the call stalls on precisely the table an
+  incident is about. A separate tool puts that warning in the description the
+  model reads while *choosing* a tool, rather than in an argument it reads
+  after having already chosen.
+
+  Both are `per_server: false`: the same files are measured on every member of
+  a replication group.
+
+### Changed
+
+- **Every session now ends in `ROLLBACK`, explicitly.** `pqxx::work` already
+  aborted an uncommitted transaction on destruction, so no behaviour changed —
+  but nothing here ever commits, every statement runs under
+  `SET TRANSACTION READ ONLY`, and stating it makes "the server is as you found
+  it" provable rather than incidental. A test asserts it across a spread of
+  tools.
+
+  One thing rollback does *not* undo, worth naming because the assumption is
+  natural: backend-local state set by an extension. A hypopg hypothetical index
+  survives `ROLLBACK`, the next transaction, and `DISCARD ALL`, which is why
+  `evaluateIndex` resets it explicitly.
+
+
+- **The sweep classification is corrected, which is the point of the
+  release.** `listTables`, `searchTables` and `tableDetails` are now
+  `{per_database: true, per_server: false, primary_authoritative: false}` and
+  no longer advertise `replication_group` or `role`; a sweep across replicas
+  is refused with the same reasoning `tableBloat` has always used. `tableSize`
+  and `listTableSizes` join them. `tableStats` and `listTableStats` take their
+  place on the per-server row.
+
+- **`tableDetails` is no longer version-conditional.** Every field it dropped
+  on PostgreSQL 14 and 15 was a statistic, so the `server_version()` probe and
+  the string-erase fixup that removed `last_idx_scan` from the finished query
+  are both gone. The gate lives in `tableStats` now, and is built by
+  concatenation rather than by erasing a literal — the old approach failed
+  silently if the literal ever drifted from the query.
+
+- `tableBloat`'s description pointed at "the ANALYZE-time estimates in
+  `listTables`/`tableDetails`"; it now points at `listTableStats`/`tableStats`.
+
+- `tableIOStats` and `tableStats` now cross-reference each other. They sit
+  next to each other alphabetically and report different views —
+  `pg_statio_all_tables` against `pg_stat_user_tables` — so each description
+  now says what the other one answers.
+
+- Tool count is 58, up from 52. The server now also serves 9 resource kinds,
+  5 resource templates and 8 prompts.
+
 ## 3.2.1 (2026-08-21)
 
 Three fixes to behaviour shipped in 3.2.0 and earlier. No payload shape

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ statement_timeout_ms = 600000      ; 0 removes the ceiling
 
 Most operations are catalog reads that never approach it. The ones that can are
 those whose cost scales with the server rather than with the query —
-`tableBloat` with `exact: true`, `indexBloat` on a btree or hash index, and
-`bufferCacheContents` — so raise it for a connection where such a scan is the
-point of the call. Reaching it is reported as the ceiling being reached, naming
+`tableBloat` with `exact: true`, `indexBloat` on a btree or hash index,
+`bufferCacheContents`, and `listTableSizes` on a wide schema — so raise it for a
+connection where such a scan is the point of the call. Reaching it is reported as the ceiling being reached, naming
 the value and the key to change, rather than as an error.
 
 Full rationale, including the guarded exception for `explainQuery`, is in the
@@ -49,15 +49,108 @@ man pg_licht_mcp
 
 Other install channels — deb, rpm, tarball, source — are in [INSTALL.md](INSTALL.md).
 
+## Output format
+
+A client that negotiates MCP revision `2025-06-18` or later receives
+`structuredContent` and no text block; one on an earlier revision receives the
+text block and no `structuredContent`. Never both — sending both would
+serialise the same payload twice, and a client that feeds tool results into a
+model's context may inject both, doubling the tokens on every call. Combined
+with dropping the pretty-printing, a modern client's wire bytes fall by 27–46%.
+
+If you have a client that advertises `2025-06-18` but only reads `content`, pin
+it to `2025-03-26` and it keeps working unchanged.
+
+Every tool declares an `outputSchema` to clients that can use it. The schemas
+describe but never reject: payloads here are version-conditional, and any tool
+may answer `{error, hint}` when an extension is absent.
+
+Results that the protocol marks cacheable carry `ttlMs` and `cacheScope`.
+`tools/list` is about 93 kB and entirely static, so it is hinted at one hour
+and scoped `private` — it varies by negotiated revision and names the
+configured default connection, so it must not be served to another caller from
+a shared cache. Catalog-derived results are hinted at one minute.
+
+List operations accept an opaque `cursor` and return `nextCursor`. The page
+size is larger than anything this server lists today, so a client that ignores
+cursors still sees every tool; `resources/list` is the one that grows, being
+connections × schemas.
+
+## Resources and prompts
+
+Structure is also served as **resources** — documents a client can browse and
+pin into context without a tool call:
+
+```
+pglicht://{conn}/schemas
+pglicht://{conn}/schema/{schema}
+pglicht://{conn}/schema/{schema}/table/{table}
+pglicht://{conn}/schema/{schema}/{functions,enums,types}
+pglicht://{conn}/server/{roles,extensions,settings}
+```
+
+Readings stay tools, because the model has to decide *when* to take them.
+`resources/list` enumerates connections and schemas and reaches tables through
+a template, so a 10 000-table database does not produce a 10 000-entry
+response.
+
+Eight **prompts** encode an order of investigation that is easy to get wrong:
+`diagnose-slow-query`, `triage-lock-contention`, `bloat-and-vacuum-review`,
+`buffer-cache-review`, `capacity-check`, `replication-slot-review`,
+`plan-schema-change` and `explain-and-fix`. They are static text and touch no
+database until the model acts on them, and each one whose tools are
+privilege-gated opens by calling `checkPrivileges`.
+
+`diagnose-slow-query` is the hub — a slow statement can end in a plan fix, a
+vacuum change, an index, or a schema change, and it routes to the others
+accordingly. `plan-schema-change` answers "how should I apply this DDL
+here?" by measuring the table rather than prescribing a method — it carries no
+DDL recipes, because the same statement that is instant on an empty table is an
+outage at a billion rows, and only the row count, measured size, existing
+indexes and current lock waits can tell the two apart. **Completions** are offered for the `conn`,
+`schema` and `table` variables.
+
 ## Tools
 
-52 read-only operations, grouped as schema exploration, catalog search, cluster-wide
+58 read-only operations, grouped as schema exploration, catalog search, cluster-wide
 objects, extensibility and text search, foreign data and replication, monitoring and
 statistics, diagnostics and query planning, topology, and connections. Highlights include
 `tableDetails` (columns, indexes, constraints, foreign keys in both directions, triggers,
 policies), `searchTables` (full-text search across names, descriptions, and enum values),
 and `explainQuery` (recover a slow statement from `pg_stat_statements` by `queryid` and get
 its `EXPLAIN` plan).
+
+`checkPrivileges` reports which of them the current role can actually use on a given
+connection. Most work for any role that can connect, since the catalog is world-readable:
+measured on PostgreSQL 18, a bare login role runs 47 of 58 at full fidelity, the monitoring
+role 54, and the ones that remain are those that read row data. Worth calling first
+against an unfamiliar connection — a privilege-filtered answer is easy to mistake for an
+empty one, since `tableStats` on a role without `SELECT` returns columns with null
+statistics, exactly like a table that was never analyzed.
+
+`evaluateIndex` plans a statement as if the indexes were different, using
+[hypopg](https://github.com/HypoPG/hypopg): `create` tests a candidate index without
+building it, `hide` plans without an existing one — which is how to ask whether an index is
+safe to drop. Nothing is built, nothing is locked, and the statement is never executed. It
+reports whether the planner actually *used* each index, which is the answer a cost figure
+hides.
+
+Tables are covered by three tools rather than one, split by what the answer costs and how
+fast it goes stale:
+
+| | tools | reads |
+|---|---|---|
+| **structure** — changes only on DDL | `tableDetails`, `listTables`, `searchTables` | catalog |
+| **statistics** — changes continuously, free to ask | `tableStats`, `listTableStats` | catalog and the statistics collector |
+| **measured size** — changes continuously, costs a lock | `tableSize`, `listTableSizes` | `stat()` per segment, under `AccessShareLock` |
+
+The structure tools return no sample column values and no counters, so the payload an agent
+reads most often to understand a schema carries neither row data nor anything that moves
+under it. `tableStats` carries the `pg_stats` histograms — including `most_common_vals`,
+which is literal values sampled from the column — and a free `size_estimate` from
+`relpages`, dated by `estimated_from` so its staleness is visible. Reach for `tableSize`
+only when that estimate is too stale to act on: it opens each relation with
+`AccessShareLock`, so during a rewrite it waits behind the `ALTER TABLE`.
 
 For operational triage there are `wraparoundStatus` (XID and multixact headroom, per
 database and per table, TOAST tables included), `checkpointStats` (timed against requested
@@ -148,8 +241,8 @@ tool accepts depends on where its answer actually varies, and its input schema s
 
 | | varies across the databases of one instance | varies across members of a replication group |
 |---|---|---|
-| catalogs, `tableBloat` | yes | no — a physical replica is byte-identical |
-| `duplicateIndexes`, `indexBloat`, `tableIOStats` | yes | **yes** — they carry `idx_scan` |
+| catalogs, `tableBloat`, the structure and size tools | yes | no — a physical replica is byte-identical |
+| `duplicateIndexes`, `indexBloat`, `tableIOStats`, `tableStats`, `listTableStats` | yes | **yes** — they carry `idx_scan` |
 | `currentActivity`, `currentLocks`, `statementStats`, buffer cache | no — instance-wide | yes |
 
 That middle row is the one worth knowing: an index that reads as unused on the primary may

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(pg_licht_mcp VERSION 3.2.1 LANGUAGES CXX)
+project(pg_licht_mcp VERSION 4.0.0 LANGUAGES CXX)
 
 # Standard bin/ and share/man/ layout, so `cmake --install` produces a tree that
 # can be dropped onto a prefix as-is: the release tarballs are staged this way,

--- a/cpp/man/pg_licht_mcp.1
+++ b/cpp/man/pg_licht_mcp.1
@@ -1,7 +1,7 @@
 .\" Copyright (c) 2026 Daniel Cristian.
 .\" Licensed under the Apache License, Version 2.0; see LICENSE.
 .\"
-.Dd August 12, 2026
+.Dd September 2, 2026
 .Dt PG_LICHT_MCP 1
 .Os pg-licht
 .Sh NAME
@@ -450,34 +450,166 @@ is running is picked up on the next call.
 An extension that is absent is reported as not installed, with the hint naming
 the setup steps; see
 .Sx DIAGNOSTICS .
+.Ss Privileges
+.Bl -tag -width Ds
+.It Ic checkPrivileges
+Which operations the current role can actually use on this connection, and how
+the rest fall short.
+.Pp
+Most of this server works for any role that can connect, because the catalog is
+world-readable.
+Measured on PostgreSQL 18: a bare
+.Ic LOGIN
+role with no grants runs 47 of the 58 operations at full fidelity, the
+monitoring role takes that to 54, and the three that remain are exactly the
+three that read row data \(em the
+.Ic tableStats
+column histograms,
+.Ic checkKey
+and
+.Ic explainQuery .
+.Pp
+Worth calling first against an unfamiliar connection or a restricted role.
+The alternative is discovering the limits one operation at a time, and the
+discovery misleads:
+.Ic tableStats
+under a role without
+.Ic SELECT
+returns every column present with null statistics, which is what a table that
+was never analyzed looks like, and
+.Ic statementStats
+returns rows whose query text is
+.Li <insufficient privilege>
+with no count of what was hidden.
+.Pp
+Operations named in neither list are fully available;
+.Va available
+is a count rather than a list, because the exceptions are the answer.
+.Va denied
+means the operation cannot answer at all,
+.Va degraded
+that it answers less than a privileged role would see.
+The three that read row data are always
+.Va degraded
+and never
+.Va denied ,
+because privilege there is per object: a role without blanket read access may
+still hold
+.Ic SELECT
+on some tables and not others.
+.Pp
+An absent extension is distinguished from a missing privilege, because the two
+send an operator to different fixes.
+.Pp
+No role memberships and no
+.Ic GRANT
+statements appear in the output.
+Which predefined role gates an operation is PostgreSQL's business; the caller
+needs to know what works.
+Naming a grant in the hint of an operation that failed is diagnosis; listing
+grants beside every unavailable operation would be a standing recommendation to
+escalate privilege, which is not this server's to make.
+.El
 .Ss Schema exploration
 .Bl -tag -width Ds
 .It Ic listSchemas
 All schemas with their table and view names and role grants.
 .It Ic listTables Ar schema
-Tables and views in
-.Ar schema
-with kind, row counts, sizes, scan stats, autovacuum stats (dead and live
-tuples, mods-since-analyze, inserts-since-vacuum, last vacuum and analyze,
-per-table reloptions), columns (name, description, per-column index count), and
-index and constraint counts.
+Structure of the tables and views in
+.Ar schema :
+kind, description, per-table reloptions, columns (name, description, per-column
+index count), and index and constraint counts.
 Full index and constraint definitions live in
 .Ic tableDetails ,
 not here; this operation is deliberately light for browsing a schema.
+Carries no statistics and no sizes: see
+.Ic listTableStats
+and
+.Ic listTableSizes .
 .It Ic tableDetails Ar schema Ar table
-Columns (types, nullability, defaults,
-.Li pg_stats
-histograms, per-column TOAST storage strategy and compression method), TOAST
-table (name, size, index size;
-.Dv null
-if the table has no toastable columns), primary key as an ordered column list,
-indexes (size, usage counts), constraints, foreign keys, inbound foreign keys
+Structure of one table: columns (types, nullability, defaults, per-column TOAST
+storage strategy and compression method), TOAST table name
+.Pq Dv null No if the table has no toastable columns ,
+primary key as an ordered column list, index definitions, constraints, foreign
+keys, inbound foreign keys
 .Pq Va referenced_by ,
 triggers (timing, events, when condition, language), rules (excluding the
 implicit view
 .Li _RETURN
-rule), row-level security status and policies, view definition, scan stats, and
-role grants.
+rule), row-level security status and policies, view definition, and role grants.
+.Pp
+Everything here changes only when someone issues DDL, and none of it is sampled
+row data.
+For row counts, scan counters, autovacuum state and the
+.Li pg_stats
+histograms see
+.Ic tableStats ;
+for measured sizes see
+.Ic tableSize .
+.It Ic tableStats Ar schema Ar table
+Statistics PostgreSQL already keeps for one table: estimated row count,
+.Va size_estimate
+.Pq Li relpages No * 8192 No with the Va estimated_from No timestamp that produced it ,
+.Va seq_scan
+and
+.Va idx_scan ,
+live and dead tuples, mods-since-analyze, inserts-since-vacuum, last vacuum and
+analyze, per-index scan counts, and the per-column
+.Li pg_stats
+histograms
+.Pq Va null_frac , Va avg_width , Va n_distinct , physical order correlation , Va most_common_vals No and their frequencies .
+Reads the catalog and the statistics collector only: no relation is opened and
+no file is measured.
+.Pp
+.Va most_common_vals
+is literal values sampled from the column, up to
+.Va default_statistics_target
+of them.
+This is the only operation that returns them.
+.It Ic listTableStats Ar schema
+The same statistics for every table in
+.Ar schema ,
+without the per-column histograms.
+Name one table to
+.Ic tableStats
+for those.
+.It Ic tableSize Ar schema Ar table
+Measured size of one table: main fork, table size including TOAST and the free
+space and visibility maps, index size, grand total, the TOAST relation, and each
+index individually.
+.Pp
+Costs more than it looks.
+.Li pg_table_size()
+and its relatives are not physical reads \(em they
+.Xr stat 2
+one file per 1 GB segment and read no blocks \(em but each opens the relation
+with
+.Sy AccessShareLock ,
+so a table being rewritten by an
+.Ic ALTER TABLE
+holds the call behind
+.Sy AccessExclusiveLock
+until
+.Va statement_timeout_ms
+fires.
+Prefer
+.Va size_estimate
+from
+.Ic tableStats ,
+which is free, and call this when the estimate is too stale to act on.
+A partitioned table reports its own storage, which is zero; measure the
+partitions.
+.It Ic listTableSizes Ar schema
+Measured table, index, and total size for every relation in
+.Ar schema .
+The lock caveat above applies with more force here: one relation is opened per
+table, so a single table under
+.Sy AccessExclusiveLock
+blocks the whole call rather than one row of it, and a wide schema means
+thousands of file-metadata calls.
+This is one of the operations worth raising
+.Va statement_timeout_ms
+for.
 .It Ic listFunctions Ar schema
 Functions and procedures in
 .Ar schema
@@ -531,6 +663,13 @@ Returns the same fields as
 .Ic listTables
 plus
 .Va roles .
+Structure only, and there is no statistics counterpart: a text search is how a
+table is found, not how a counter is read.
+Name a match to
+.Ic tableStats
+or
+.Ic tableSize
+for those.
 .It Ic searchFunctions Ar web_search
 Full-text search across function names, source code, language, trigger names,
 and descriptions.
@@ -1077,15 +1216,59 @@ flags, since those decide whether the index can be dropped at all.
 Restrict the check to one table.
 Omit it to check every table in the schema.
 .El
+.It Ic evaluateIndex Ar sql Op Va create , hide
+Plan a statement as if the indexes were different, using
+.Li hypopg .
+.Va create
+takes
+.Ic CREATE INDEX
+statements to plan against without building them;
+.Va hide
+takes the names of existing indexes to plan without, which is how to ask
+whether an index is safe to drop \(em the question
+.Ic duplicateIndexes
+raises and cannot settle, since neither redundancy nor an unused
+.Va idx_scan
+proves the planner would not miss it.
+.Pp
+Nothing is built, no lock is taken, no catalog row is written, and the
+statement is never executed:
+.Li hypopg
+cannot serve
+.Ic EXPLAIN ANALYZE ,
+so this is plan-only and safer than
+.Ic explainQuery
+with
+.Va analyze .
+Reports the plan and total cost before and after, and for each index whether
+the planner actually used it \(em a proposed index the planner ignores is the
+common case, and a cost figure alone hides it.
+The cost is the planner's estimate, not a measurement.
+.Pp
+A hypothetical index lives in backend-local memory for the whole session and is
+cleared by neither
+.Ic ROLLBACK ,
+a new transaction, nor
+.Ic DISCARD ALL ,
+which is what PgBouncer issues as
+.Va server_reset_query .
+This operation therefore resets explicitly on the way in and on the way out, so
+that behind a transaction pooler one caller's hypothetical index cannot reshape
+the next caller's plans.
+.Pp
+.Va hide
+requires
+.Li hypopg
+1.4.0 or later, gated on the extension version.
 .It Ic tableBloat Ar schema Ar table Op Va exact
 Physical storage bloat for a table
 .Pq Li pgstattuple No or Li pgstattuple_approx :
 table size, live and dead tuple counts and percentages, free space and
 percentage.
 More accurate than the ANALYZE-time estimates in
-.Ic listTables
+.Ic listTableStats
 and
-.Ic tableDetails .
+.Ic tableStats .
 Returns a clear error with setup instructions if the extension is not installed.
 .Pp
 .Bl -tag -width "timeout_ms" -compact
@@ -1293,6 +1476,256 @@ are the only operations that do not take a
 .Va connection
 argument.
 .El
+.Sh OUTPUT FORMAT
+A client that negotiated MCP revision
+.Li 2025-06-18
+or later receives its answer as
+.Va structuredContent
+and no text block.
+A client on an earlier revision receives the text block and no
+.Va structuredContent .
+Never both.
+.Pp
+The specification suggests serving both for backwards compatibility, and this
+implementation deliberately does not.
+Sending both serialises the same payload twice in one response, and a client
+that feeds tool results into a model's context may inject both, doubling the
+tokens on every call.
+The compatibility that suggestion protects is already covered by the negotiated
+revision: a client that cannot read
+.Va structuredContent
+does not ask for a revision that has it.
+If a client advertises
+.Li 2025-06-18
+but reads only
+.Va content ,
+pin it to
+.Li 2025-03-26
+and it behaves as before.
+.Pp
+The text block is serialised compactly.
+Indentation measured 18-39% of the payload across real catalog reads and no
+consumer reads it; every one parses the text as JSON.
+.Pp
+Errors remain a text block in both eras:
+.Va structuredContent
+is the format for a tool's answer, and an error is a message about why there is
+no answer.
+.Pp
+Every operation declares an
+.Va outputSchema
+to clients that negotiated the revision defining it.
+The schemas type the keys that are unconditional, mark nothing required, and
+permit additional properties.
+This is deliberate: payloads are version-conditional, and any operation may
+answer
+.Li {error, hint}
+when an extension is absent or a grant is missing, so a schema that enumerated
+leaf fields would reject correct answers.
+.Ss Caching and pagination
+Results that revision
+.Li 2026-07-28
+marks cacheable \(em
+.Ic server/discover ,
+.Ic tools/list ,
+.Ic prompts/list ,
+.Ic resources/list ,
+.Ic resources/templates/list
+and
+.Ic resources/read
+\(em carry
+.Va ttlMs
+and
+.Va cacheScope .
+Both are emitted only alongside
+.Va resultType ,
+so a legacy result is unchanged.
+.Pp
+Anything compiled in or read from the configuration file at startup is hinted
+at one hour: none of it can change while the process lives, and no
+.Va listChanged
+capability is declared, so there is no mechanism by which it could.
+Anything read from a live catalog is hinted at one minute.
+This matters most for
+.Ic tools/list ,
+which is roughly 93 kB once 58 operations carry descriptions, annotations,
+titles and output schemas, and which a client would otherwise re-fetch whenever
+it needed the list.
+.Pp
+.Ic tools/list
+is scoped
+.Li private
+rather than
+.Li public .
+Its content varies by negotiated revision, while the cache key is the method and
+its parameters and the revision travels in
+.Va _meta ;
+and its
+.Va connection
+property names the configured default connection.
+Neither belongs in a cache a shared gateway may serve to another caller.
+A private cache still serves the calling client, which is where the saving
+lands.
+.Pp
+The list operations accept an opaque
+.Va cursor
+and return
+.Va nextCursor
+when more results remain; an unusable cursor is refused with
+.Er -32602 .
+The page size is larger than any list this server currently produces, so a
+client that ignores cursors still receives every operation.
+.Ic resources/list
+is the one that grows, being connections multiplied by schemas.
+.Ss Transactions
+Every session runs inside a transaction opened with
+.Ic SET TRANSACTION READ ONLY
+and ends in
+.Ic ROLLBACK .
+Nothing is ever committed: there is nothing a commit could preserve, and
+rolling back leaves the server provably as it was found.
+.Pp
+Rollback does not undo backend-local state set by an extension.
+A
+.Li hypopg
+hypothetical index survives
+.Ic ROLLBACK ,
+the next transaction, and
+.Ic DISCARD ALL ,
+which is why
+.Ic evaluateIndex
+resets it explicitly rather than relying on the transaction ending.
+.Sh RESOURCES
+Structure is served as resources as well as operations \(em documents a client
+may browse and pin into context without a call.
+The division is volatility: a resource changes only when someone issues DDL,
+while a reading changes continuously and the model must decide when to take it.
+.Pp
+.Bl -tag -width Ds -compact
+.It Li pglicht:// Ns Ar conn Ns Li /schemas
+Every schema, with its tables and role grants.
+.It Li pglicht:// Ns Ar conn Ns Li /schema/ Ns Ar schema
+Structure of every table and view in one schema.
+.It Li pglicht:// Ns Ar conn Ns Li /schema/ Ns Ar schema Ns Li /table/ Ns Ar table
+One table's full structure.
+.It Li pglicht:// Ns Ar conn Ns Li /schema/ Ns Ar schema Ns Li /functions
+.It Li pglicht:// Ns Ar conn Ns Li /schema/ Ns Ar schema Ns Li /enums
+.It Li pglicht:// Ns Ar conn Ns Li /schema/ Ns Ar schema Ns Li /types
+.It Li pglicht:// Ns Ar conn Ns Li /server/roles
+.It Li pglicht:// Ns Ar conn Ns Li /server/extensions
+.It Li pglicht:// Ns Ar conn Ns Li /server/settings
+.El
+.Pp
+.Ic resources/list
+is bounded.
+It enumerates connections and their schemas and reaches tables, functions,
+enums and types through
+.Ic resources/templates/list
+instead: a database with 10 000 tables would otherwise produce a 10 000-entry
+response on a call clients make eagerly.
+Enumerating schemas costs one connection per configured connection; one that
+cannot be reached is skipped rather than failing the list.
+.Pp
+The topology axes are absent from the URI space by design.
+A resource names exactly one object in exactly one database, and partial
+failure across members can only be reported per member, which belongs to
+operations.
+.Sh PROMPTS
+Eight templates, each encoding an order of investigation that is easy to get
+wrong.
+Every one whose tools are privilege-gated opens by calling
+.Ic checkPrivileges :
+a restricted role receives null statistics rather than an error, so a plan
+built on operations that will not answer looks like it worked.
+They are static text with argument substitution and touch no database until the
+model acts on them.
+.Bl -tag -width Ds
+.It Ic diagnose-slow-query Op Va query_id , min_duration_s
+From
+.Ic statementStats
+to a plan to a fix, reading
+.Va info.dealloc
+first so a truncated list is not mistaken for the whole picture.
+.It Ic triage-lock-contention Op Va connection
+Follow the wait chain to its root before proposing to terminate anything.
+.It Ic bloat-and-vacuum-review Op Va schema
+Check
+.Ic replicationSlots
+before concluding anything about bloat: an inactive slot holds back the xmin
+horizon cluster-wide, and no autovacuum tuning fixes it.
+.It Ic buffer-cache-review Op Va connection
+Summary before contents, and hit ratios read against table size.
+.It Ic capacity-check Op Va connection
+Worst-case committed memory against host RAM; stops with a partial answer
+rather than guessing an undeclared host.
+.It Ic replication-slot-review Op Va connection
+The runbook for the failure mode that presents as something else.
+An unconsumed slot holds back the xmin horizon, so vacuum cannot remove dead
+tuples anywhere in the cluster, and pins WAL until the disk fills; both get
+diagnosed as bloat or as a disk problem.
+Reads
+.Va wal_status ,
+establishes whose slot it is before proposing anything, weighs
+.Va max_slot_wal_keep_size
+against the disk, and treats dropping a slot as irreversible for its consumer.
+.It Ic plan-schema-change Ar change Op Va schema , table
+Chooses how to apply a DDL change by measuring the table it targets.
+Carries no DDL recipes, deliberately: the safe method is a property of the
+table, not of the statement.
+The same statement that is instant on an empty table is an outage at a billion
+rows, and partitioning is the extreme case \(em trivial before there is data, a
+migration with a cutover after it.
+.Pp
+It sends the model to measure instead, and to measure every object the change
+touches rather than only the one named: a foreign key locks the table it
+references as well as the table it is added to, a partitioned table means the
+parent and every partition, and the object not named is often the busier one.
+The readings are rows and
+.Va most_common_vals
+from
+.Ic tableStats ,
+what a rewrite would move from
+.Ic tableSize ,
+the indexes and constraints that multiply it from
+.Ic tableDetails ,
+the oldest running transaction from
+.Ic currentActivity
+\(em then asks for the change to be classified as metadata only, a scan, or a
+full rewrite, and for the size at which the answer would flip.
+Lock level alone settles nothing: a strong lock held for a millisecond is safe
+and a weak one held for an hour may not be, and duration comes from the
+measurements.
+.It Ic explain-and-fix Ar sql Op Va params
+Plan without
+.Va analyze
+first, then with it if needed, and check existing indexes before proposing one.
+.Pp
+Both this and
+.Ic diagnose-slow-query
+close by choosing the kind of fix rather than defaulting to DDL: a query
+rewrite, a statistics fix, a configuration change, or DDL, preferred in that
+order because that is the order of what they cost \(em an
+.Ic ANALYZE
+is free, a rewrite costs a deploy and nothing in the database, configuration
+changes every other query too, and an index is a write cost paid by every
+.Ic INSERT
+and
+.Ic UPDATE
+for as long as it exists.
+A rewrite can then be verified on the spot by explaining it; an index cannot,
+so its benefit is presented as the prediction it is, and its creation handed to
+.Ic plan-schema-change .
+.El
+.Pp
+.Ic completion/complete
+offers values for the
+.Va conn ,
+.Va schema
+and
+.Va table
+variables that appear in prompt arguments and resource templates.
+A completion is a convenience: an argument it does not recognise, or a catalog
+it cannot read, yields an empty list rather than an error.
 .Sh ENVIRONMENT
 .Bl -tag -width ".Ev PG_LICHT_CONFIG"
 .It Ev DATABASE_URL

--- a/cpp/src/server.h
+++ b/cpp/src/server.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <cctype>
 #include <iostream>
 #include <map>
@@ -152,7 +153,24 @@ public:
   int server_version() const { return conn_.server_version(); }
 
   // txn_ is destroyed before conn_, rolling back; conn_ then disconnects.
-  ~Session() = default;
+  // Every session ends in ROLLBACK, explicitly. pqxx::work already aborts an
+  // uncommitted transaction on destruction, so this changes no behaviour -- it
+  // states the intent, and makes it something a test can assert rather than
+  // something that holds by accident. Nothing here ever commits: every
+  // statement runs under SET TRANSACTION READ ONLY, so there is nothing a
+  // commit could preserve, and rolling back leaves the server provably as it
+  // was found.
+  //
+  // One thing rollback does NOT undo, and it is worth naming because the
+  // assumption is natural: backend-local state set by an extension. A hypopg
+  // hypothetical index survives ROLLBACK, survives into the next transaction,
+  // and survives DISCARD ALL. evaluate_index resets it explicitly for exactly
+  // that reason; see the bracket there.
+  ~Session() {
+    // A destructor must not throw, and a connection already gone is not an
+    // error worth reporting: the transaction dies with it either way.
+    try { txn_.abort(); } catch (...) {}
+  }
 
   Session(const Session&) = delete;
   Session& operator=(const Session&) = delete;
@@ -198,6 +216,14 @@ public:
   const json call_table(const std::string& schema, const std::string& table_name) {
     return table(schema, table_name);
   }
+  const json call_table_stats(const std::string& schema, const std::string& table_name) {
+    return table_stats(schema, table_name);
+  }
+  const json call_list_table_stats(const std::string& schema) { return list_table_stats(schema); }
+  const json call_table_size(const std::string& schema, const std::string& table_name) {
+    return table_size(schema, table_name);
+  }
+  const json call_list_table_sizes(const std::string& schema) { return list_table_sizes(schema); }
   const json call_functions(const std::string& schema) { return functions(schema); }
   const json call_function_detail(const std::string& schema, const std::string& func_name) {
     return function_detail(schema, func_name);
@@ -257,6 +283,13 @@ public:
   // but was never registered -- and is therefore unreachable by any client --
   // fails the suite rather than passing it.
   const json call_tools_list() { return get_tools_list(client_protocol_)["tools"]; }
+  // Test hook. Nothing this server lists today exceeds one page, which is
+  // deliberate -- see kListPageSize -- so the multi-page path would otherwise
+  // ship untested until the first operator with a hundred schemas found it.
+  static bool call_paginate(const json& items, const json& params,
+                            const char* key, json& out) {
+    return paginate(items, params, key, out);
+  }
   const json call_tools_list(const std::string& protocol) {
     return get_tools_list(protocol)["tools"];
   }
@@ -313,6 +346,11 @@ public:
   const json call_connections() { return connections(); }
   const json call_topology() { return topology(); }
   const json call_verify_topology() { return verify_topology(); }
+  const json call_check_privileges() { return check_privileges(); }
+  const json call_evaluate_index(const std::string& sql, const json& create_defs,
+                                 const json& hide_names) {
+    return evaluate_index(sql, create_defs, hide_names);
+  }
   const json call_buffer_cache_summary() { return buffer_cache_summary(); }
   const json call_buffer_cache_contents(int limit) { return buffer_cache_contents(limit); }
   const json call_explain_query(const std::string& queryid, const std::string& sql,
@@ -556,7 +594,9 @@ private:
       if (!c.capacity.note.empty())     entry["host_note"]    = c.capacity.note;
       out.push_back(entry);
     }
-    return out;
+    // Wrapped for the same reason as currentLocks: a top-level array cannot be
+    // a `structuredContent` payload.
+    return json{{"connections", out}};
   }
 
   // The configured topology, as three indexes plus whatever belongs to none of
@@ -908,16 +948,41 @@ private:
       {"listTypes",             {true,  false, false, false}},
       {"searchEnums",           {true,  false, false, false}},
       {"searchFunctions",       {true,  false, false, false}},
+      // Predefined-role membership is cluster-wide, but which extensions are
+      // installed is per database, and so are object grants -- so the answer
+      // legitimately differs between two databases of one instance. A physical
+      // replica returns it verbatim.
+      {"checkPrivileges",       {true,  false, false, false}},
+      // Planning is per database, and a physical replica plans identically off
+      // the same statistics. Like explainQuery it is never swept: the same
+      // statement is rarely valid in another database.
+      {"evaluateIndex",         {true,  false, false, false}},
       {"tableBloat",            {true,  false, false, false}},
       {"typeDetails",           {true,  false, false, false}},
+      // 4.0.0 moved these three off the per_server row below. They were only
+      // ever there because they carried statistics counters; structure is
+      // byte-identical on a physical replica by definition, so a
+      // replication_group sweep used to re-run the whole structural payload --
+      // columns, constraints, triggers, policies, view definitions -- once per
+      // replica to get identical bytes back. Correcting this row is the point
+      // of the split, not a side effect of it.
+      {"listTables",            {true,  false, false, false}},
+      {"searchTables",          {true,  false, false, false}},
+      {"tableDetails",          {true,  false, false, false}},
+      // Measured sizes read the same files on every member of a replication
+      // group, so they belong here too rather than beside the counters.
+      {"listTableSizes",        {true,  false, false, false}},
+      {"tableSize",             {true,  false, false, false}},
 
       // Per-database *and* per-server: they carry statistics counters.
       {"duplicateIndexes",      {true,  true,  false, false}},
       {"indexBloat",            {true,  true,  false, false}},
       {"tableIOStats",          {true,  true,  false, false}},
-      {"listTables",            {true,  true,  true,  false}},
-      {"searchTables",          {true,  true,  true,  false}},
-      {"tableDetails",          {true,  true,  true,  false}},
+      // The other half of the split, and the half that is worth sweeping:
+      // scan counts and dead tuples are each server's own, and vacuum only
+      // runs on the primary.
+      {"listTableStats",        {true,  true,  true,  false}},
+      {"tableStats",            {true,  true,  true,  false}},
       // Frozen xids are replicated, but the vacuum counters beside them are not
       // meaningful on a server where vacuum never runs.
       {"wraparoundStatus",      {true,  false, true,  false}},
@@ -953,6 +1018,832 @@ private:
     return note;
   }
 
+  // ======================= Resources ======================================
+  //
+  // The organising principle is the spec's control model read through
+  // volatility: a resource is a document a client may pin into context and
+  // re-read later, so only structure belongs here. Everything that changes
+  // without a DDL statement -- counters, sizes, activity, locks, plans --
+  // stays a tool, because the model has to decide *when* to take a reading.
+  //
+  // This is what the 4.0.0 statistics split bought. Before it, listTables and
+  // tableDetails carried n_dead_tup, last_vacuum and idx_scan, and serving
+  // them as documents would have invited a client to cache a number that moves
+  // under it. Now the structure half is genuinely stable and the readings have
+  // their own tools.
+  //
+  // URI scheme, namespaced per connection so multi-database stays coherent. A
+  // resource names exactly one object in exactly one database; the topology
+  // axes are deliberately absent, because partial failure across members can
+  // only be reported per member, and that belongs to tools.
+  //
+  //   pglicht://{conn}/schemas
+  //   pglicht://{conn}/schema/{schema}
+  //   pglicht://{conn}/schema/{schema}/table/{table}
+  //   pglicht://{conn}/schema/{schema}/functions
+  //   pglicht://{conn}/schema/{schema}/enums
+  //   pglicht://{conn}/schema/{schema}/types
+  //   pglicht://{conn}/server/roles
+  //   pglicht://{conn}/server/extensions
+  //   pglicht://{conn}/server/settings
+
+  static std::string uri_encode(const std::string& s) {
+    static const char* hex = "0123456789ABCDEF";
+    std::string out;
+    for (char raw : s) {
+      const unsigned char c = static_cast<unsigned char>(raw);
+      if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') out += raw;
+      else { out += '%'; out += hex[c >> 4]; out += hex[c & 0x0F]; }
+    }
+    return out;
+  }
+
+  static std::string uri_decode(const std::string& s) {
+    std::string out;
+    for (size_t i = 0; i < s.size(); i++) {
+      if (s[i] == '%' && i + 2 < s.size()) {
+        out += static_cast<char>(std::stoi(s.substr(i + 1, 2), nullptr, 16));
+        i += 2;
+      } else out += s[i];
+    }
+    return out;
+  }
+
+  static json resource_entry(const std::string& uri, const std::string& name,
+                             const std::string& desc) {
+    return {{"uri", uri}, {"name", name}, {"description", desc},
+            {"mimeType", "application/json"}};
+  }
+
+  // Bounded on purpose. Per connection this lists the handful of documents
+  // that exist without knowing the catalog, plus one entry per schema. Tables,
+  // functions, enums and types are reached through a template instead: a
+  // database with 10 000 tables would otherwise produce a 10 000-entry
+  // response on every resources/list, which clients call eagerly.
+  //
+  // Enumerating schemas does cost one connection per configured connection. A
+  // connection that cannot be reached is skipped rather than failing the list,
+  // so one unreachable database does not hide every other one's schemas.
+  json get_resources_list() {
+    json out = json::array();
+    for (const auto& conn : registry_.names()) {
+      const std::string c = uri_encode(conn);
+      const std::string base = "pglicht://" + c;
+      out.push_back(resource_entry(base + "/schemas", conn + " schemas",
+                                   "Every schema in " + conn + ", with its tables and role grants."));
+      out.push_back(resource_entry(base + "/server/roles", conn + " roles",
+                                   "Cluster-wide roles, attributes and memberships."));
+      out.push_back(resource_entry(base + "/server/extensions", conn + " extensions",
+                                   "Installed extensions, their versions and schemas."));
+      out.push_back(resource_entry(base + "/server/settings", conn + " settings",
+                                   "Server configuration, grouped by category."));
+      const std::string prev = active_;
+      try {
+        active_ = conn;
+        const json schema_list = schemas();   // bound: .items() on a temporary dangles
+        if (schema_list.is_object()) {
+          for (const auto& item : schema_list.items()) {
+            const std::string schema = item.key();
+            out.push_back(resource_entry(
+                base + "/schema/" + uri_encode(schema),
+                conn + "." + schema,
+                "Structure of every table and view in schema " + schema + "."));
+          }
+        }
+      } catch (const std::exception&) {
+        // Unreachable, or the caller cannot read the catalog. Its static
+        // entries above still stand.
+      }
+      active_ = prev;
+    }
+    return {{"resources", out}};
+  }
+
+  json get_resource_templates_list() {
+    json t = json::array();
+    auto tpl = [&](const char* uri, const char* name, const char* desc) {
+      t.push_back({{"uriTemplate", uri}, {"name", name}, {"description", desc},
+                   {"mimeType", "application/json"}});
+    };
+    tpl("pglicht://{conn}/schema/{schema}/table/{table}", "table structure",
+        "Columns, indexes, constraints, foreign keys in both directions, triggers, "
+        "policies and grants for one table. Structure only -- for counters call "
+        "the tableStats tool, for measured size the tableSize tool.");
+    tpl("pglicht://{conn}/schema/{schema}/functions", "schema functions",
+        "Functions and procedures in one schema.");
+    tpl("pglicht://{conn}/schema/{schema}/enums", "schema enums",
+        "Enum types in one schema, with their ordered values.");
+    tpl("pglicht://{conn}/schema/{schema}/types", "schema types",
+        "Composite types, domains and range types in one schema.");
+    tpl("pglicht://{conn}/schema/{schema}", "schema tables",
+        "Structure of every table and view in one schema.");
+    return {{"resourceTemplates", t}};
+  }
+
+  // Splits a pglicht:// URI and answers it with the query method that already
+  // exists. Throws std::invalid_argument for anything unrecognised, which the
+  // caller turns into -32602 rather than a connect error.
+  json read_resource(const std::string& uri) {
+    const std::string prefix = "pglicht://";
+    if (uri.rfind(prefix, 0) != 0)
+      throw std::invalid_argument("unknown resource scheme: " + uri);
+
+    std::vector<std::string> seg;
+    {
+      std::string rest = uri.substr(prefix.size()), cur;
+      for (char ch : rest) {
+        if (ch == '/') { seg.push_back(uri_decode(cur)); cur.clear(); }
+        else cur += ch;
+      }
+      seg.push_back(uri_decode(cur));
+    }
+    if (seg.size() < 2) throw std::invalid_argument("incomplete resource URI: " + uri);
+
+    const std::string conn = seg[0];
+    // Fails here, naming the configured connections, rather than as a
+    // confusing connect error later.
+    (void)registry_.get(conn);
+
+    struct Restore {
+      std::string& slot; std::string prev;
+      ~Restore() { slot = prev; }
+    } restore{active_, active_};
+    active_ = conn;
+
+    if (seg.size() == 2 && seg[1] == "schemas")               return schemas();
+    if (seg.size() == 3 && seg[1] == "server") {
+      if (seg[2] == "roles")      return roles();
+      if (seg[2] == "extensions") return extensions();
+      if (seg[2] == "settings")   return server_settings();
+    }
+    if (seg[1] == "schema" && seg.size() >= 3) {
+      const std::string& sch = seg[2];
+      if (seg.size() == 3)                              return tables(sch);
+      if (seg.size() == 4 && seg[3] == "functions")     return functions(sch);
+      if (seg.size() == 4 && seg[3] == "enums")         return enums(sch);
+      if (seg.size() == 4 && seg[3] == "types")         return types(sch);
+      if (seg.size() == 5 && seg[3] == "table")         return table(sch, seg[4]);
+    }
+    throw std::invalid_argument("unknown resource: " + uri);
+  }
+
+  // ======================= Prompts ========================================
+  //
+  // Static templates with argument substitution: no database is touched until
+  // the model acts on the message and calls a tool. Each one encodes an order
+  // of investigation that is easy to get wrong -- read before you write, check
+  // the replication slot before blaming bloat, observe the role before
+  // trusting a reading -- and names the tools that answer each step.
+
+  struct PromptArg { const char* name; const char* desc; bool required; };
+  struct PromptDef {
+    const char* name;
+    const char* description;
+    std::vector<PromptArg> args;
+    std::string (*render)(const json&);
+  };
+
+  static std::string arg_or(const json& a, const char* key, const std::string& fallback) {
+    if (!a.contains(key) || a[key].is_null()) return fallback;
+    if (a[key].is_string()) return a[key].get<std::string>();
+    return a[key].dump();
+  }
+
+  static const std::vector<PromptDef>& prompt_defs() {
+    static const std::vector<PromptDef> v = {
+      {"diagnose-slow-query",
+       "Trace a slow statement from pg_stat_statements to a plan and a fix.",
+       {{"query_id", "queryid from statementStats; omit to start from the worst offender", false},
+        {"min_duration_s", "ignore statements faster than this mean duration", false}},
+       [](const json& a) -> std::string {
+         const std::string qid = arg_or(a, "query_id", "");
+         const std::string mind = arg_or(a, "min_duration_s", "");
+         std::string s =
+           "Diagnose a slow statement on this PostgreSQL server.\n\n"
+           "0. Call checkPrivileges first. statementStats hides the query text "
+           "of other roles without stats access, explainQuery needs SELECT on "
+           "the tables referenced, and tableBloat needs a grant of its own -- "
+           "a plan built on tools that will not answer wastes the incident.\n"
+           "1. Call statementStats to rank statements by total execution time. "
+           "Read info.dealloc first: if it is non-zero the extension has been "
+           "evicting entries, so the list is the slowest of what survived, not "
+           "the slowest overall -- say so before drawing conclusions.\n";
+         if (!qid.empty())
+           s += "2. The statement of interest is query_id " + qid +
+                ". Call explainQuery with that queryid.\n";
+         else
+           s += "2. Pick the statement with the largest total_exec_time"
+                + (mind.empty() ? std::string()
+                                : " whose mean duration is at least " + mind + "s")
+                + " and call explainQuery with its query_id.\n";
+         s +=
+           "3. Read the plan for the usual causes in this order: a sequential "
+           "scan on a large table, an estimate that is orders of magnitude off "
+           "the actual row count, a sort or hash that spilled to disk, and a "
+           "nested loop driven by a bad estimate.\n"
+           "4. If the estimates are wrong, call tableStats on the tables "
+           "involved and compare n_mod_since_analyze and last_analyze -- stale "
+           "statistics explain more bad plans than missing indexes do.\n"
+           "5. If the plan shows a sequential scan where a usable index exists, "
+           "or an index scan fetching far more heap pages than it returns rows, "
+           "suspect bloat rather than the plan. tableBloat measures dead space "
+           "in the table, indexBloat in one index; both cost a scan, so name "
+           "the object rather than sweeping the schema.\n"
+           "6. If bloat is confirmed, the fix is usually vacuum reaching the "
+           "table more often rather than a REINDEX. Read n_dead_tup and the "
+           "last vacuum times from tableStats and the per-table autovacuum "
+           "settings from tableDetails.reloptions, and follow "
+           "bloat-and-vacuum-review before changing anything cluster-wide -- "
+           "an unconsumed replication slot makes every autovacuum setting "
+           "irrelevant, and that prompt checks for one.\n"
+           "7. Before proposing an index, call duplicateIndexes to check that "
+           "one does not already exist, and tableDetails to see what is there. "
+           "If the change is DDL, follow plan-schema-change: an index that is "
+           "correct and an index that is safe to create on a live server are "
+           "different questions.\n"
+           "8. Decide what kind of fix this is before writing one, and say "
+           "which. Either the statement asks for something the planner cannot "
+           "use -- a predicate that is not sargable, a function or a cast over "
+           "an indexed column, NOT IN against a nullable subquery, OFFSET deep "
+           "into a large result -- and the fix is a rewrite. Or the planner was "
+           "misinformed, and the fix is statistics: an ANALYZE, a higher "
+           "statistics target, or extended statistics for correlated columns. "
+           "Or the plan is right but under-resourced, and the fix is "
+           "configuration, such as work_mem for a node that spilled. Or the "
+           "statement is already well formed and nothing supports the access "
+           "path it needs -- and only then is the fix DDL.\n"
+           "   Prefer them in that order, because that is the order of what "
+           "they cost. An ANALYZE is free and instant. A rewrite costs a deploy "
+           "and nothing in the database. Configuration changes the behaviour of "
+           "every other query too. An index is a write cost paid by every "
+           "INSERT and UPDATE for as long as it exists, to buy speed for one "
+           "read pattern. Say why the cheaper options were rejected rather than "
+           "passing over them.\n"           "9. Verify what can be verified. A rewrite can be checked here and "
+           "now: call explainQuery on the rewritten statement and show that the "
+           "plan actually changed, and how. An index is checkable too "
+           "wherever hypopg is installed: call evaluateIndex with the CREATE "
+           "INDEX statement and report whether the planner actually took it, "
+           "because a proposed index the planner ignores is the common case "
+           "and a cost figure alone hides it. checkPrivileges says whether "
+           "hypopg is there; where it is not, an index is a prediction and has "
+           "to be presented as one rather than as a result. Either way hand "
+           "the creation to plan-schema-change: whether an index is correct "
+           "and whether it is safe to build on this server are different "
+           "questions, and evaluateIndex answers only the first.";
+         return s;
+       }},
+
+      {"triage-lock-contention",
+       "Find what is blocking what, and who to look at first.",
+       {{"connection", "connection to investigate; defaults to the configured default", false}},
+       [](const json& a) -> std::string {
+         const std::string c = arg_or(a, "connection", "");
+         const std::string on = c.empty() ? std::string() : " on connection " + c;
+         return
+           "Triage lock contention" + on + ".\n\n"
+           "0. Call checkPrivileges. Without stats access, currentActivity hides "
+           "the query text of backends belonging to other roles, which is most "
+           "of what this investigation reads.\n\n"
+           "Read before you write. Do not kill anything, and do not recommend "
+           "killing anything until the last step.\n\n"
+           "1. Call currentLocks. The rows carry a chain_depth: 0 is the "
+           "backend asked about, and the largest depth is the backend at the "
+           "root of the wait chain. That is the one to look at first.\n"
+           "2. Call currentActivity for the pids in the chain. For each, read "
+           "state, wait_event_type, query and how long the transaction has "
+           "been open.\n"
+           "3. An idle in transaction backend at the root is the usual answer, "
+           "and the fix is in the application that left it open, not in the "
+           "database.\n"
+           "4. Report the chain root, what it is doing, how long it has held "
+           "the lock, and what is queued behind it. Only then discuss whether "
+           "terminating it is safe, and say what would be lost.";
+       }},
+
+      {"bloat-and-vacuum-review",
+       "Decide whether bloat is real, and whether autovacuum is keeping up.",
+       {{"schema", "schema to review; defaults to public", false}},
+       [](const json& a) -> std::string {
+         const std::string sch = arg_or(a, "schema", "public");
+         return
+           "Review bloat and autovacuum health for schema " + sch + ".\n\n"
+           "0. Call checkPrivileges. tableBloat and indexBloat are denied outright "
+           "to a role without the scanning grant, and tableStats returns null "
+           "statistics rather than an error when it cannot read a column -- "
+           "which looks exactly like a table nobody has analyzed.\n"
+           "1. Call listTableStats for " + sch + ". Rank by n_dead_tup, and "
+           "read last_vacuum and last_autovacuum beside it: a large dead-tuple "
+           "count on a table vacuumed minutes ago is a busy table, not a "
+           "neglected one.\n"
+           "2. Call replicationSlots before concluding anything. An inactive "
+           "or lagging slot holds back the xmin horizon, which stops vacuum "
+           "from removing dead tuples cluster-wide -- and no amount of "
+           "autovacuum tuning fixes it. This is the single most common wrong "
+           "diagnosis in this area.\n"
+           "3. Call wraparoundStatus. If any database or table is approaching "
+           "autovacuum_freeze_max_age, that outranks ordinary bloat.\n"
+           "4. For the worst few tables, call tableBloat to measure rather than "
+           "estimate. Leave exact at its default first; the approximation is "
+           "usually enough to rank them.\n"
+           "5. For an index that looks redundant, duplicateIndexes says it is "
+           "covered and idx_scan says nobody used it on this server -- but "
+           "neither proves the planner would not miss it. Where hypopg is "
+           "installed, evaluateIndex with 'hide' plans the query without the "
+           "index and settles it. Dropping an index is easy; rebuilding one on "
+           "a large table is not.\n"
+           "6. Only where bloat is confirmed, look at per-table autovacuum "
+           "storage parameters via tableDetails.reloptions and propose "
+           "changes. Say which reading justifies each one.";
+       }},
+
+      {"buffer-cache-review",
+       "See what is occupying shared buffers and whether it is the right thing.",
+       {{"connection", "connection to review; defaults to the configured default", false}},
+       [](const json& a) -> std::string {
+         const std::string c = arg_or(a, "connection", "");
+         const std::string on = c.empty() ? std::string() : " on connection " + c;
+         return
+           "Review shared buffer usage" + on + ".\n\n"
+           "0. Call checkPrivileges. Both buffer-cache tools need the monitoring "
+           "role, and they are the whole of this review.\n"
+           "1. Call bufferCacheSummary first. It is cheap; bufferCacheContents "
+           "aggregates every buffer and is not.\n"
+           "2. Call hostCapacity and compare shared_buffers against the host's "
+           "RAM, and effective_cache_size against what the OS can plausibly "
+           "cache.\n"
+           "3. Call tableIOStats. A low hit ratio on a small, frequently read "
+           "table is the actionable case; a low ratio on a large table scanned "
+           "once a day is not a problem.\n"
+           "4. Only if the summary suggests something is wrong, call "
+           "bufferCacheContents to see which relations hold the buffers.\n"
+           "5. Report whether the cache is undersized, mis-sized relative to "
+           "the host, or being churned by one workload, and say which reading "
+           "supports the conclusion.";
+       }},
+
+      {"capacity-check",
+       "Check memory and parallelism settings against the machine.",
+       {{"connection", "connection to check; defaults to the configured default", false}},
+       [](const json& a) -> std::string {
+         const std::string c = arg_or(a, "connection", "");
+         const std::string on = c.empty() ? std::string() : " for connection " + c;
+         return
+           "Check server capacity settings" + on + ".\n\n"
+           "1. Call hostCapacity. If it reports that host RAM and vCPU count "
+           "are unknown, say so and stop with a partial answer: PostgreSQL "
+           "cannot see the machine it runs on, and those values have to be "
+           "declared per connection in the config file. Do not guess them.\n"
+           "2. Read derived.committed_worst_case_percent_of_ram. This is "
+           "work_mem times max_connections plus maintenance_work_mem times "
+           "autovacuum_max_workers, and it is the number that decides whether "
+           "the OOM killer is a risk.\n"
+           "3. Compare shared_buffers and effective_cache_size against RAM.\n"
+           "4. Check parallelism: max_parallel_workers_per_vcpu above 1 means "
+           "a single query can oversubscribe the machine.\n"
+           "5. Call databaseStats and read numbackends against max_connections "
+           "to see how much of the worst case is actually reached.\n"
+           "6. Report each finding with the reading behind it, and name the "
+           "setting to change.";
+       }},
+
+      {"replication-slot-review",
+       "Find what a replication slot is holding back, and what it costs to release it.",
+       {{"connection", "connection to review; defaults to the configured default", false}},
+       [](const json& a) -> std::string {
+         const std::string c = arg_or(a, "connection", "");
+         const std::string on = c.empty() ? std::string() : " on connection " + c;
+         return
+           "Review replication slots" + on + " and what they are holding back.\n\n"
+           "An unconsumed slot is the failure mode that presents as something "
+           "else. It holds back the xmin horizon, so vacuum cannot remove dead "
+           "tuples anywhere in the cluster; and it pins WAL until the disk "
+           "fills. Both symptoms get diagnosed as bloat, or as a disk problem, "
+           "and neither diagnosis leads anywhere.\n\n"
+           "0. Call checkPrivileges: a role without stats access sees less of "
+           "replicationSlots and of currentActivity than this review needs.\n"
+           "1. Call replicationSlots. For each slot read three things: whether "
+           "it is active, how far its restart_lsn trails the current WAL "
+           "position, and its wal_status. reserved is healthy. extended means "
+           "it has gone past max_wal_size. unreserved means the slot is now the "
+           "only thing keeping that WAL on disk. lost means the WAL it needs is "
+           "already gone and the consumer cannot resume -- that slot is dead, "
+           "and only rebuilding its consumer fixes it.\n"
+           "2. An inactive slot with growing lag is the finding. Before "
+           "anything else, establish whose it is: listTopology and "
+           "verifyTopology for physical replicas, listSubscriptions and "
+           "listPublications for logical ones. A slot with no owner anybody "
+           "recognises is the common case and the easy one.\n"
+           "3. Measure how fast it grows before deciding how urgent it is. "
+           "checkpointStats reports WAL volume, and serverSettings carries "
+           "max_slot_wal_keep_size -- if that is set, PostgreSQL will "
+           "invalidate the slot rather than fill the disk, which trades a "
+           "broken replica for a live primary. If it is unset, nothing bounds "
+           "the growth.\n"
+           "4. Call wraparoundStatus. The same held xmin horizon also stops "
+           "freezing, and if wraparound headroom is shrinking that outranks the "
+           "disk: one ends in a slow server, the other in a cluster that stops "
+           "accepting writes.\n"
+           "5. Report the slot, its owner, what it is holding, and how long the "
+           "disk has at the current rate. Dropping a slot is irreversible for "
+           "its consumer: say exactly what would have to be rebuilt, and prefer "
+           "fixing or decommissioning the consumer over dropping the slot "
+           "underneath it.";
+       }},
+
+      {"plan-schema-change",
+       "Choose how to apply a DDL change by measuring the table it targets.",
+       {{"change", "the change you intend to make, in your own words", true},
+        {"schema", "schema of the table being changed", false},
+        {"table", "table being changed", false}},
+       [](const json& a) -> std::string {
+         const std::string change = arg_or(a, "change", "");
+         const std::string sch = arg_or(a, "schema", "");
+         const std::string tbl = arg_or(a, "table", "");
+         std::string target;
+         if (!tbl.empty()) target = "Target: " + (sch.empty() ? "" : sch + ".") + tbl + "\n";
+         return
+           "Plan this schema change against what this database actually is.\n\n"
+           "The change: " + change + "\n" + target + "\n"
+           "This server is read-only and will run none of it. What you produce "
+           "is a plan for an operator to apply.\n\n"
+           "Do not answer from a recipe. The safe method for a change is a "
+           "property of the table in front of you, not of the statement: the "
+           "same DDL that is instant on one table is an outage on another. A "
+           "table with no rows can be rewritten in place and nobody notices; "
+           "the same rewrite at a billion rows is hours under an exclusive "
+           "lock. Partitioning is the extreme case -- trivial before there is "
+           "data, a migration project with a cutover after it. Reaching for the "
+           "safest-at-scale approach on a small table is complexity nobody "
+           "needs, and reaching for the simple one on a large table is the "
+           "outage. Measure first, then choose, and say which reading decided "
+           "it.\n\n"
+           "1. Call checkPrivileges. tableStats and tableSize are what this "
+           "whole plan rests on; if either is degraded here, say so rather than "
+           "estimating, because they are what separates a metadata change from "
+           "a full rewrite.\n"
+           "2. Identify every object the change touches, then measure each of "
+           "them -- not only the one named as the target. A statement that "
+           "names one table routinely locks more than one: a foreign key locks "
+           "the table it references as well as the table it is added to, a "
+           "partitioned table means the parent and every partition, and a "
+           "column that other tables reference cannot be considered alone. The "
+           "object you did not name is often the busier one, and its lock is "
+           "the one that surprises people. Read the change itself for the "
+           "objects it names, and tableDetails for the ones the catalog knows "
+           "about -- foreign keys in both directions, and inheritance or "
+           "partition parents.\n"
+           "   For each of them:\n"
+           "   - tableStats: the row count, and n_distinct and most_common_vals "
+           "when the change involves a default, an index or a partition key -- "
+           "most_common_vals is the empirical answer to what value the rows "
+           "already hold\n"
+           "   - tableSize: what a rewrite would actually move. Use the "
+           "measured size, not the estimate; this is the number that turns "
+           "\"instant\" into \"an hour\"\n"
+           "   - tableDetails: the indexes, constraints, inbound foreign keys "
+           "and triggers already there, and whether it is already partitioned. "
+           "Each one multiplies the cost of a rewrite, and some rule out "
+           "approaches outright\n"
+           "   - the scan and tuple counters in tableStats: how busy it is. A "
+           "lock window costs nothing on a table nothing is touching\n"
+           "   - currentActivity and currentLocks: the oldest running "
+           "transaction, and whether anything already holds or waits for a lock "
+           "on any of these objects. A brief exclusive lock request waits "
+           "behind a long transaction, and everything arriving after it waits "
+           "behind that -- which is how a millisecond operation becomes an "
+           "outage. Check this for every object the change touches, since one "
+           "busy parent is enough to stall the whole statement\n"
+           "   - serverSettings for the server version, since what is possible "
+           "and what it costs both moved across majors\n"
+           "   - listTopology and replicationSlots if the change rewrites: the "
+           "WAL a rewrite generates has to reach every replica and pass through "
+           "every slot\n"
+           "3. From those numbers, classify the change before writing any DDL. "
+           "Say which of the three it is -- metadata only, a scan without a "
+           "rewrite, or a full rewrite of the table and its indexes -- and "
+           "separately what lock it needs and for how long. The lock level "
+           "alone settles nothing: a strong lock held for a millisecond is "
+           "safe, and a weak one held for an hour may not be. Duration is the "
+           "number that matters, and duration comes from the measurements.\n"
+           "4. Choose the method by matching that cost against what this table "
+           "can tolerate. Above some size the incremental approach is the only "
+           "one available; below it, it is machinery for nothing. State the "
+           "size or rate at which your answer would flip, so the reasoning can "
+           "be checked against a different table later.\n"
+           "5. Give the plan as ordered DDL. Against each statement say the "
+           "lock it takes, whether it rewrites, what must not be running "
+           "alongside it, and roughly how long at this table's measured size.\n"
+           "6. Say what the revert looks like, and flag anything irreversible "
+           "as irreversible whatever the size.";
+       }},
+
+      {"explain-and-fix",
+       "Explain one statement and propose a concrete fix.",
+       {{"sql", "the statement to explain", true},
+        {"params", "JSON array of parameter values, if the statement is parameterised", false}},
+       [](const json& a) -> std::string {
+         const std::string sql = arg_or(a, "sql", "");
+         const std::string prm = arg_or(a, "params", "");
+         return
+           "Explain this statement and propose a fix.\n\n"
+           "SQL:\n" + sql + "\n\n" +
+           (prm.empty() ? std::string()
+                        : "Parameters: " + prm + "\n\n") +
+           "0. Call checkPrivileges: EXPLAIN needs SELECT on every table the "
+           "statement touches, so a restricted role fails here rather than "
+           "returning a worse plan.\n"
+           "1. Call explainQuery with this sql" +
+           (prm.empty() ? std::string() : " and these params") +
+           ". Leave analyze false on the first call: the plan alone usually "
+           "shows the problem, and analyze executes the statement.\n"
+           "2. If the plan is not conclusive and the statement is a SELECT, "
+           "call again with analyze true to get actual row counts and timing. "
+           "The server proves the plan has no ModifyTable node before running "
+           "it, so this cannot mutate -- but say that you are about to run it.\n"
+           "3. Compare estimated against actual rows at each node. A ratio "
+           "worse than about 100x is a statistics problem, not an index "
+           "problem.\n"
+           "4. Call tableDetails and tableStats on the tables involved before "
+           "proposing an index: check what indexes exist, and whether "
+           "last_analyze is recent.\n"
+           "5. Decide what kind of fix this is before writing one, and say "
+           "which. Either the statement asks for something the planner cannot "
+           "use -- a predicate that is not sargable, a function or a cast over "
+           "an indexed column, NOT IN against a nullable subquery, OFFSET deep "
+           "into a large result -- and the fix is a rewrite. Or the planner was "
+           "misinformed, and the fix is statistics: an ANALYZE, a higher "
+           "statistics target, or extended statistics for correlated columns. "
+           "Or the plan is right but under-resourced, and the fix is "
+           "configuration, such as work_mem for a node that spilled. Or the "
+           "statement is already well formed and nothing supports the access "
+           "path it needs -- and only then is the fix DDL.\n"
+           "   Prefer them in that order, because that is the order of what "
+           "they cost. An ANALYZE is free and instant. A rewrite costs a deploy "
+           "and nothing in the database. Configuration changes the behaviour of "
+           "every other query too. An index is a write cost paid by every "
+           "INSERT and UPDATE for as long as it exists, to buy speed for one "
+           "read pattern. Say why the cheaper options were rejected rather than "
+           "passing over them.\n"           "6. Verify what can be verified. A rewrite can be checked here and "
+           "now: call explainQuery on the rewritten statement and show that the "
+           "plan actually changed, and how. An index is checkable too "
+           "wherever hypopg is installed: call evaluateIndex with the CREATE "
+           "INDEX statement and report whether the planner actually took it, "
+           "because a proposed index the planner ignores is the common case "
+           "and a cost figure alone hides it. checkPrivileges says whether "
+           "hypopg is there; where it is not, an index is a prediction and has "
+           "to be presented as one rather than as a result. Either way hand "
+           "the creation to plan-schema-change: whether an index is correct "
+           "and whether it is safe to build on this server are different "
+           "questions, and evaluateIndex answers only the first.";
+       }},
+    };
+    return v;
+  }
+
+  json get_prompts_list() {
+    json out = json::array();
+    for (const auto& p : prompt_defs()) {
+      json args = json::array();
+      for (const auto& a : p.args)
+        args.push_back({{"name", a.name}, {"description", a.desc}, {"required", a.required}});
+      out.push_back({{"name", p.name}, {"description", p.description}, {"arguments", args}});
+    }
+    return {{"prompts", out}};
+  }
+
+  json get_prompt(const std::string& name, const json& arguments) {
+    for (const auto& p : prompt_defs()) {
+      if (name != p.name) continue;
+      for (const auto& a : p.args)
+        if (a.required && (!arguments.contains(a.name) || arguments[a.name].is_null()))
+          throw std::invalid_argument(std::string("prompt ") + p.name +
+                                      " requires argument '" + a.name + "'");
+      return {{"description", p.description},
+              {"messages", {{{"role", "user"},
+                             {"content", {{"type", "text"}, {"text", p.render(arguments)}}}}}}};
+    }
+    throw std::invalid_argument("unknown prompt: " + name);
+  }
+
+  // ======================= Completions ====================================
+  //
+  // completion/complete is defined for prompt arguments and resource template
+  // variables -- there is no ref/tool in the spec -- so this covers the schema,
+  // table and connection variables that appear in both. The backing queries
+  // already exist; nothing new touches the database.
+  //
+  // A completion is a convenience, so it must never be the thing that fails a
+  // session: an unreachable database or an unreadable catalog returns an empty
+  // list rather than an error.
+  json complete(const json& ref, const json& argument) {
+    const std::string arg_name = argument.value("name", "");
+    const std::string typed    = argument.value("value", "");
+    std::vector<std::string> values;
+
+    auto starts_with = [&](const std::string& s) {
+      return typed.empty() || s.rfind(typed, 0) == 0;
+    };
+
+    try {
+      if (arg_name == "conn" || arg_name == "connection") {
+        for (const auto& n : registry_.names()) if (starts_with(n)) values.push_back(n);
+      } else if (arg_name == "schema") {
+        const std::string prev = active_;
+        struct R { std::string& s; std::string p; ~R(){ s = p; } } r{active_, prev};
+        // A resource template carries the connection in the same URI, but the
+        // completion request does not pass sibling variables, so this can only
+        // complete against the default connection. Better than nothing, and it
+        // never guesses at a connection the caller did not name.
+        const json all = schemas();
+        if (all.is_object())
+          for (const auto& it : all.items())
+            if (starts_with(it.key())) values.push_back(it.key());
+      } else if (arg_name == "table") {
+        const std::string prev = active_;
+        struct R { std::string& s; std::string p; ~R(){ s = p; } } r{active_, prev};
+        const json all = tables("public");
+        if (all.is_object())
+          for (const auto& it : all.items())
+            if (starts_with(it.key())) values.push_back(it.key());
+      }
+    } catch (const std::exception&) {
+      values.clear();
+    }
+    (void)ref;
+
+    // The spec caps a completion response at 100 values and asks the server to
+    // say whether more exist.
+    const bool has_more = values.size() > 100;
+    if (has_more) values.resize(100);
+    return {{"completion", {{"values", values},
+                            {"total", values.size()},
+                            {"hasMore", has_more}}}};
+  }
+
+  // --- outputSchema -------------------------------------------------------
+  //
+  // Emitted only to a client that negotiated 2025-06-18: that revision defined
+  // both `outputSchema` and `structuredContent`, and declaring a schema for a
+  // payload the client will never receive in structured form is noise.
+  //
+  // These are deliberately permissive, and that is the design rather than a
+  // shortcut. The roadmap's own warning is the real risk: a client that
+  // validates results against a declared schema turns any drift between the
+  // schema and the payload into a failed call, on a call that worked before.
+  // Three things make leaf-level schemas unsafe here:
+  //
+  //   1. Payloads are version-conditional. tableStats gains
+  //      n_tup_newpage_upd and last_seq_scan on PostgreSQL 16, checkpointStats
+  //      is normalised across three different sets of underlying views, and a
+  //      schema would have to be re-proved on five majors for 58 tools.
+  //   2. Every tool carries the same escape hatch: when an extension is absent
+  //      or a grant is missing, the payload is {error, hint} instead of the
+  //      documented shape. A schema that enumerated the documented shape would
+  //      reject exactly the answer an operator most needs to read.
+  //   3. A catalog is open-ended. New PostgreSQL releases add columns.
+  //
+  // So each schema names the shape it can actually promise, types the keys
+  // that are unconditional, marks nothing `required`, and allows additional
+  // properties. It can describe a payload; it can never reject one this server
+  // produces. A test walks real payloads against these to keep that true.
+
+  static json schema_map(const std::string& keyed_by, const std::string& entry) {
+    return {{"type", "object"},
+            {"description", "Keyed by " + keyed_by + "; each value is " + entry +
+                            ". An absent extension or a missing grant is reported "
+                            "as {error, hint} in place of the map."},
+            {"additionalProperties", true}};
+  }
+
+  static json schema_fixed(const std::string& desc,
+                           std::initializer_list<std::pair<const char*, const char*>> props) {
+    json p = json::object();
+    // Every declared type admits null. Almost all of these come out of a LEFT
+    // JOIN or a nullable catalog column -- tableDetails.definition is null for
+    // an ordinary table, reloptions is null unless storage parameters were set,
+    // last_vacuum is null on a table never vacuumed -- and a schema that said
+    // "integer" where the server can legitimately answer null would reject a
+    // correct payload. That is the one failure this whole table exists to
+    // avoid, so it is spelled out rather than left to chance.
+    for (const auto& kv : props)
+      p[kv.first] = json{{"type", json::array({kv.second, "null"})}};
+    return {{"type", "object"},
+            {"description", desc + " An absent extension or a missing grant is "
+                            "reported as {error, hint} instead."},
+            {"properties", p},
+            {"additionalProperties", true}};
+  }
+
+  static const std::map<std::string, json>& tool_output_schemas() {
+    static const std::map<std::string, json> m = {
+      // --- schema exploration: name -> object ---
+      {"listSchemas",            schema_map("schema name", "that schema's tables, views and role grants")},
+      {"listTables",             schema_map("table name", "that table's structure")},
+      {"searchTables",           schema_map("schema-qualified table name", "that table's structure")},
+      {"listFunctions",          schema_map("function signature", "that routine's signature and properties")},
+      {"searchFunctions",        schema_map("schema-qualified function signature", "that routine's signature and properties")},
+      {"functionDetails",        schema_map("function signature", "that routine's source, definition and grants")},
+      {"listEnums",              schema_map("enum type name", "that enum's ordered values")},
+      {"searchEnums",            schema_map("enum type name", "that enum's ordered values")},
+      {"enumDetails",            schema_map("enum type name", "its values and the columns that reference it")},
+      {"listTypes",              schema_map("type name", "that composite, domain or range type")},
+      {"typeDetails",            schema_map("type name", "its attributes or subtype and the columns using it")},
+      {"listSequences",          schema_map("sequence name", "that sequence's range, increment and owning column")},
+      {"listExtendedStatistics", schema_map("statistics object name", "its target table, columns and kinds")},
+      {"listCollations",         schema_map("collation name", "its provider, ctype and determinism")},
+      {"listCasts",              schema_map("source->target type pair", "that cast's function and context")},
+      {"listOperators",          schema_map("operator signature", "its operand and result types")},
+      {"listOperatorClasses",    schema_map("opclass name and access method", "its input type and default flag")},
+      {"listAccessMethods",      schema_map("access method name", "its kind and handler")},
+      {"listLanguages",          schema_map("language name", "its handler, trust and ownership")},
+      {"listTextSearchConfigs",  schema_map("configuration name", "its parser and token mappings")},
+      {"listEventTriggers",      schema_map("event trigger name", "its event, function and enabled state")},
+      {"listExtensions",         schema_map("extension name", "its version and installation schema")},
+      {"listRoles",              schema_map("role name", "its attributes and group memberships")},
+      {"listTablespaces",        schema_map("tablespace name", "its location, owner and options")},
+      {"listForeignServers",     schema_map("server name", "its wrapper, options and user mappings")},
+      {"listForeignTables",      schema_map("foreign table name", "its server and column list")},
+      {"listPublications",       schema_map("publication name", "its tables and replicated operations")},
+      {"listSubscriptions",      schema_map("subscription name", "its publication, slot and state")},
+      {"replicationSlots",       schema_map("slot name", "its type, activity and retained WAL")},
+
+      // --- statistics keyed by object ---
+      {"listTableStats",         schema_map("table name", "that table's statistics counters and size estimate")},
+      {"listTableSizes",         schema_map("table name", "that table's measured size, index size and total")},
+      {"tableIOStats",           schema_map("schema-qualified table name", "its buffer cache hit ratios and scan counts")},
+      {"databaseStats",          schema_map("database name", "that database's pg_stat_database counters")},
+      {"currentActivity",        schema_map("backend pid", "that backend's state, query and wait event")},
+      {"serverSettings",         schema_map("settings category", "a map of setting name to its value and metadata")},
+      {"bufferCacheContents",    schema_map("schema-qualified relation name", "its buffered pages and usage counts")},
+
+      // --- fixed shapes ---
+      {"tableDetails",           schema_fixed("One table's structure.",
+                                   {{"table", "string"}, {"kind", "string"}, {"description", "string"},
+                                    {"columns", "object"}, {"primary_key", "array"}, {"indexes", "object"},
+                                    {"constraints", "object"}, {"foreign_keys", "object"},
+                                    {"referenced_by", "object"}, {"triggers", "object"}, {"rules", "object"},
+                                    {"row_level_security", "object"}, {"policies", "object"},
+                                    {"roles", "object"}})},
+      {"tableStats",             schema_fixed("One table's statistics.",
+                                   {{"table", "string"}, {"rows", "number"}, {"size_estimate", "integer"},
+                                    {"seq_scan", "integer"}, {"idx_scan", "integer"},
+                                    {"n_live_tup", "integer"}, {"n_dead_tup", "integer"},
+                                    {"n_mod_since_analyze", "integer"}, {"n_ins_since_vacuum", "integer"},
+                                    {"columns", "object"}, {"indexes", "object"}})},
+      {"tableSize",              schema_fixed("One table's measured size.",
+                                   {{"table", "string"}, {"kind", "string"}, {"main_size", "integer"},
+                                    {"size", "integer"}, {"indexes_size", "integer"},
+                                    {"total_size", "integer"}, {"indexes", "object"}})},
+      {"databaseSize",           schema_fixed("Size of the connected database.",
+                                   {{"database", "string"}, {"size", "integer"}})},
+      {"checkKey",               schema_fixed("Whether a row with the given key exists.",
+                                   {{"exists", "boolean"}})},
+      {"evaluateIndex",          schema_fixed("How a statement would plan with different indexes.",
+                                   {{"statement", "string"}, {"hypopg_version", "string"},
+                                    {"baseline", "object"}, {"hypothetical", "object"},
+                                    {"cost_ratio", "number"}, {"indexes", "array"},
+                                    {"hidden", "array"}, {"note", "string"}})},
+      {"checkPrivileges",        schema_fixed("Which tools this role can use on this connection.",
+                                   {{"connection", "string"}, {"role", "string"},
+                                    {"tools", "integer"}, {"available", "integer"},
+                                    {"degraded", "array"}, {"denied", "array"}})},
+      {"currentLocks",           schema_fixed("Lock rows, newest blocking chain first.",
+                                   {{"locks", "array"}})},
+      {"listConnections",        schema_fixed("The configured connection registry.",
+                                   {{"connections", "array"}})},
+      {"listTopology",           schema_fixed("The three configured topology axes.",
+                                   {{"instances", "array"}, {"replication_groups", "array"},
+                                    {"groups", "array"}, {"unlabelled", "array"}})},
+      {"verifyTopology",         schema_fixed("Declared topology checked against each server.",
+                                   {{"connections", "array"}, {"findings", "array"}})},
+      {"ioStats",                schema_fixed("pg_stat_io rows per backend type and context.",
+                                   {{"io", "array"}})},
+      {"duplicateIndexes",       schema_fixed("Indexes that duplicate or cover another.",
+                                   {{"identical", "array"}, {"redundant", "array"}})},
+      {"progressStats",          schema_fixed("Running commands, one array per category; always all six.",
+                                   {{"vacuum", "array"}, {"analyze", "array"}, {"create_index", "array"},
+                                    {"cluster", "array"}, {"copy", "array"}, {"basebackup", "array"}})},
+      {"wraparoundStatus",       schema_fixed("Transaction id and multixact headroom.",
+                                   {{"databases", "object"}, {"tables", "array"}, {"limits", "object"}})},
+      {"checkpointStats",        schema_fixed("Checkpoint, WAL and background writer activity, normalised across versions.",
+                                   {{"checkpointer", "object"}, {"bgwriter", "object"}, {"backend_io", "object"},
+                                    {"wal", "object"}, {"settings", "object"}, {"source", "string"}})},
+      {"hostCapacity",           schema_fixed("Memory and parallelism settings against the host.",
+                                   {{"host", "object"}, {"server", "object"}, {"settings", "object"},
+                                    {"derived", "object"}})},
+      {"statementStats",         schema_fixed("pg_stat_statements rows with the extension's own counters.",
+                                   {{"statements", "array"}, {"info", "object"}})},
+      {"explainQuery",           schema_fixed("An EXPLAIN plan and what produced it.",
+                                   {{"plan", "array"}, {"sql", "string"}, {"source", "string"},
+                                    {"analyzed", "boolean"}, {"generic", "boolean"},
+                                    {"read_only", "boolean"}})},
+      {"tableBloat",             schema_fixed("Physical storage bloat for one table.", {})},
+      {"indexBloat",             schema_fixed("Physical statistics for one index, per access method.", {})},
+      {"bufferCacheSummary",     schema_fixed("Shared buffer occupancy across the instance.", {})},
+    };
+    return m;
+  }
+
   const json get_tools_list(const std::string& protocol) {
     json list = {
       {"tools", {
@@ -966,7 +1857,7 @@ private:
 	  },
 	  {
 	    {"name", "listTables"},
-	    {"description", "return table list with basic statistics"},
+	    {"description", "return the structure of every table, view and materialised view in a schema: kind, comment, storage options, columns and their per-column index counts, index count and constraint count. Structure only -- it changes when someone issues DDL and not otherwise. For row counts, scan counters, dead tuples and vacuum times call listTableStats; for measured on-disk sizes call listTableSizes"},
 	    {"inputSchema", {
 		{"type", "object"},
 		{"properties", {
@@ -977,7 +1868,7 @@ private:
 	  },
 	  {
 	    {"name", "tableDetails"},
-	    {"description", "return table details like columns, foreign keys, inbound foreign keys (referenced_by), indexes, data histograms"},
+	    {"description", "return the structure of one table: columns with types, defaults, storage and compression, primary key, indexes, constraints, foreign keys, inbound foreign keys (referenced_by), triggers, rules, row-level security, policies and privileges. Structure only -- it changes when someone issues DDL and not otherwise, and it returns no sample column values. For row counts, scan counters, dead tuples, vacuum times and the pg_stats column histograms call tableStats; for measured on-disk sizes call tableSize"},
 	    {"inputSchema", {
 		{"type", "object"},
 		{"properties", {
@@ -989,13 +1880,82 @@ private:
 	  },
 	  {
 	    {"name", "searchTables"},
-	    {"description", "return table list with basic statistics based on text search"},
+	    {"description", "find tables across every non-system schema by full-text search over table names, comments, column names and comments, enum labels and grantee names, and return their structure. Structure only -- there is no statistics counterpart, because a text search is how you find a table, not how you read a counter: name a match to tableStats or tableSize for those"},
 	    {"inputSchema", {
 		{"type", "object"},
 		{"properties", {
 		    {"web_search", {{"type", "string"}}}
 		  }},
 		{"required", {"web_search"}}
+	      }}
+	  },
+	  {
+	    {"name", "evaluateIndex"},
+	    {"description", "plan a statement as if the indexes were different, using hypopg. 'create' takes CREATE INDEX statements to plan against without building them; 'hide' takes the names of existing indexes to plan without, which is how to ask whether an index is safe to drop. Nothing is built, no lock is taken and no catalog row is written, and the statement is never executed -- hypopg cannot serve EXPLAIN ANALYZE, so this is plan-only and safer than explainQuery with analyze. Returns the plan and total cost before and after, and for each index whether the planner actually used it, which is the answer that matters: a proposed index the planner ignores is the common case and a cost figure alone hides it. The cost is the planner's estimate, not a measurement. For a statement recovered from pg_stat_statements, call explainQuery with its queryid first and pass the sql it echoes back. Reports a clear error with setup instructions if hypopg is not installed"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", {
+		    {"sql", {{"type", "string"}}},
+		    {"create", {{"type", "array"}, {"items", {{"type", "string"}}},
+		                {"description", "CREATE INDEX statements to plan against"}}},
+		    {"hide", {{"type", "array"}, {"items", {{"type", "string"}}},
+		              {"description", "names of existing indexes to plan without"}}}
+		  }},
+		{"required", {"sql"}}
+	      }}
+	  },
+	  {
+	    {"name", "checkPrivileges"},
+	    {"description", "report which tools the current role can actually use on this connection, and how the rest fall short. Most of this server works for any role that can connect, because the catalog is world-readable; what varies is the monitoring extras and whether the role can read table data. Call this first when working against an unfamiliar connection or a restricted role -- the alternative is discovering the limits tool by tool, and a privilege-filtered answer is easy to mistake for an empty one. Names no role memberships and no GRANT statements: what a caller needs is which tools work. Tools absent from both lists are fully available"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", json::object()}
+	      }}
+	  },
+	  {
+	    {"name", "tableStats"},
+	    {"description", "return the statistics PostgreSQL keeps for one table: estimated row count, seq_scan and idx_scan counts, live and dead tuples, rows modified since the last analyze, rows inserted since the last vacuum, the last vacuum and analyze times, per-index scan counts, and the per-column pg_stats histograms (null_frac, avg_width, n_distinct, physical order correlation, most_common_vals and their frequencies). Reads the catalog and the statistics collector only -- no relation is opened and no file is measured. size_estimate is relpages*8192 and is only as fresh as estimated_from says: for a measured size call tableSize. Note that most_common_vals contains literal values sampled from the column. Not to be confused with tableIOStats, which reports pg_statio_all_tables -- whether reads came from the buffer cache or the disk"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", {
+		    {"table", {{"type", "string"}}},
+		    {"schema", {{"type", "string"}}}
+		  }},
+		{"required", {"table", "schema"}}
+	      }}
+	  },
+	  {
+	    {"name", "listTableStats"},
+	    {"description", "return the statistics PostgreSQL keeps for every table in a schema: estimated row count, seq_scan and idx_scan counts, live and dead tuples, rows modified since the last analyze, rows inserted since the last vacuum, and the last vacuum and analyze times. Reads the catalog and the statistics collector only -- no relation is opened and no file is measured. Carries no per-column histograms; name one table to tableStats for those. size_estimate is relpages*8192 and is only as fresh as estimated_from says: for measured sizes call listTableSizes"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", {
+		    {"schema", {{"type", "string"}}}
+		  }},
+		{"required", {"schema"}}
+	      }}
+	  },
+	  {
+	    {"name", "tableSize"},
+	    {"description", "measure one table on disk: main fork, total table size including TOAST and the free space and visibility maps, index size, grand total, the TOAST relation and each index individually. COSTS MORE THAN IT LOOKS: these functions open the relation with AccessShareLock, so on a table an ALTER TABLE is rewriting the call waits behind AccessExclusiveLock until statement_timeout fires. Prefer size_estimate from tableStats, which is free, and call this when the estimate is too stale to act on. A partitioned table reports its own storage, which is zero -- measure the partitions"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", {
+		    {"table", {{"type", "string"}}},
+		    {"schema", {{"type", "string"}}}
+		  }},
+		{"required", {"table", "schema"}}
+	      }}
+	  },
+	  {
+	    {"name", "listTableSizes"},
+	    {"description", "measure every table in a schema on disk: table size, index size and grand total per relation. COSTS MORE THAN IT LOOKS, and more here than in tableSize: one relation is opened per table, each taking AccessShareLock, so a single table held under AccessExclusiveLock by an ALTER TABLE blocks the whole call rather than one row of it, and on a large schema this is thousands of file-metadata calls. Prefer size_estimate from listTableStats, which is free, and call this when the estimates are too stale to act on. Partitioned tables report their own storage, which is zero"},
+	    {"inputSchema", {
+		{"type", "object"},
+		{"properties", {
+		    {"schema", {{"type", "string"}}}
+		  }},
+		{"required", {"schema"}}
 	      }}
 	  },
 	  {
@@ -1407,7 +2367,7 @@ private:
 	  },
 	  {
 	    {"name", "tableIOStats"},
-	    {"description", "return per-object buffer cache hit ratios (pg_statio_all_tables): heap_blks_read versus heap_blks_hit, idx_blks_read versus idx_blks_hit, the TOAST and TOAST-index pairs, and a combined ratio, with relation size and scan counts. Naming a single table adds a per-index breakdown from pg_statio_all_indexes. Ratios are null, not zero, for an object that has seen no reads at all"},
+	    {"description", "return per-object buffer cache hit ratios (pg_statio_all_tables): heap_blks_read versus heap_blks_hit, idx_blks_read versus idx_blks_hit, the TOAST and TOAST-index pairs, and a combined ratio, with relation size and scan counts. Naming a single table adds a per-index breakdown from pg_statio_all_indexes. Ratios are null, not zero, for an object that has seen no reads at all. Not to be confused with tableStats, which reports pg_stat_user_tables -- scans, tuples and vacuum state; this tool answers only whether those reads came from the buffer cache or the disk"},
 	    {"inputSchema", {
 		{"type", "object"},
 		{"properties", {
@@ -1462,7 +2422,7 @@ private:
 	  },
 	  {
 	    {"name", "tableBloat"},
-	    {"description", "return physical storage bloat for a table (pgstattuple/pgstattuple_approx): table size, live/dead tuple counts and percentages, free space and percentage. Defaults to the cheap visibility-map-based approximation; set exact=true for a precise but I/O-heavy full table scan. More accurate than the ANALYZE-time estimates in listTables/tableDetails. Returns a clear error with setup instructions if the pgstattuple extension is not installed"},
+	    {"description", "return physical storage bloat for a table (pgstattuple/pgstattuple_approx): table size, live/dead tuple counts and percentages, free space and percentage. Defaults to the cheap visibility-map-based approximation; set exact=true for a precise but I/O-heavy full table scan. More accurate than the ANALYZE-time estimates in listTableStats/tableStats. Returns a clear error with setup instructions if the pgstattuple extension is not installed"},
 	    {"inputSchema", {
 		{"type", "object"},
 		{"properties", {
@@ -1589,6 +2549,10 @@ private:
     // them by date.
     const bool wants_annotations = protocol >= "2025-03-26";
     const bool wants_title       = protocol >= "2025-06-18";
+    // Same revision that defined structuredContent, and gated together on
+    // purpose: outputSchema describes the structured payload, so a client that
+    // will only ever be sent a text block has no use for it.
+    const bool wants_output_schema = protocol >= kStructuredContentRevision;
 
     for (auto& tool : list["tools"]) {
       const std::string name = tool["name"].get<std::string>();
@@ -1655,13 +2619,20 @@ private:
         tool["annotations"] = ann;
       }
       if (wants_title) tool["title"] = tool_title(name);
+      if (wants_output_schema) {
+        auto os = tool_output_schemas().find(name);
+        // A tool with no schema is a bug, not a default: declaring none for one
+        // tool while declaring them for the other 55 reads to a client as "this
+        // one is unstructured". A test asserts the table covers every tool.
+        if (os != tool_output_schemas().end()) tool["outputSchema"] = os->second;
+      }
     }
     return list;
   }
 
   // explainQuery aside, any tool that touches a database can be swept.
   static bool tool_name_is_sweepable(const std::string& name) {
-    return name != "explainQuery";
+    return name != "explainQuery" && name != "evaluateIndex";
   }
 
   // A human-readable label, derived from the tool name rather than stored
@@ -1717,19 +2688,15 @@ private:
     }
   }
 
+  // Structure only. Every reading this used to carry -- reltuples, the
+  // relpages size estimate and the whole pg_stat_user_tables row -- moved to
+  // listTableStats in 4.0.0, and the measured sizes to listTableSizes. What is
+  // left changes only when someone issues DDL, which is what lets the tool be
+  // classified per_database and refuse a replication-group sweep: a physical
+  // replica would return these bytes verbatim.
   const json tables(const std::string& schema) {
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
-
-    // PostgreSQL 16 additions. n_tup_newpage_upd counts updates that had to
-    // move the row to another page, which is the direct measure of failed HOT
-    // updates -- the usual cause is a too-high fillfactor or an index on a
-    // frequently updated column. last_seq_scan dates the last sequential scan,
-    // which turns a large seq_scan count into something you can act on.
-    const std::string pg16 = sess.server_version() >= 160000
-      ? R"(, 'n_tup_newpage_upd', s.n_tup_newpage_upd,
-            'last_seq_scan', s.last_seq_scan)"
-      : "";
 
     std::string query = R"(
       SELECT JSONB_OBJECT_AGG(c.relname,
@@ -1737,15 +2704,9 @@ private:
                'kind', CASE c.relkind WHEN 'r' THEN 'table' WHEN 'p' THEN 'partitioned table'
                                       WHEN 'm' THEN 'materialized view' WHEN 'v' THEN 'view' END,
                'description', COALESCE(obj_description(c.oid, 'pg_class'), ''),
-               'rows', c.reltuples, 'size', c.relpages::bigint * 8192,
-               'seq_scan', s.seq_scan, 'idx_scan', s.idx_scan, 'n_live_tup', s.n_live_tup, 'n_dead_tup', s.n_dead_tup,
-               'n_mod_since_analyze', s.n_mod_since_analyze, 'n_ins_since_vacuum', s.n_ins_since_vacuum,
-               'last_vacuum', GREATEST(s.last_vacuum, s.last_autovacuum), 'last_analyze', GREATEST(s.last_analyze, s.last_autoanalyze),
                'reloptions', c.reloptions,
-               'columns', columns, 'index_count', COALESCE(index_count, 0), 'constraint_count', COALESCE(constraint_count, 0))" + pg16 + R"(
-               ))
+               'columns', columns, 'index_count', COALESCE(index_count, 0), 'constraint_count', COALESCE(constraint_count, 0)))
       FROM pg_class AS c
-      LEFT JOIN pg_stat_user_tables AS s ON s.relid = c.oid
       LEFT JOIN LATERAL (SELECT JSONB_OBJECT_AGG(a.attname,
                         JSONB_BUILD_OBJECT(
                          'description', col_description(c.oid, a.attnum),
@@ -1777,6 +2738,10 @@ private:
     }
   }
 
+  // Structure only, for the same reason as tables() above. searchTables is the
+  // one tool of the three with no statistics counterpart: text search is a
+  // discovery path, and nobody runs a full-text query to read a counter. A
+  // caller who wants readings on a match names it to tableStats.
   const json search(const std::string& web_search) {
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
@@ -1787,15 +2752,10 @@ private:
                'kind', CASE c.relkind WHEN 'r' THEN 'table' WHEN 'p' THEN 'partitioned table'
                                       WHEN 'm' THEN 'materialized view' WHEN 'v' THEN 'view' END,
                'description', COALESCE(obj_description(c.oid, 'pg_class'), ''),
-               'rows', c.reltuples, 'size', c.relpages::bigint * 8192,
-               'seq_scan', s.seq_scan, 'idx_scan', s.idx_scan, 'n_live_tup', s.n_live_tup, 'n_dead_tup', s.n_dead_tup,
-               'n_mod_since_analyze', s.n_mod_since_analyze, 'n_ins_since_vacuum', s.n_ins_since_vacuum,
-               'last_vacuum', GREATEST(s.last_vacuum, s.last_autovacuum), 'last_analyze', GREATEST(s.last_analyze, s.last_autoanalyze),
                'reloptions', c.reloptions,
                'columns', columns, 'index_count', COALESCE(index_count, 0), 'constraint_count', COALESCE(constraint_count, 0),
                'roles', COALESCE(roles, '{}'::jsonb)))
       FROM pg_class AS c
-      LEFT JOIN pg_stat_user_tables AS s ON s.relid = c.oid
       LEFT JOIN LATERAL (SELECT JSONB_OBJECT_AGG(a.attname,
                                 JSONB_BUILD_OBJECT(
                                  'description', col_description(c.oid, a.attnum),
@@ -2222,10 +3182,14 @@ private:
       ? pqxx_exec(txn, query, pqxx::params{pid})
       : txn.exec(query);
 
+    // 4.0.0 wraps the rows in an object. `structuredContent` may only be a
+    // JSON object, so a top-level array is unrepresentable in the format
+    // modern clients receive -- the same reason, and the same fix, that 3.0.0
+    // applied to statementStats.
     if (!res.empty() && !res[0][0].is_null()) {
-      return json::parse(res[0][0].as<std::string>());
+      return json{{"locks", json::parse(res[0][0].as<std::string>())}};
     } else {
-      return json::array();
+      return json{{"locks", json::array()}};
     }
   }
 
@@ -5154,33 +6118,32 @@ private:
     }
   }
 
+  // Structure only. In 4.0.0 this shed reltuples, the measured sizes, the
+  // pg_stat_user_tables row, the per-column pg_stats histograms and the
+  // per-index scan counters; they are in tableStats and tableSize now.
+  //
+  // Two consequences worth naming. The tool no longer returns
+  // most_common_vals, which was literal column values -- on a customers table,
+  // customer names -- from the tool an agent calls most often to inspect
+  // structure. And nothing here is version-conditional any more, so the
+  // server_version() probe and the string-erase fixup that used to drop
+  // last_idx_scan on PostgreSQL 14 and 15 are both gone; that gate lives in
+  // table_stats() now.
   const json table(const std::string& schema, const std::string& table) {
     Session sess{active_cfg()};
     pqxx::work& txn = sess.txn();
 
-    // Same PostgreSQL 16 additions as listTables: failed HOT updates and the
-    // date of the last sequential scan.
-    const std::string pg16_tbl = sess.server_version() >= 160000
-      ? R"( 'n_tup_newpage_upd', s.n_tup_newpage_upd, 'last_seq_scan', s.last_seq_scan,)"
-      : "";
-
     std::string query = R"(
       SELECT JSONB_BUILD_OBJECT(
-               'table', c.relname, 'rows', c.reltuples, 'size', pg_table_size(c.oid), 'indexes_size', pg_indexes_size(c.oid),
+               'table', c.relname,
                'description', COALESCE(obj_description(c.oid, 'pg_class'), ''),
                'kind', CASE c.relkind WHEN 'r' THEN 'table' WHEN 'p' THEN 'partitioned table'
                                       WHEN 'm' THEN 'materialized view' WHEN 'v' THEN 'view' END,
                'definition', CASE WHEN c.relkind IN ('v', 'm') THEN pg_get_viewdef(c.oid, true) END,
-               'seq_scan', s.seq_scan, 'idx_scan', s.idx_scan, 'n_live_tup', s.n_live_tup, 'n_dead_tup', s.n_dead_tup,
-               'n_mod_since_analyze', s.n_mod_since_analyze, 'n_ins_since_vacuum', s.n_ins_since_vacuum,
-               'last_vacuum', GREATEST(s.last_vacuum, s.last_autovacuum), 'last_analyze', GREATEST(s.last_analyze, s.last_autoanalyze),
-               'reloptions', c.reloptions,)" + pg16_tbl + R"(
+               'reloptions', c.reloptions,
                'columns', columns,
                'toast', CASE WHEN c.reltoastrelid != 0 THEN
-                          JSONB_BUILD_OBJECT(
-                            'name',       tc.relname,
-                            'size',       pg_relation_size(c.reltoastrelid),
-                            'index_size', pg_indexes_size(c.reltoastrelid))
+                          JSONB_BUILD_OBJECT('name', tc.relname)
                         END,
                'primary_key', COALESCE(primary_key, '[]'::jsonb),
                'indexes', COALESCE(indexes, '{}'::jsonb),
@@ -5194,7 +6157,6 @@ private:
                'policies', COALESCE(policies, '{}'::jsonb),
                'roles', COALESCE(roles, '{}'::jsonb))
       FROM pg_class AS c
-      LEFT JOIN pg_stat_user_tables AS s ON s.relid = c.oid
       LEFT JOIN pg_class AS tc ON tc.oid = c.reltoastrelid
       LEFT JOIN LATERAL (SELECT JSONB_STRIP_NULLS(JSONB_OBJECT_AGG(a.attname,
                         JSONB_BUILD_OBJECT(
@@ -5206,27 +6168,16 @@ private:
                          'default', pg_get_expr(ad.adbin, ad.adrelid),
                          'storage', CASE a.attstorage WHEN 'p' THEN 'plain' WHEN 'e' THEN 'external'
                                                        WHEN 'm' THEN 'main' WHEN 'x' THEN 'extended' END,
-                         'compression', CASE a.attcompression WHEN 'p' THEN 'pglz' WHEN 'l' THEN 'lz4' ELSE 'default' END,
-                         'null_frac', ps.null_frac,
-                         'avg_width', ps.avg_width,
-                         'n_distinct', ps.n_distinct,
-                         'physical_order_correlation', ps.correlation,
-                         'most_common_vals', ps.most_common_vals,
-                         'most_common_freqs', ps.most_common_freqs))) AS columns
+                         'compression', CASE a.attcompression WHEN 'p' THEN 'pglz' WHEN 'l' THEN 'lz4' ELSE 'default' END))) AS columns
                        FROM pg_attribute AS a
                        JOIN pg_type AS t ON t.oid = a.atttypid
                        LEFT JOIN pg_attrdef AS ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
-                       LEFT JOIN pg_stats AS ps ON ps.schemaname = $1 AND ps.tablename = $2 AND ps.attname = a.attname
                        WHERE attnum > 0
                          AND attrelid = c.oid
                          AND NOT attisdropped) _lat29 ON true
       LEFT JOIN LATERAL (SELECT JSONB_OBJECT_AGG(indexname,
-                          JSONB_BUILD_OBJECT(
-                           'definition', indexdef, 'size', pg_relation_size(si.indexrelid), 'index_uses', idx_scan, 'last_use', last_idx_scan)) AS indexes
+                          JSONB_BUILD_OBJECT('definition', indexdef)) AS indexes
                          FROM pg_indexes AS i
-                         JOIN pg_stat_user_indexes si ON si.indexrelname = i.indexname
-                                                      AND si.schemaname = i.schemaname
-                                                      AND si.relname = i.tablename
                          WHERE i.schemaname = $1
                            AND i.tablename = c.relname) _lat30 ON true
       LEFT JOIN LATERAL (SELECT JSONB_AGG(a.attname ORDER BY array_position(pk.conkey, a.attnum)) AS primary_key
@@ -5312,16 +6263,6 @@ private:
         AND c.relname = $2;
     )";
 
-    // pg_stat_user_indexes.last_idx_scan is PostgreSQL 16+; drop the index
-    // 'last_use' field on older servers so the query still parses. If this
-    // literal ever drifts from the query above, the pg14/pg15 CI jobs fail
-    // loudly with an undefined-column error rather than silently.
-    if (sess.server_version() < 160000) {
-      const std::string frag = ", 'last_use', last_idx_scan";
-      auto pos = query.find(frag);
-      if (pos != std::string::npos) query.erase(pos, frag.size());
-    }
-
     pqxx::result res = pqxx_exec(txn, query, pqxx::params{schema, table});
 
     if (!res.empty() && !res[0][0].is_null()) {
@@ -5330,6 +6271,520 @@ private:
     } else {
       return {};
     }
+  }
+
+  // Plan a statement as if the indexes were different, using hypopg.
+  //
+  // This is what closes the asymmetry the diagnostic prompts otherwise have to
+  // admit to: a proposed rewrite can be explained on the spot, while a proposed
+  // index used to be a prediction. A hypothetical index is planned against but
+  // never built -- no lock, no catalog row, no file -- so the planner's verdict
+  // is available before anyone commits to the write cost an index carries for
+  // the rest of its life.
+  //
+  // It never executes the statement. hypopg cannot serve EXPLAIN ANALYZE (there
+  // is no index to scan), so this tool is plan-only and therefore strictly
+  // safer than explainQuery with analyze.
+  //
+  // THE RESET BRACKET IS NOT OPTIONAL. Measured against hypopg 1.4.3: a
+  // hypothetical index lives in backend-local memory for the whole session and
+  // is cleared by none of the things that would be expected to clear it --
+  // not ROLLBACK, not a new transaction, and not DISCARD ALL, which is exactly
+  // what PgBouncer issues as server_reset_query. Only hypopg_reset() removes
+  // it. Against a transaction-mode pooler that means one caller's hypothetical
+  // index would otherwise stay on the backend and silently reshape the next
+  // caller's plans -- a wrong answer with nothing to indicate it. So the reset
+  // runs on the way in, which protects this call from whatever a previous one
+  // left, and again on the way out through a scope guard that survives an
+  // exception, which protects the next call from this one. Either alone would
+  // do most of the job; both is cheap and neither depends on the other.
+  const json evaluate_index(const std::string& sql, const json& create_defs,
+                            const json& hide_names) {
+    if (sql.empty()) throw std::runtime_error("sql is required");
+    if (!create_defs.is_array() || !hide_names.is_array())
+      throw std::runtime_error("create and hide must be arrays");
+    if (create_defs.empty() && hide_names.empty())
+      throw std::runtime_error(
+        "name at least one index: 'create' takes CREATE INDEX statements to "
+        "plan against, 'hide' the names of existing indexes to plan without");
+    if (create_defs.size() + hide_names.size() > 16)
+      throw std::runtime_error("at most 16 indexes may be evaluated in one call");
+
+    Session sess{active_cfg()};
+    pqxx::work& txn = sess.txn();
+
+    const std::string hypo = extension_schema(txn, "hypopg");
+    if (hypo.empty())
+      return {{"error", "hypopg is not installed"},
+              {"hint", "Run: CREATE EXTENSION hypopg; -- it plans against "
+                       "indexes without building them, and creates nothing"}};
+
+    // hypopg_hide_index arrived in 1.4.0. Gated on the extension version rather
+    // than the server version, for the reason recorded when pg_buffercache
+    // needed the same treatment: the two move independently.
+    std::string ver;
+    {
+      pqxx::result r = pqxx_exec(
+        txn, "SELECT extversion FROM pg_extension WHERE extname = 'hypopg'", pqxx::params{});
+      if (!r.empty() && !r[0][0].is_null()) ver = r[0][0].as<std::string>();
+    }
+    const bool can_hide = ver >= "1.4";
+    if (!hide_names.empty() && !can_hide)
+      return {{"error", "hiding an existing index needs hypopg 1.4.0 or later"},
+              {"hint", "this server has hypopg " + ver +
+                       "; run ALTER EXTENSION hypopg UPDATE, or use 'create' "
+                       "alone, which every version supports"},
+              {"hypopg_version", ver}};
+
+    auto reset = [&]() {
+      try { txn.exec("SELECT " + hypo + ".hypopg_reset()"); } catch (...) {}
+      if (can_hide)
+        try { txn.exec("SELECT " + hypo + ".hypopg_unhide_all_indexes()"); } catch (...) {}
+    };
+    reset();
+    struct Guard {
+      std::function<void()> f;
+      ~Guard() { f(); }
+    } guard{reset};
+
+    // Each EXPLAIN runs inside a savepoint so that a failing statement leaves
+    // the transaction usable -- the reset on the way out needs it alive.
+    const bool pg16 = sess.server_version() >= 160000;
+    auto plan_of = [&]() -> json {
+      try {
+        pqxx::subtransaction sub{txn};
+        pqxx::result r = sub.exec("EXPLAIN (FORMAT JSON) " + sql);
+        json p = json::parse(r[0][0].as<std::string>());
+        sub.commit();
+        return p;
+      } catch (const pqxx::sql_error& e) {
+        // 42P02: the statement carries $n placeholders. GENERIC_PLAN is the
+        // same fallback explainQuery uses, and it is PostgreSQL 16+.
+        if (e.sqlstate() != "42P02" || !pg16) throw;
+        pqxx::subtransaction sub{txn};
+        pqxx::result r = sub.exec("EXPLAIN (FORMAT JSON, GENERIC_PLAN) " + sql);
+        json p = json::parse(r[0][0].as<std::string>());
+        sub.commit();
+        return p;
+      }
+    };
+    auto cost_of = [](const json& p) -> double {
+      if (p.is_array() && !p.empty() && p[0].contains("Plan") &&
+          p[0]["Plan"].contains("Total Cost"))
+        return p[0]["Plan"]["Total Cost"].get<double>();
+      return 0.0;
+    };
+
+    const json baseline = plan_of();
+
+    json indexes = json::array();
+    for (const auto& d : create_defs) {
+      if (!d.is_string())
+        throw std::runtime_error("every entry of create must be a CREATE INDEX statement");
+      const std::string def = d.get<std::string>();
+      try {
+        pqxx::result r = pqxx_exec(
+          txn, "SELECT indexrelid::text, indexname FROM " + hypo + ".hypopg_create_index($1)",
+          pqxx::params{def});
+        if (r.empty()) continue;
+        const std::string oid = r[0][0].as<std::string>();
+        const std::string nm  = r[0][1].as<std::string>();
+        pqxx::result sz = pqxx_exec(
+          txn, "SELECT " + hypo + ".hypopg_relation_size($1::oid)", pqxx::params{oid});
+        indexes.push_back({{"definition", def},
+                           {"name", nm},
+                           {"estimated_size", sz.empty() || sz[0][0].is_null()
+                              ? json(nullptr) : json(sz[0][0].as<long long>())}});
+      } catch (const pqxx::sql_error& e) {
+        return {{"error", "hypopg rejected an index definition"},
+                {"definition", def},
+                {"detail", e.what()}};
+      }
+    }
+
+    json hidden = json::array();
+    for (const auto& h : hide_names) {
+      if (!h.is_string())
+        throw std::runtime_error("every entry of hide must be an index name");
+      const std::string nm = h.get<std::string>();
+      try {
+        pqxx::result r = pqxx_exec(
+          txn,
+          // to_regclass rather than a ::regclass cast: the cast raises on an
+          // unknown name, which would surface a raw server error instead of
+          // the message below naming what to do about it.
+          "SELECT c.oid::text FROM pg_class AS c"
+          " WHERE c.oid = to_regclass($1) AND c.relkind IN ('i', 'I')",
+          pqxx::params{nm});
+        if (r.empty())
+          return {{"error", "no index named " + nm},
+                  {"hint", "name an existing index, schema-qualified if it is "
+                           "not on the search path; tableDetails lists them "
+                           "for one table"}};
+        txn.exec("SELECT " + hypo + ".hypopg_hide_index(" +
+                 txn.quote(r[0][0].as<std::string>()) + "::oid)");
+        hidden.push_back({{"index", nm}});
+      } catch (const pqxx::sql_error& e) {
+        return {{"error", "could not hide " + nm}, {"detail", e.what()}};
+      }
+    }
+
+    const json after = plan_of();
+    const std::string after_text = after.dump();
+    // Whether the planner took the index is the answer people actually want,
+    // and a cost figure alone hides it: hypopg's most useful verdict is often
+    // that a proposed index was ignored.
+    for (auto& e : indexes)
+      e["used"] = after_text.find(e["name"].get<std::string>()) != std::string::npos;
+
+    const double before_cost = cost_of(baseline), after_cost = cost_of(after);
+    json out = {
+      {"statement", sql},
+      {"hypopg_version", ver},
+      {"baseline", {{"total_cost", before_cost}, {"plan", baseline}}},
+      {"hypothetical", {{"total_cost", after_cost}, {"plan", after}}},
+      {"cost_ratio", before_cost > 0 ? json(after_cost / before_cost) : json(nullptr)},
+      {"indexes", indexes}
+    };
+    if (!hidden.empty()) out["hidden"] = hidden;
+    out["note"] = "Hypothetical indexes are planned against and never built. "
+                  "The cost is the planner's estimate, not a measurement: it "
+                  "says the plan would change, not how long it would take.";
+    return out;
+  }
+
+  // Which tools this role can actually use on this connection.
+  //
+  // The catalog is world-readable, so most of the tool set works for any role
+  // that can connect. What varies is a small, knowable set: the predefined
+  // roles that gate the monitoring extras, and whether the role can read table
+  // data at all. Measured against PostgreSQL 18: a bare login role runs 47 of
+  // the 58 tools at full fidelity, pg_monitor takes that to 54, and the ones
+  // that remain are exactly the three that touch row data.
+  //
+  // The point of asking once, up front, is that the alternative is discovering
+  // it tool by tool -- and the discovery is misleading, because a filtered
+  // answer looks like an empty one. tableStats on a role without SELECT
+  // returns every column with null statistics, which is byte-for-byte what a
+  // never-analyzed table looks like.
+  //
+  // Deliberately reports no role memberships and no GRANT statements. Which
+  // predefined role gates a tool is PostgreSQL's business, not the caller's --
+  // the caller needs to know what works. And emitting DDL would contradict what
+  // this server tells every client about itself: plans verbatim, no heuristics,
+  // no generated DDL. Naming a grant in the hint of a tool that *failed* is
+  // diagnosis; listing grants beside every unavailable tool is a standing
+  // recommendation to escalate privilege, which is not this server's to make.
+  const json check_privileges() {
+    Session sess{active_cfg()};
+    pqxx::work& txn = sess.txn();
+
+    // One round trip. pg_has_role is looked up through pg_roles rather than by
+    // name so that a predefined role missing on some version yields false
+    // instead of raising -- pg_read_all_data is PostgreSQL 14+, which is the
+    // floor this server supports, but the guard costs nothing and the next
+    // predefined role added upstream will not need this remembered.
+    auto has_role = [](const char* name) {
+      return std::string(
+        "COALESCE((SELECT pg_has_role(current_user, oid, 'USAGE')"
+        " FROM pg_roles WHERE rolname = '") + name + "'), false)";
+    };
+    const std::string query =
+      "SELECT JSONB_BUILD_OBJECT("
+      " 'role', current_user,"
+      " 'superuser', COALESCE((SELECT rolsuper FROM pg_roles"
+      "                        WHERE rolname = current_user), false),"
+      " 'monitor',      " + has_role("pg_monitor")           + ","
+      " 'read_stats',   " + has_role("pg_read_all_stats")    + ","
+      " 'read_settings'," + has_role("pg_read_all_settings") + ","
+      " 'scan_tables',  " + has_role("pg_stat_scan_tables")  + ","
+      " 'read_data',    " + has_role("pg_read_all_data")     + ")";
+
+    pqxx::result res = txn.exec(query);
+    const json p = json::parse(res[0][0].as<std::string>());
+
+    const bool super     = p.value("superuser", false);
+    const bool monitor   = super || p.value("monitor", false);
+    const bool stats     = monitor || p.value("read_stats", false);
+    const bool settings  = monitor || p.value("read_settings", false);
+    const bool scan      = monitor || p.value("scan_tables", false);
+    const bool data      = super  || p.value("read_data", false);
+
+    // Extension presence is a different failure from missing privilege, and
+    // conflating them would send an operator to the wrong fix. Checked here so
+    // the answer distinguishes "not installed" from "not permitted".
+    const bool has_pgstattuple  = !extension_schema(txn, "pgstattuple").empty();
+    const bool has_buffercache  = !extension_schema(txn, "pg_buffercache").empty();
+    const bool has_pgss         = !extension_schema(txn, "pg_stat_statements").empty();
+    const bool has_hypopg       = !extension_schema(txn, "hypopg").empty();
+
+    json denied = json::array(), degraded = json::array();
+    auto deny = [&](const char* tool, const std::string& why) {
+      denied.push_back({{"tool", tool}, {"reason", why}});
+    };
+    auto degrade = [&](const char* tool, const std::string& what) {
+      degraded.push_back({{"tool", tool}, {"what", what}});
+    };
+
+    // Denied means the tool cannot produce an answer for this role at all.
+    for (const char* t : {"tableBloat", "indexBloat"}) {
+      if (!has_pgstattuple) deny(t, "the pgstattuple extension is not installed");
+      else if (!scan)       deny(t, "the pgstattuple functions are restricted to "
+                                    "roles permitted to run table-scanning "
+                                    "monitoring functions");
+    }
+    for (const char* t : {"bufferCacheSummary", "bufferCacheContents"}) {
+      if (!has_buffercache) deny(t, "the pg_buffercache extension is not installed");
+      else if (!monitor)    deny(t, "pg_buffercache is readable only by roles "
+                                    "granted the monitoring role");
+    }
+    if (!has_hypopg)
+      deny("evaluateIndex", "the hypopg extension is not installed");
+    else if (!data)
+      degrade("evaluateIndex", "planning a statement needs SELECT on the tables "
+                               "it references, so this fails on any statement "
+                               "reaching a table this role cannot read");
+    if (!has_pgss)
+      deny("statementStats", "the pg_stat_statements extension is not installed");
+    else if (!stats)
+      degrade("statementStats", "the query text of statements run by other roles "
+                                "is replaced with <insufficient privilege>; the "
+                                "counters beside it are complete");
+
+    if (!settings)
+      degrade("serverSettings", "settings marked superuser-only are absent "
+                                "entirely rather than masked, so the category "
+                                "count is lower than a privileged role sees");
+    if (!stats)
+      degrade("currentActivity", "the query text and some columns of backends "
+                                 "belonging to other roles are hidden");
+
+    // The three that read row data. Not "denied": privilege here is per object,
+    // so a role without blanket read access may still hold SELECT on some
+    // tables and none on others. Reporting these as unavailable would be as
+    // wrong as reporting them as available.
+    if (!data) {
+      degrade("tableStats", "per-column statistics are omitted for any column "
+                            "this role cannot SELECT, and the columns still "
+                            "appear with null values -- indistinguishable from "
+                            "a table that was never analyzed");
+      degrade("checkKey", "fails on any table this role cannot SELECT");
+      degrade("explainQuery", "fails on any statement referencing a table this "
+                              "role cannot SELECT");
+    }
+
+    // Everything not named is fully available. Counting rather than listing:
+    // the exceptions are the answer, and enumerating 53 working tool names
+    // would be most of the payload.
+    const size_t total = tool_scopes().size();
+    json out = {
+      {"connection", active_cfg().name},
+      {"role", p.value("role", "")},
+      {"tools", total},
+      {"available", total - denied.size() - degraded.size()}
+    };
+    if (!degraded.empty()) out["degraded"] = degraded;
+    if (!denied.empty())   out["denied"]   = denied;
+    return out;
+  }
+
+  // --- Catalog statistics: readings, but free ones ------------------------
+  //
+  // Everything here comes out of pg_stat_user_tables, pg_stats and the
+  // pg_class counters that ANALYZE maintains. No relation is opened and no
+  // file is stat()ed, so the cost is a catalog scan and nothing else. That is
+  // the line these two tools sit on: they are volatile, which is why they are
+  // not in tableDetails, but they are cheap, which is why they are not behind
+  // the gate that tableSize is.
+  //
+  // size_estimate is relpages * 8192 and is deliberately not called `size`.
+  // relpages is set by VACUUM and ANALYZE, so between runs it can be arbitrarily
+  // stale -- on a table that has doubled since the last analyze it is half the
+  // truth. estimated_from carries the timestamp that produced it so a caller can
+  // judge the staleness instead of guessing at it, and tableSize is where an
+  // actually-measured number comes from.
+
+  // The PostgreSQL 16 additions, shared by both statistics tools.
+  // n_tup_newpage_upd counts updates that had to move the row to another page:
+  // the direct measure of failed HOT updates, whose usual cause is a too-high
+  // fillfactor or an index on a frequently updated column. last_seq_scan dates
+  // the last sequential scan, which turns a large seq_scan count into something
+  // actionable.
+  static std::string stats_pg16_fragment(int server_version) {
+    return server_version >= 160000
+      ? R"(, 'n_tup_newpage_upd', s.n_tup_newpage_upd,
+            'last_seq_scan', s.last_seq_scan)"
+      : "";
+  }
+
+  // The pg_stat_user_tables columns both tools return, in one place so the
+  // single-table and schema-wide forms cannot drift apart.
+  static constexpr const char* kTableStatsCommon = R"(
+               'rows', c.reltuples,
+               'size_estimate', c.relpages::bigint * 8192,
+               'estimated_from', GREATEST(s.last_vacuum, s.last_autovacuum,
+                                          s.last_analyze, s.last_autoanalyze),
+               'seq_scan', s.seq_scan, 'idx_scan', s.idx_scan,
+               'n_live_tup', s.n_live_tup, 'n_dead_tup', s.n_dead_tup,
+               'n_mod_since_analyze', s.n_mod_since_analyze,
+               'n_ins_since_vacuum', s.n_ins_since_vacuum,
+               'last_vacuum', GREATEST(s.last_vacuum, s.last_autovacuum),
+               'last_analyze', GREATEST(s.last_analyze, s.last_autoanalyze))";
+
+  const json table_stats(const std::string& schema, const std::string& table) {
+    Session sess{active_cfg()};
+    pqxx::work& txn = sess.txn();
+
+    const std::string pg16 = stats_pg16_fragment(sess.server_version());
+    // pg_stat_user_indexes.last_idx_scan is PostgreSQL 16+. Built the same way
+    // as the table fragment rather than by erasing a literal out of the
+    // finished query, which is what the pre-4.0.0 tableDetails did: if the two
+    // ever drifted the erase silently did nothing and the pg14/pg15 jobs failed
+    // on an undefined column.
+    const std::string idx_pg16 = sess.server_version() >= 160000
+      ? R"(, 'last_use', si.last_idx_scan)" : "";
+
+    std::string query = std::string(R"(
+      SELECT JSONB_BUILD_OBJECT(
+               'table', c.relname,)") + kTableStatsCommon + pg16 + R"(,
+               'columns', COALESCE(columns, '{}'::jsonb),
+               'indexes', COALESCE(indexes, '{}'::jsonb))
+      FROM pg_class AS c
+      LEFT JOIN pg_stat_user_tables AS s ON s.relid = c.oid
+      LEFT JOIN LATERAL (SELECT JSONB_OBJECT_AGG(a.attname,
+                          JSONB_BUILD_OBJECT(
+                           'null_frac', ps.null_frac,
+                           'avg_width', ps.avg_width,
+                           'n_distinct', ps.n_distinct,
+                           'physical_order_correlation', ps.correlation,
+                           'most_common_vals', ps.most_common_vals,
+                           'most_common_freqs', ps.most_common_freqs)) AS columns
+                         FROM pg_attribute AS a
+                         LEFT JOIN pg_stats AS ps ON ps.schemaname = $1
+                                                  AND ps.tablename = $2
+                                                  AND ps.attname = a.attname
+                         WHERE a.attnum > 0
+                           AND a.attrelid = c.oid
+                           AND NOT a.attisdropped) _lat40 ON true
+      LEFT JOIN LATERAL (SELECT JSONB_OBJECT_AGG(si.indexrelname,
+                          JSONB_BUILD_OBJECT(
+                           'index_uses', si.idx_scan)" + idx_pg16 + R"()) AS indexes
+                         FROM pg_stat_user_indexes AS si
+                         WHERE si.relid = c.oid) _lat41 ON true
+      WHERE c.relnamespace = $1::regnamespace
+        AND c.relname = $2;
+    )";
+
+    pqxx::result res = pqxx_exec(txn, query, pqxx::params{schema, table});
+
+    if (!res.empty() && !res[0][0].is_null())
+      return json::parse(res[0][0].as<std::string>());
+    return {};
+  }
+
+  const json list_table_stats(const std::string& schema) {
+    Session sess{active_cfg()};
+    pqxx::work& txn = sess.txn();
+
+    const std::string pg16 = stats_pg16_fragment(sess.server_version());
+
+    // No per-column pg_stats here, deliberately. tableDetails never carried
+    // them in the schema-wide form either, and default_statistics_target
+    // sample values for every column of every table in a schema is a payload
+    // nobody asked for. Name a table to tableStats to get them.
+    std::string query = std::string(R"(
+      SELECT JSONB_OBJECT_AGG(c.relname,
+              JSONB_BUILD_OBJECT()") + kTableStatsCommon + pg16 + R"(
+               ))
+      FROM pg_class AS c
+      LEFT JOIN pg_stat_user_tables AS s ON s.relid = c.oid
+      WHERE c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = $1)
+        AND c.relkind IN ('r', 'p', 'm', 'v');
+    )";
+
+    pqxx::result res = pqxx_exec(txn, query, pqxx::params{schema});
+
+    if (!res.empty() && !res[0][0].is_null())
+      return json::parse(res[0][0].as<std::string>());
+    return {};
+  }
+
+  // --- Measured size: the gated tier --------------------------------------
+  //
+  // pg_table_size() and friends are not physical reads -- they stat() one file
+  // per 1 GB segment and read no blocks. What makes them worth gating is the
+  // lock: each opens the relation with AccessShareLock, so a size call on a
+  // table that an ALTER TABLE is rewriting waits behind AccessExclusiveLock.
+  // Across a schema that means the call stalls on precisely the table an
+  // incident is about. Since 3.2.1 every statement carries a statement_timeout,
+  // so it fails rather than hanging -- but it still fails, and it fails at the
+  // worst moment.
+  //
+  // Hence a separate tool rather than a flag: the cost note is in the
+  // description the model reads while choosing which tool to call, not in an
+  // argument it reads after it has already chosen.
+  const json table_size(const std::string& schema, const std::string& table) {
+    Session sess{active_cfg()};
+    pqxx::work& txn = sess.txn();
+
+    std::string query = R"(
+      SELECT JSONB_BUILD_OBJECT(
+               'table', c.relname,
+               'kind', CASE c.relkind WHEN 'r' THEN 'table' WHEN 'p' THEN 'partitioned table'
+                                      WHEN 'm' THEN 'materialized view' WHEN 'v' THEN 'view' END,
+               'main_size', pg_relation_size(c.oid, 'main'),
+               'size', pg_table_size(c.oid),
+               'indexes_size', pg_indexes_size(c.oid),
+               'total_size', pg_total_relation_size(c.oid),
+               'toast', CASE WHEN c.reltoastrelid != 0 THEN
+                          JSONB_BUILD_OBJECT(
+                            'name',       tc.relname,
+                            'size',       pg_relation_size(c.reltoastrelid),
+                            'index_size', pg_indexes_size(c.reltoastrelid))
+                        END,
+               'indexes', COALESCE(indexes, '{}'::jsonb))
+      FROM pg_class AS c
+      LEFT JOIN pg_class AS tc ON tc.oid = c.reltoastrelid
+      LEFT JOIN LATERAL (SELECT JSONB_OBJECT_AGG(i.relname, pg_relation_size(i.oid)) AS indexes
+                         FROM pg_index AS ix
+                         JOIN pg_class AS i ON i.oid = ix.indexrelid
+                         WHERE ix.indrelid = c.oid) _lat42 ON true
+      WHERE c.relnamespace = $1::regnamespace
+        AND c.relname = $2;
+    )";
+
+    pqxx::result res = pqxx_exec(txn, query, pqxx::params{schema, table});
+
+    if (!res.empty() && !res[0][0].is_null())
+      return json::parse(res[0][0].as<std::string>());
+    return {};
+  }
+
+  const json list_table_sizes(const std::string& schema) {
+    Session sess{active_cfg()};
+    pqxx::work& txn = sess.txn();
+
+    // This is the form the lock caveat is really about: one relation_open per
+    // table in the schema, so a single table under AccessExclusiveLock blocks
+    // the whole call rather than one row of it.
+    std::string query = R"(
+      SELECT JSONB_OBJECT_AGG(c.relname,
+              JSONB_BUILD_OBJECT(
+               'kind', CASE c.relkind WHEN 'r' THEN 'table' WHEN 'p' THEN 'partitioned table'
+                                      WHEN 'm' THEN 'materialized view' WHEN 'v' THEN 'view' END,
+               'size', pg_table_size(c.oid),
+               'indexes_size', pg_indexes_size(c.oid),
+               'total_size', pg_total_relation_size(c.oid)))
+      FROM pg_class AS c
+      WHERE c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = $1)
+        AND c.relkind IN ('r', 'p', 'm', 'v');
+    )";
+
+    pqxx::result res = pqxx_exec(txn, query, pqxx::params{schema});
+
+    if (!res.empty() && !res[0][0].is_null())
+      return json::parse(res[0][0].as<std::string>());
+    return {};
   }
 
   // The three _meta keys the stateless revision defines, and the revision
@@ -5399,8 +6854,14 @@ private:
 
     send_response(id, {
         {"protocolVersion", reply},
+        // 4.0.0 adds resources, prompts and completions. Declared together
+        // because they were authored together against the finished tool
+        // surface, which is what the statistics split was blocking.
         {"capabilities", {
-            {"tools", json::object()}
+            {"tools", json::object()},
+            {"resources", json::object()},
+            {"prompts", json::object()},
+            {"completions", json::object()}
 	  }},
         {"serverInfo", {{"name", "pg-licht-cpp"}, {"version", PGLICHT_VERSION}}}
       });
@@ -5624,6 +7085,33 @@ private:
       std::string web_search = arguments.contains("web_search") ? arguments["web_search"].get<std::string>() : "";
       result_content = search(web_search);
     }
+    else if (tool_name == "evaluateIndex") {
+      std::string sql = arguments.contains("sql") ? arguments["sql"].get<std::string>() : "";
+      json creates = arguments.contains("create") ? arguments["create"] : json::array();
+      json hides   = arguments.contains("hide")   ? arguments["hide"]   : json::array();
+      result_content = evaluate_index(sql, creates, hides);
+    }
+    else if (tool_name == "checkPrivileges") {
+      result_content = check_privileges();
+    }
+    else if (tool_name == "tableStats") {
+      std::string target_schema = arguments.contains("schema") ? arguments["schema"].get<std::string>() : "public";
+      std::string target_table = arguments.contains("table") ? arguments["table"].get<std::string>() : "";
+      result_content = table_stats(target_schema, target_table);
+    }
+    else if (tool_name == "listTableStats") {
+      std::string target_schema = arguments.contains("schema") ? arguments["schema"].get<std::string>() : "public";
+      result_content = list_table_stats(target_schema);
+    }
+    else if (tool_name == "tableSize") {
+      std::string target_schema = arguments.contains("schema") ? arguments["schema"].get<std::string>() : "public";
+      std::string target_table = arguments.contains("table") ? arguments["table"].get<std::string>() : "";
+      result_content = table_size(target_schema, target_table);
+    }
+    else if (tool_name == "listTableSizes") {
+      std::string target_schema = arguments.contains("schema") ? arguments["schema"].get<std::string>() : "public";
+      result_content = list_table_sizes(target_schema);
+    }
     else if (tool_name == "listFunctions") {
       std::string target_schema = arguments.contains("schema") ? arguments["schema"].get<std::string>() : "public";
       result_content = functions(target_schema);
@@ -5844,6 +7332,14 @@ private:
     else {
       return false;
     }
+    // Every tool payload is a JSON object, enforced here rather than trusted
+    // of ~50 query methods. `structuredContent` may only be an object, so from
+    // 4.0.0 a null payload is not merely untidy -- it is unrepresentable in the
+    // format modern clients receive. The methods return a value-initialised
+    // `json` (which is null, not `{}`) when a query matches no rows, so that is
+    // the case this catches. Reading "no rows" as an empty map is also the
+    // better answer: null invites "the tool failed", `{}` says "nothing there".
+    if (result_content.is_null()) result_content = json::object();
     return true;
   }
 
@@ -5895,12 +7391,17 @@ private:
     }
 
     if (method == "server/discover") {
-      send_response(req.value("id", json()), {
+      send_response(req.value("id", json()), cacheable({
           {"resultType", "complete"},
           {"supportedVersions", all_protocols()},
-          {"capabilities", {{"tools", json::object()}}},
+          {"capabilities", {{"tools", json::object()},
+                            {"resources", json::object()},
+                            {"prompts", json::object()},
+                            {"completions", json::object()}}},
           {"instructions", instructions()}
-        });
+        // Versions, capabilities and instructions are all compiled in, and
+        // none of it is specific to a caller.
+        }, kTtlStatic, "public"));
       return;
     }
 
@@ -5911,7 +7412,85 @@ private:
       return;
     }
     else if (method == "tools/list") {
-      send_response(req["id"], get_tools_list(request_protocol_));
+      json out = json::object();
+      // "private" rather than "public", for two reasons that both bite. The
+      // list varies by negotiated revision -- annotations, title and
+      // outputSchema are each gated -- while the cache key is the method and
+      // its params, and the revision travels in _meta. And the `connection`
+      // property description carries the operator's configured default
+      // connection name. Neither belongs in a cache a gateway may serve to
+      // another caller. A private cache still gives this client the full
+      // benefit, which is where the ~93 kB saving actually lands.
+      if (!paginate(get_tools_list(request_protocol_)["tools"], params, "tools", out)) {
+        send_error(req["id"], -32602, "invalid cursor");
+        return;
+      }
+      send_response(req["id"], cacheable(out, kTtlStatic, "private"));
+    }
+    else if (method == "resources/list") {
+      json out = json::object();
+      // Connection names and a live schema enumeration: deployment-specific,
+      // and short-lived because CREATE SCHEMA changes it.
+      if (!paginate(get_resources_list()["resources"], params, "resources", out)) {
+        send_error(req["id"], -32602, "invalid cursor");
+        return;
+      }
+      send_response(req["id"], cacheable(out, kTtlCatalog, "private"));
+    }
+    else if (method == "resources/templates/list") {
+      json out = json::object();
+      if (!paginate(get_resource_templates_list()["resourceTemplates"], params,
+                    "resourceTemplates", out)) {
+        send_error(req["id"], -32602, "invalid cursor");
+        return;
+      }
+      // Static URI templates, identical for every caller.
+      send_response(req["id"], cacheable(out, kTtlStatic, "public"));
+    }
+    else if (method == "resources/read") {
+      const std::string uri = params.value("uri", "");
+      try {
+        json body = read_resource(uri);
+        if (body.is_null()) body = json::object();
+        // A resource is a document, so it is served as one: the JSON text of
+        // the object, with its mimeType. There is no structuredContent form
+        // for resource contents in the spec, and the text is compact for the
+        // same reason a tool result is.
+        // Structure changes only on DDL, but it does change, so the hint is
+        // short. Private: this is the content of the operator's database.
+        send_response(req["id"], cacheable({
+            {"contents", {{{"uri", uri},
+                           {"mimeType", "application/json"},
+                           {"text", body.dump()}}}}
+          }, kTtlCatalog, "private"));
+      } catch (const std::invalid_argument& e) {
+        send_error(req["id"], -32602, e.what());
+      } catch (const std::exception& e) {
+        send_error(req["id"], -32603, std::string("resource read failed: ") + e.what());
+      }
+    }
+    else if (method == "prompts/list") {
+      json out = json::object();
+      if (!paginate(get_prompts_list()["prompts"], params, "prompts", out)) {
+        send_error(req["id"], -32602, "invalid cursor");
+        return;
+      }
+      // Compiled-in templates with no configuration in them.
+      send_response(req["id"], cacheable(out, kTtlStatic, "public"));
+    }
+    else if (method == "prompts/get") {
+      try {
+        send_response(req["id"], get_prompt(params.value("name", ""),
+                                            params.contains("arguments")
+                                              ? params["arguments"] : json::object()));
+      } catch (const std::invalid_argument& e) {
+        send_error(req["id"], -32602, e.what());
+      }
+    }
+    else if (method == "completion/complete") {
+      send_response(req["id"], complete(params.contains("ref") ? params["ref"] : json::object(),
+                                        params.contains("argument") ? params["argument"]
+                                                                    : json::object()));
     }
     else if (method == "tools/call") {
       std::string tool_name = params.value("name", "");
@@ -5980,10 +7559,7 @@ private:
 				   axis == "instance" ? want_instance
 				 : axis == "replication_group" ? want_repl : want_group,
 				   want_role, tool_name, arguments);
-	  send_response(req["id"], {
-	      {"content", {{{"type", "text"}, {"text", result_content.dump(2)}}}},
-	      {"isError", false}
-	    });
+	  send_response(req["id"], tool_result(result_content));
 	  return;
 	}
 
@@ -5998,13 +7574,7 @@ private:
 	  return;
 	}
 
-	send_response(req["id"], {
-	    {"content", {{
-                  {"type", "text"},
-                  {"text", result_content.dump(2)}
-		}}},
-	    {"isError", false}
-          });
+	send_response(req["id"], tool_result(result_content));
 
       } catch (const pqxx::sql_error& e) {
 	// Hitting the ceiling is reported as a result rather than an execution
@@ -6012,9 +7582,12 @@ private:
 	// connection allows, and the caller can act on that.
 	if (is_statement_timeout(e)) {
 	  send_response(req["id"], {
+	      // Errors stay a text block in both eras. `structuredContent` is the
+	      // format for a tool's answer; an error is a message about why there
+	      // is no answer, and the spec pairs isError with content.
 	      {"content", {{{"type", "text"},
 			    {"text", statement_timeout_error(
-			       Session::last_statement_timeout_ms(), e.what()).dump(2)}}}},
+			       Session::last_statement_timeout_ms(), e.what()).dump()}}}},
 	      {"isError", true}
 	    });
 	} else {
@@ -6035,6 +7608,163 @@ private:
         send_error(req["id"], -32601, "Method not available");
       }
     }
+  }
+
+  // ============ Caching hints and pagination (revision 2026-07-28) =========
+  //
+  // The caching utility requires `ttlMs` and `cacheScope` on every result with
+  // resultType "complete" from server/discover, tools/list, prompts/list,
+  // resources/list, resources/templates/list and resources/read. Both are
+  // therefore gated on modern_, exactly as resultType is: they are defined by
+  // the same revision, and a legacy result must not grow fields its era never
+  // had.
+  //
+  // This matters more here than it looks. tools/list is ~93 kB once 58 tools
+  // carry descriptions, annotations, titles and outputSchemas, and without a
+  // freshness hint a client SHOULD treat it as immediately stale and re-fetch
+  // it whenever it needs the list. That is the largest single payload the
+  // server produces and it is entirely static.
+
+  // Everything compiled into the binary or read from the config file at
+  // startup. None of it can change while the process lives: the registry is
+  // built once, the tool table is a static, and no `listChanged` capability is
+  // declared, so there is no mechanism by which a client could be told
+  // otherwise even if it could.
+  static constexpr int kTtlStatic = 3600000;   // 1 hour
+  // Anything derived from a live catalog. Structure changes only when someone
+  // issues DDL -- that is the whole premise of serving it as a resource -- but
+  // DDL does happen, so this is short enough that a CREATE SCHEMA or an ALTER
+  // TABLE is picked up on the next access rather than an hour later.
+  static constexpr int kTtlCatalog = 60000;    // 1 minute
+
+  // Page size for every paginated list. Deliberately larger than any list this
+  // server currently produces, so nothing is truncated for a client that
+  // ignores nextCursor: 58 tools, 8 prompts and 5 templates are each one page.
+  // The list that can genuinely outgrow it is resources/list, which is
+  // connections x schemas -- and that is the case pagination exists for.
+  static constexpr size_t kListPageSize = 100;
+
+  static std::string b64_encode(const std::string& in) {
+    static const char* t =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::string out;
+    unsigned val = 0;
+    int valb = -6;
+    for (char raw : in) {
+      val = (val << 8) + static_cast<unsigned char>(raw);
+      valb += 8;
+      while (valb >= 0) { out += t[(val >> static_cast<unsigned>(valb)) & 0x3Fu]; valb -= 6; }
+    }
+    if (valb > -6) out += t[((val << 8) >> static_cast<unsigned>(valb + 8)) & 0x3Fu];
+    while (out.size() % 4) out += '=';
+    return out;
+  }
+
+  static bool b64_decode(const std::string& in, std::string& out) {
+    static const char* t =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::vector<int> rev(256, -1);
+    for (int i = 0; i < 64; i++) rev[static_cast<unsigned char>(t[i])] = i;
+    unsigned val = 0;
+    int valb = -8;
+    out.clear();
+    for (char raw : in) {
+      const unsigned char c = static_cast<unsigned char>(raw);
+      if (c == '=') break;
+      if (rev[c] == -1) return false;
+      val = (val << 6) + static_cast<unsigned>(rev[c]);
+      valb += 6;
+      if (valb >= 0) {
+        out += static_cast<char>((val >> static_cast<unsigned>(valb)) & 0xFFu);
+        valb -= 8;
+      }
+    }
+    return true;
+  }
+
+  // Opaque by contract: clients MUST NOT parse these. Base64 rather than a
+  // bare offset so that a client which ignores that rule fails visibly instead
+  // of quietly depending on the encoding.
+  static std::string encode_cursor(size_t offset) {
+    return b64_encode("pglicht:" + std::to_string(offset));
+  }
+
+  static bool decode_cursor(const std::string& cursor, size_t& offset) {
+    std::string plain;
+    if (!b64_decode(cursor, plain)) return false;
+    const std::string prefix = "pglicht:";
+    if (plain.rfind(prefix, 0) != 0) return false;
+    const std::string digits = plain.substr(prefix.size());
+    if (digits.empty()) return false;
+    for (char c : digits) if (c < '0' || c > '9') return false;
+    try { offset = static_cast<size_t>(std::stoull(digits)); }
+    catch (const std::exception&) { return false; }
+    return true;
+  }
+
+  json cacheable(json result, int ttl_ms, const char* scope) const {
+    if (modern_) {
+      result["ttlMs"] = ttl_ms;
+      result["cacheScope"] = scope;
+    }
+    return result;
+  }
+
+  // Slices one page out of `items` under `key`, attaching nextCursor when more
+  // remain. Returns false for a cursor this server did not issue, which the
+  // caller turns into -32602 as the spec requires.
+  //
+  // An absent cursor and an empty-string cursor are deliberately not the same
+  // thing: the spec says an empty string is a valid cursor value and must not
+  // read as end-of-results, so only `contains` decides whether one was sent.
+  static bool paginate(const json& items, const json& params,
+                       const char* key, json& out) {
+    size_t offset = 0;
+    if (params.contains("cursor")) {
+      if (!params["cursor"].is_string()) return false;
+      if (!decode_cursor(params["cursor"].get<std::string>(), offset)) return false;
+      if (offset > items.size()) return false;
+    }
+    json page = json::array();
+    const size_t end = std::min(offset + kListPageSize, items.size());
+    for (size_t i = offset; i < end; i++) page.push_back(items[i]);
+    out[key] = page;
+    if (end < items.size()) out["nextCursor"] = encode_cursor(end);
+    return true;
+  }
+
+  // The revision that defined `outputSchema` and `structuredContent`. A client
+  // that negotiated it receives the structured payload and no text block; one
+  // that did not receives the text block and nothing else. Never both.
+  //
+  // The spec suggests serving both for backwards compatibility, and this
+  // deliberately does not. Sending both means serialising the same payload
+  // twice in one response, and a client that feeds tool results into a model's
+  // context may well inject both -- doubling the tokens for every call. The
+  // compatibility the suggestion protects is already covered here by the
+  // negotiated revision: a client that cannot read `structuredContent` does
+  // not ask for a revision that has it. This is the same rule 3.2.0 settled on
+  // for `annotations` and `title` (see the roadmap's refined rule): a
+  // protocol-revision feature is emitted only to a client that negotiated the
+  // revision defining it.
+  static constexpr const char* kStructuredContentRevision = "2025-06-18";
+
+  bool wants_structured_content() const {
+    return request_protocol_ >= kStructuredContentRevision;
+  }
+
+  // One success result, in whichever of the two formats the client negotiated.
+  //
+  // The text form is serialised compactly rather than with dump(2). The
+  // indentation was 18-39% of the payload measured across real catalog reads,
+  // and it buys a caller nothing: every consumer parses the text as JSON
+  // rather than reading it. This is the only remaining path that carries it,
+  // since a modern client no longer receives a text block at all.
+  json tool_result(const json& payload) const {
+    if (wants_structured_content())
+      return {{"structuredContent", payload}, {"isError", false}};
+    return {{"content", {{{"type", "text"}, {"text", payload.dump()}}}},
+            {"isError", false}};
   }
 
   void send_response(const json& id, const json& result) {

--- a/cpp/src/test_main.cpp
+++ b/cpp/src/test_main.cpp
@@ -220,11 +220,19 @@ protected:
       // tools are exercised against a schema-qualified lookup rather than
       // whatever happens to be on the role's search_path.
       txn.exec("CREATE EXTENSION IF NOT EXISTS pg_buffercache SCHEMA extensions");
-      // hypopg, also out of public. Optional: it is a third-party extension
-      // that may not be packaged everywhere, so the tests that need it skip
+      // hypopg, also out of public. Optional: it is third-party rather than
+      // contrib and is not packaged everywhere, so the tests that need it skip
       // rather than fail when it is absent.
+      //
+      // The savepoint is what makes that true, and catching the exception is
+      // not enough on its own: a failed statement poisons the whole
+      // transaction, so every command after it errors with 25P02 until a
+      // rollback -- which took the rest of this fixture down with it. Same
+      // reason explain_query and evaluate_index wrap their EXPLAINs.
       try {
-        txn.exec("CREATE EXTENSION IF NOT EXISTS hypopg SCHEMA extensions");
+        pqxx::subtransaction sub{txn};
+        sub.exec("CREATE EXTENSION IF NOT EXISTS hypopg SCHEMA extensions");
+        sub.commit();
       } catch (const std::exception&) {
       }
       txn.exec(

--- a/cpp/src/test_main.cpp
+++ b/cpp/src/test_main.cpp
@@ -220,6 +220,13 @@ protected:
       // tools are exercised against a schema-qualified lookup rather than
       // whatever happens to be on the role's search_path.
       txn.exec("CREATE EXTENSION IF NOT EXISTS pg_buffercache SCHEMA extensions");
+      // hypopg, also out of public. Optional: it is a third-party extension
+      // that may not be packaged everywhere, so the tests that need it skip
+      // rather than fail when it is absent.
+      try {
+        txn.exec("CREATE EXTENSION IF NOT EXISTS hypopg SCHEMA extensions");
+      } catch (const std::exception&) {
+      }
       txn.exec(
         "CREATE SERVER grocery_remote FOREIGN DATA WRAPPER postgres_fdw"
         " OPTIONS (host 'localhost', dbname 'probe', port '5432')"
@@ -426,20 +433,38 @@ TEST_F(PostgresMCPServerTest, TablesReturnsKnownTables) {
 
 TEST_F(PostgresMCPServerTest, TablesHasExpectedFields) {
   json result = srv->call_tables("grocery");
+  EXPECT_TRUE(result["users"].contains("kind"));
   EXPECT_TRUE(result["users"].contains("description"));
-  EXPECT_TRUE(result["users"].contains("rows"));
-  EXPECT_TRUE(result["users"].contains("size"));
-  EXPECT_TRUE(result["users"].contains("seq_scan"));
-  EXPECT_TRUE(result["users"].contains("idx_scan"));
-  EXPECT_TRUE(result["users"].contains("n_live_tup"));
-  EXPECT_TRUE(result["users"].contains("n_dead_tup"));
-  EXPECT_TRUE(result["users"].contains("last_vacuum"));
-  EXPECT_TRUE(result["users"].contains("last_analyze"));
+  EXPECT_TRUE(result["users"].contains("reloptions"));
   EXPECT_TRUE(result["users"].contains("columns"));
   EXPECT_TRUE(result["users"].contains("index_count"));
   EXPECT_TRUE(result["users"].contains("constraint_count"));
   EXPECT_GT(result["users"]["index_count"].get<int>(), 0);
   EXPECT_GT(result["users"]["constraint_count"].get<int>(), 0);
+}
+
+// 4.0.0: the structure tools carry no readings at all. Asserted by absence
+// rather than trusted, because a field left behind here is exactly what would
+// keep the tool wrongly classified per_server in tool_scopes().
+TEST_F(PostgresMCPServerTest, TablesCarriesNoStatistics) {
+  json result = srv->call_tables("grocery");
+  for (const char* f : {"rows", "size", "size_estimate", "seq_scan", "idx_scan",
+                        "n_live_tup", "n_dead_tup", "n_mod_since_analyze",
+                        "n_ins_since_vacuum", "last_vacuum", "last_analyze",
+                        "n_tup_newpage_upd", "last_seq_scan"})
+    EXPECT_FALSE(result["users"].contains(f)) << f << " is still on listTables";
+}
+
+TEST_F(PostgresMCPServerTest, SearchCarriesNoStatistics) {
+  json result = srv->call_search("users");
+  ASSERT_TRUE(result.contains("grocery.users")) << result.dump(2);
+  for (const char* f : {"rows", "size", "size_estimate", "seq_scan", "idx_scan",
+                        "n_live_tup", "n_dead_tup", "last_vacuum", "last_analyze"})
+    EXPECT_FALSE(result["grocery.users"].contains(f)) << f << " is still on searchTables";
+  // What it does keep: structure, and the privileges that make it findable by
+  // grantee name.
+  EXPECT_TRUE(result["grocery.users"].contains("columns"));
+  EXPECT_TRUE(result["grocery.users"].contains("roles"));
 }
 
 TEST_F(PostgresMCPServerTest, TablesColumnsIncludePerColumnIndexCount) {
@@ -534,18 +559,50 @@ TEST_F(PostgresMCPServerTest, SearchSnakeCaseName) {
 TEST_F(PostgresMCPServerTest, TableReturnsExpectedTopLevelKeys) {
   json result = srv->call_table("grocery", "users");
   EXPECT_TRUE(result.contains("table"));
-  EXPECT_TRUE(result.contains("rows"));
-  EXPECT_TRUE(result.contains("size"));
-  EXPECT_TRUE(result.contains("indexes_size"));
+  EXPECT_TRUE(result.contains("kind"));
   EXPECT_TRUE(result.contains("description"));
-  EXPECT_TRUE(result.contains("seq_scan"));
-  EXPECT_TRUE(result.contains("idx_scan"));
+  EXPECT_TRUE(result.contains("reloptions"));
   EXPECT_TRUE(result.contains("columns"));
   EXPECT_TRUE(result.contains("indexes"));
   EXPECT_TRUE(result.contains("constraints"));
   EXPECT_TRUE(result.contains("foreign_keys"));
   EXPECT_TRUE(result.contains("referenced_by"));
   EXPECT_TRUE(result.contains("primary_key"));
+  EXPECT_TRUE(result.contains("triggers"));
+  EXPECT_TRUE(result.contains("rules"));
+  EXPECT_TRUE(result.contains("row_level_security"));
+  EXPECT_TRUE(result.contains("policies"));
+  EXPECT_TRUE(result.contains("roles"));
+}
+
+TEST_F(PostgresMCPServerTest, TableDetailsCarriesNoStatistics) {
+  json result = srv->call_table("grocery", "users");
+  for (const char* f : {"rows", "size", "indexes_size", "size_estimate",
+                        "seq_scan", "idx_scan", "n_live_tup", "n_dead_tup",
+                        "n_mod_since_analyze", "n_ins_since_vacuum",
+                        "last_vacuum", "last_analyze", "n_tup_newpage_upd",
+                        "last_seq_scan"})
+    EXPECT_FALSE(result.contains(f)) << f << " is still on tableDetails";
+
+  // Reason 3 of the split: most_common_vals is literal column values, and this
+  // is the tool an agent calls most often to inspect structure. It must return
+  // none of them.
+  ASSERT_TRUE(result["columns"].contains("email"));
+  for (const char* f : {"null_frac", "avg_width", "n_distinct",
+                        "physical_order_correlation", "most_common_vals",
+                        "most_common_freqs"})
+    EXPECT_FALSE(result["columns"]["email"].contains(f))
+        << f << " is still on a tableDetails column";
+
+  // Index definitions are structure and stay; their scan counters and sizes
+  // do not.
+  ASSERT_FALSE(result["indexes"].empty());
+  for (auto& [name, idx] : result["indexes"].items()) {
+    EXPECT_TRUE(idx.contains("definition")) << name;
+    EXPECT_FALSE(idx.contains("size")) << name;
+    EXPECT_FALSE(idx.contains("index_uses")) << name;
+    EXPECT_FALSE(idx.contains("last_use")) << name;
+  }
 }
 
 TEST_F(PostgresMCPServerTest, TableDetailsSingleColumnPrimaryKey) {
@@ -662,14 +719,28 @@ TEST_F(PostgresMCPServerTest, TableColumnsHaveNoDefaultWhenAbsent) {
   EXPECT_FALSE(result["columns"]["name"].contains("default"));
 }
 
+// 4.0.0 split this one test across the three tiers it now spans: the
+// definition stayed on tableDetails, the scan count went to tableStats, and
+// the size to tableSize.
 TEST_F(PostgresMCPServerTest, TableIndexesHaveSizeField) {
-  json result = srv->call_table("grocery", "users");
-  EXPECT_FALSE(result["indexes"].empty());
-  for (auto& [idx_name, idx_obj] : result["indexes"].items()) {
-    EXPECT_TRUE(idx_obj.contains("size")) << "Index " << idx_name << " missing size";
-    EXPECT_TRUE(idx_obj.contains("definition"));
-    EXPECT_TRUE(idx_obj.contains("index_uses"));
-  }
+  json structure = srv->call_table("grocery", "users");
+  EXPECT_FALSE(structure["indexes"].empty());
+  for (auto& [idx_name, idx_obj] : structure["indexes"].items())
+    EXPECT_TRUE(idx_obj.contains("definition")) << idx_name;
+
+  json stats = srv->call_table_stats("grocery", "users");
+  for (auto& [idx_name, idx_obj] : stats["indexes"].items())
+    EXPECT_TRUE(idx_obj.contains("index_uses")) << idx_name;
+
+  json sizes = srv->call_table_size("grocery", "users");
+  EXPECT_FALSE(sizes["indexes"].empty());
+  for (auto& [idx_name, sz] : sizes["indexes"].items())
+    EXPECT_TRUE(sz.is_number()) << "Index " << idx_name << " missing size";
+
+  // Every index the structure tool names is measured and counted, so a caller
+  // can join the three payloads on the index name without gaps.
+  EXPECT_EQ(structure["indexes"].size(), sizes["indexes"].size());
+  EXPECT_EQ(structure["indexes"].size(), stats["indexes"].size());
 }
 
 TEST_F(PostgresMCPServerTest, TableColumnsHaveTypeInfo) {
@@ -681,7 +752,9 @@ TEST_F(PostgresMCPServerTest, TableColumnsHaveTypeInfo) {
 }
 
 TEST_F(PostgresMCPServerTest, TableColumnsIncludeStatsForAnalyzedTable) {
-  json result = srv->call_table("grocery", "users");
+  // The histograms answer the same question they always did; 4.0.0 moved which
+  // tool asks it.
+  json result = srv->call_table_stats("grocery", "users");
   EXPECT_TRUE(result["columns"]["name"].contains("null_frac"));
   EXPECT_TRUE(result["columns"]["name"].contains("avg_width"));
   EXPECT_TRUE(result["columns"]["name"].contains("n_distinct"));
@@ -1468,9 +1541,12 @@ TEST_F(PostgresMCPServerTest, TableDetailsIncludesToastInfoWhenPresent) {
   json result = srv->call_table("grocery", "users"); // has VARCHAR columns
   ASSERT_TRUE(result.contains("toast"));
   ASSERT_FALSE(result["toast"].is_null());
+  // The name is a catalog fact and stays; the sizes are measured and moved to
+  // tableSize in 4.0.0. What this tool still answers is "does this table store
+  // anything out of line at all".
   EXPECT_TRUE(result["toast"]["name"].get<std::string>().rfind("pg_toast", 0) == 0);
-  EXPECT_TRUE(result["toast"].contains("size"));
-  EXPECT_TRUE(result["toast"].contains("index_size"));
+  EXPECT_FALSE(result["toast"].contains("size"));
+  EXPECT_FALSE(result["toast"].contains("index_size"));
 }
 
 TEST_F(PostgresMCPServerTest, TableDetailsToastIsNullWhenNoToastableColumns) {
@@ -1653,10 +1729,14 @@ TEST_F(PostgresMCPServerTest, LocksShowsHeldLockFromAnotherConnection) {
   lock_txn.exec("LOCK TABLE grocery.users IN ACCESS EXCLUSIVE MODE");
 
   json result = srv->call_locks();
-  ASSERT_TRUE(result.is_array());
+  // 4.0.0: the rows are under "locks" -- a top-level array cannot be a
+  // structuredContent payload.
+  ASSERT_TRUE(result.is_object());
+  ASSERT_TRUE(result.contains("locks"));
+  ASSERT_TRUE(result["locks"].is_array());
 
   bool found = false;
-  for (auto& lock : result) {
+  for (auto& lock : result["locks"]) {
     if (lock.contains("relation") && !lock["relation"].is_null() &&
         lock["relation"].get<std::string>() == "grocery.users" &&
         lock["granted"].get<bool>()) {
@@ -1939,9 +2019,9 @@ TEST_F(PostgresMCPServerTest, LocksResolveTheTransitiveBlockingChain) {
   json chain;
   for (int i = 0; i < 40 && chain.is_null(); i++) {
     json r = srv->call_locks(waiter_pid);
-    if (!r.is_array()) continue;
-    for (const auto& l : r) {
-      if (l.contains("chain_depth") && l["chain_depth"].get<int>() > 0) chain = r;
+    if (!r.is_object() || !r["locks"].is_array()) continue;
+    for (const auto& l : r["locks"]) {
+      if (l.contains("chain_depth") && l["chain_depth"].get<int>() > 0) chain = r["locks"];
     }
   }
 
@@ -2031,21 +2111,172 @@ TEST_F(PostgresMCPServerTest, DatabaseStatsIncludesSessionCounters) {
   EXPECT_EQ(s.contains("parallel_workers_launched"), pg18);
 }
 
-// --- listTables / tableDetails version-gated columns ---
+// --- listTableStats / tableStats version-gated columns ---
 
 TEST_F(PostgresMCPServerTest, TableStatsIncludeFailedHotUpdatesOnPg16AndLater) {
   const bool pg16 = pg_server_version_num(test_url) >= 160000;
 
-  json tables = srv->call_tables("grocery");
-  ASSERT_TRUE(tables.contains("users"));
+  // The gate followed the fields out of the structure tools in 4.0.0.
+  json listed = srv->call_list_table_stats("grocery");
+  ASSERT_TRUE(listed.contains("users")) << listed.dump(2);
   // n_tup_newpage_upd counts updates that had to move the row to another
   // page: the direct measure of failed HOT updates.
-  EXPECT_EQ(tables["users"].contains("n_tup_newpage_upd"), pg16);
-  EXPECT_EQ(tables["users"].contains("last_seq_scan"), pg16);
+  EXPECT_EQ(listed["users"].contains("n_tup_newpage_upd"), pg16);
+  EXPECT_EQ(listed["users"].contains("last_seq_scan"), pg16);
 
-  json detail = srv->call_table("grocery", "users");
-  EXPECT_EQ(detail.contains("n_tup_newpage_upd"), pg16);
-  EXPECT_EQ(detail.contains("last_seq_scan"), pg16);
+  json one = srv->call_table_stats("grocery", "users");
+  EXPECT_EQ(one.contains("n_tup_newpage_upd"), pg16);
+  EXPECT_EQ(one.contains("last_seq_scan"), pg16);
+
+  // pg_stat_user_indexes.last_idx_scan is gated on the same release, and it is
+  // built by concatenation now rather than erased out of a finished query --
+  // the older approach failed silently if the literal ever drifted.
+  ASSERT_FALSE(one["indexes"].empty()) << one.dump(2);
+  for (auto& [name, idx] : one["indexes"].items()) {
+    EXPECT_TRUE(idx.contains("index_uses")) << name;
+    EXPECT_EQ(idx.contains("last_use"), pg16) << name;
+  }
+}
+
+// --- 4.0.0 statistics split ---
+
+TEST_F(PostgresMCPServerTest, TableStatsCarriesTheReadingsTableDetailsLost) {
+  json r = srv->call_table_stats("grocery", "users");
+  for (const char* f : {"table", "rows", "size_estimate", "estimated_from",
+                        "seq_scan", "idx_scan", "n_live_tup", "n_dead_tup",
+                        "n_mod_since_analyze", "n_ins_since_vacuum",
+                        "last_vacuum", "last_analyze", "columns", "indexes"})
+    EXPECT_TRUE(r.contains(f)) << f << " missing from tableStats";
+  EXPECT_EQ(r["table"].get<std::string>(), "users");
+
+  // The pg_stats histograms live here now, including the sample values.
+  ASSERT_TRUE(r["columns"].contains("email")) << r["columns"].dump(2);
+  for (const char* f : {"null_frac", "avg_width", "n_distinct",
+                        "physical_order_correlation", "most_common_vals",
+                        "most_common_freqs"})
+    EXPECT_TRUE(r["columns"]["email"].contains(f)) << f;
+}
+
+TEST_F(PostgresMCPServerTest, TableStatsListsEveryColumnEvenWithoutStatistics) {
+  // Nulls are kept rather than stripped: a column with no row in pg_stats has
+  // never been analyzed, and that is the actionable signal. Stripping it would
+  // make "never analyzed" and "column does not exist" look the same.
+  json r = srv->call_table_stats("grocery", "users");
+  json structure = srv->call_table("grocery", "users");
+  EXPECT_EQ(r["columns"].size(), structure["columns"].size());
+}
+
+TEST_F(PostgresMCPServerTest, ListTableStatsCoversTheSchemaWithoutHistograms) {
+  json r = srv->call_list_table_stats("grocery");
+  ASSERT_TRUE(r.contains("users")) << r.dump(2);
+  for (const char* f : {"rows", "size_estimate", "estimated_from", "seq_scan",
+                        "idx_scan", "n_live_tup", "n_dead_tup", "last_vacuum",
+                        "last_analyze"})
+    EXPECT_TRUE(r["users"].contains(f)) << f << " missing from listTableStats";
+  // Per-column histograms for every table in a schema is a payload nobody
+  // asked for; name one table to tableStats instead.
+  EXPECT_FALSE(r["users"].contains("columns"));
+}
+
+TEST_F(PostgresMCPServerTest, SizeEstimateIsNamedAsAnEstimateAndDatedByIt) {
+  json stats = srv->call_table_stats("grocery", "users");
+  // The field is deliberately not called `size`: relpages is only as fresh as
+  // the last vacuum or analyze, and estimated_from is what lets a caller judge
+  // that rather than guess.
+  EXPECT_TRUE(stats.contains("size_estimate"));
+  EXPECT_FALSE(stats.contains("size"));
+  EXPECT_TRUE(stats.contains("estimated_from"));
+
+  json measured = srv->call_table_size("grocery", "users");
+  // ...and the measured tool uses the plain name, so the two can never be
+  // confused for one another.
+  EXPECT_TRUE(measured.contains("size"));
+  EXPECT_FALSE(measured.contains("size_estimate"));
+}
+
+TEST_F(PostgresMCPServerTest, TableSizeMeasuresEveryFork) {
+  json r = srv->call_table_size("grocery", "users");
+  for (const char* f : {"table", "kind", "main_size", "size", "indexes_size",
+                        "total_size", "toast", "indexes"})
+    EXPECT_TRUE(r.contains(f)) << f << " missing from tableSize";
+  // pg_table_size covers the main fork plus the free space and visibility
+  // maps, so it is at least the main fork; the grand total adds the indexes.
+  EXPECT_GE(r["size"].get<long long>(), r["main_size"].get<long long>());
+  EXPECT_GE(r["total_size"].get<long long>(), r["size"].get<long long>());
+  ASSERT_FALSE(r["indexes"].empty());
+  for (auto& [name, sz] : r["indexes"].items())
+    EXPECT_TRUE(sz.is_number()) << name;
+  // The TOAST sizes that left tableDetails landed here.
+  ASSERT_FALSE(r["toast"].is_null());
+  EXPECT_TRUE(r["toast"].contains("size"));
+  EXPECT_TRUE(r["toast"].contains("index_size"));
+}
+
+TEST_F(PostgresMCPServerTest, ListTableSizesMeasuresEveryRelationInTheSchema) {
+  json r = srv->call_list_table_sizes("grocery");
+  ASSERT_TRUE(r.contains("users")) << r.dump(2);
+  for (const char* f : {"kind", "size", "indexes_size", "total_size"})
+    EXPECT_TRUE(r["users"].contains(f)) << f;
+  EXPECT_GE(r["users"]["total_size"].get<long long>(),
+            r["users"]["size"].get<long long>());
+}
+
+TEST_F(PostgresMCPServerTest, SizeToolsDoNotFailOnRelationsWithNoStorage) {
+  // A view and a partitioned parent own no files. pg_table_size returns 0 for
+  // them rather than raising, which is what lets listTableSizes cover a whole
+  // schema without the caller pre-filtering by relkind -- but a caller reading
+  // 0 off a partitioned table is being told about the parent, not the data,
+  // and the tool description says so.
+  json r = srv->call_list_table_sizes("grocery");
+  bool saw_view = false;
+  for (auto& [name, v] : r.items()) {
+    if (v["kind"].get<std::string>() == "view") {
+      saw_view = true;
+      EXPECT_EQ(v["size"].get<long long>(), 0) << name;
+    }
+  }
+  EXPECT_TRUE(saw_view) << "the fixture has no view to prove this with";
+}
+
+TEST_F(PostgresMCPServerTest, StatisticsSplitCorrectsTheSweepClassification) {
+  // Reason 1, and the point of the whole exercise: structure is byte-identical
+  // on a physical replica, so the structure tools must refuse a
+  // replication_group sweep while the statistics tools accept one.
+  json tools = srv->call_tools_list();
+  std::map<std::string, json> by_name;
+  for (const auto& t : tools) by_name[t.value("name", "")] = t;
+
+  for (const char* n : {"listTables", "searchTables", "tableDetails",
+                        "tableSize", "listTableSizes"}) {
+    ASSERT_TRUE(by_name.count(n)) << n;
+    EXPECT_FALSE(by_name[n]["inputSchema"]["properties"].contains("replication_group"))
+        << n << " still advertises a replication-group sweep";
+    EXPECT_NE(by_name[n].value("description", "").find("byte-identical here"),
+              std::string::npos) << n;
+  }
+  for (const char* n : {"tableStats", "listTableStats"}) {
+    ASSERT_TRUE(by_name.count(n)) << n;
+    EXPECT_TRUE(by_name[n]["inputSchema"]["properties"].contains("replication_group"))
+        << n << " cannot sweep, and it is the half that should";
+    EXPECT_NE(by_name[n].value("description", "").find("each server's own"),
+              std::string::npos) << n;
+  }
+}
+
+TEST_F(PostgresMCPServerTest, TheGatedSizeToolsSayWhatTheyCost) {
+  // The gate is the description, because MCP has no annotation for "expensive"
+  // and a server cannot force a client to confirm. What it can do is make the
+  // cost visible where the model chooses the tool.
+  json tools = srv->call_tools_list();
+  for (const auto& t : tools) {
+    const std::string n = t.value("name", "");
+    if (n != "tableSize" && n != "listTableSizes") continue;
+    const std::string d = t.value("description", "");
+    EXPECT_NE(d.find("AccessShareLock"), std::string::npos) << n;
+    EXPECT_NE(d.find("AccessExclusiveLock"), std::string::npos) << n;
+    EXPECT_NE(d.find("size_estimate"), std::string::npos)
+        << n << " does not point at the free alternative";
+  }
 }
 
 // --- progressStats ---
@@ -3615,6 +3846,585 @@ TEST_F(PostgresMCPServerTest, AnnotationsAppearForClientsThatUnderstandThem) {
   EXPECT_EQ(explain_seen, 1);
 }
 
+// --- 4.0.0 outputSchema ---
+
+namespace {
+
+// A validator for exactly the JSON Schema subset these declarations use:
+// "type" (a name or a list of names) and "properties". Nothing here uses
+// "required" and every schema sets additionalProperties true, so conformance
+// reduces to "the top level is an object, and every declared property that is
+// present has one of its declared types". That is the whole drift risk: a
+// field whose type changes under a declared schema turns a working call into a
+// client-side validation error, which is what the roadmap warns about.
+bool json_type_matches(const json& v, const std::string& t) {
+  if (t == "null")    return v.is_null();
+  if (t == "object")  return v.is_object();
+  if (t == "array")   return v.is_array();
+  if (t == "string")  return v.is_string();
+  if (t == "boolean") return v.is_boolean();
+  if (t == "integer") return v.is_number_integer();
+  if (t == "number")  return v.is_number();
+  return false;
+}
+
+bool conforms(const json& value, const json& schema, std::string& why) {
+  if (schema.contains("type")) {
+    const json& t = schema["type"];
+    bool ok = false;
+    if (t.is_string()) ok = json_type_matches(value, t.get<std::string>());
+    else for (const auto& one : t) if (json_type_matches(value, one.get<std::string>())) ok = true;
+    if (!ok) { why = std::string("expected ") + t.dump() + ", got " + value.type_name(); return false; }
+  }
+  if (schema.contains("properties") && value.is_object()) {
+    for (auto& [key, sub] : schema["properties"].items()) {
+      if (!value.contains(key)) continue;   // nothing is required, by design
+      std::string inner;
+      if (!conforms(value[key], sub, inner)) { why = key + ": " + inner; return false; }
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+TEST_F(PostgresMCPServerTest, EveryToolDeclaresAnOutputSchema) {
+  // Declaring one for 55 tools and not the 56th reads to a client as "that one
+  // is unstructured", which is worse than declaring none at all.
+  json tools = srv->call_tools_list("2025-06-18");
+  ASSERT_FALSE(tools.empty());
+  for (const auto& t : tools) {
+    const std::string name = t.value("name", "");
+    ASSERT_TRUE(t.contains("outputSchema")) << name << " declares no outputSchema";
+    EXPECT_EQ(t["outputSchema"]["type"], "object") << name;
+    // structuredContent may only be an object, so no schema may say otherwise.
+    EXPECT_TRUE(t["outputSchema"].value("additionalProperties", false))
+        << name << " forbids additional properties, which a catalog will grow";
+    EXPECT_FALSE(t["outputSchema"].contains("required"))
+        << name << " marks a field required; a version-conditional payload cannot";
+  }
+}
+
+TEST_F(PostgresMCPServerTest, OutputSchemaStartsAtTheRevisionThatDefinedIt) {
+  for (const char* proto : {"2024-11-05", "2025-03-26"})
+    for (const auto& t : srv->call_tools_list(proto))
+      EXPECT_FALSE(t.contains("outputSchema")) << proto << " " << t.value("name", "");
+  for (const auto& t : srv->call_tools_list("2025-06-18"))
+    EXPECT_TRUE(t.contains("outputSchema")) << t.value("name", "");
+}
+
+TEST_F(PostgresMCPServerTest, RealPayloadsConformToTheirDeclaredSchema) {
+  // The test that makes the declarations safe to ship. A schema that drifts
+  // from the payload turns a previously-working call into a validation error
+  // on the client, and that failure would be invisible from here otherwise.
+  json tools = srv->call_tools_list("2025-06-18");
+  std::map<std::string, json> schema;
+  for (const auto& t : tools) schema[t.value("name", "")] = t["outputSchema"];
+
+  // Negotiate the revision through initialize rather than per-request _meta,
+  // so this exercises the same path a real 2025-06-18 client takes.
+  PostgresMCPServer modern(test_url);
+  modern.call_rpc({{"jsonrpc", "2.0"}, {"id", 0}, {"method", "initialize"},
+                   {"params", {{"protocolVersion", "2025-06-18"},
+                               {"capabilities", json::object()},
+                               {"clientInfo", {{"name", "t"}, {"version", "0"}}}}}});
+
+  const std::vector<std::pair<std::string, json>> calls = {
+    {"listSchemas",      json::object()},
+    {"listTables",       {{"schema", "grocery"}}},
+    {"tableDetails",     {{"schema", "grocery"}, {"table", "users"}}},
+    {"tableStats",       {{"schema", "grocery"}, {"table", "users"}}},
+    {"tableSize",        {{"schema", "grocery"}, {"table", "users"}}},
+    {"listTableStats",   {{"schema", "grocery"}}},
+    {"listTableSizes",   {{"schema", "grocery"}}},
+    {"searchTables",     {{"web_search", "users"}}},
+    {"listFunctions",    {{"schema", "grocery"}}},
+    {"listEnums",        {{"schema", "grocery"}}},
+    {"listTypes",        {{"schema", "grocery"}}},
+    {"listSequences",    {{"schema", "grocery"}}},
+    {"listRoles",        json::object()},
+    {"listExtensions",   json::object()},
+    {"listTablespaces",  json::object()},
+    {"listCollations",   json::object()},
+    {"listAccessMethods",json::object()},
+    {"listLanguages",    json::object()},
+    {"listConnections",  json::object()},
+    {"listTopology",     json::object()},
+    {"currentLocks",     json::object()},
+    {"currentActivity",  json::object()},
+    {"databaseSize",     json::object()},
+    {"databaseStats",    json::object()},
+    {"progressStats",    json::object()},
+    {"wraparoundStatus", json::object()},
+    {"checkpointStats",  json::object()},
+    {"hostCapacity",     json::object()},
+    {"ioStats",          json::object()},
+    {"tableIOStats",     {{"schema", "grocery"}}},
+    {"duplicateIndexes", {{"schema", "grocery"}}},
+    {"serverSettings",   json::object()},
+    {"checkKey",         {{"schema", "grocery"}, {"table", "users"}, {"values", json::array({1})}}},
+    {"explainQuery",     {{"sql", "SELECT 1"}}},
+  };
+  int checked = 0;
+  for (const auto& [tool, args] : calls) {
+    json r = modern.call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", "tools/call"},
+                              {"params", {{"name", tool}, {"arguments", args}}}});
+    if (!r["result"].contains("structuredContent")) continue;  // an isError path
+    const json& payload = r["result"]["structuredContent"];
+    ASSERT_TRUE(schema.count(tool)) << tool;
+    std::string why;
+    EXPECT_TRUE(conforms(payload, schema[tool], why))
+        << tool << " payload violates its declared outputSchema: " << why;
+    checked++;
+  }
+  EXPECT_GE(checked, 30) << "too few tools actually exercised to prove anything";
+}
+
+namespace {
+
+const char* kProtoVersion  = "io.modelcontextprotocol/protocolVersion";
+const char* kProtoCaps     = "io.modelcontextprotocol/clientCapabilities";
+const char* kProtoSrvInfo  = "io.modelcontextprotocol/serverInfo";
+
+json modern_meta(const std::string& version = "2026-07-28") {
+  return {{kProtoVersion, version}, {kProtoCaps, json::object()}};
+}
+
+}  // namespace
+
+// --- 4.0.0 caching hints and pagination (revision 2026-07-28) ---
+
+TEST_F(PostgresMCPServerTest, CacheableResultsCarryTheirHints) {
+  // The spec says servers MUST include caching hints on every result with
+  // resultType "complete" from these six operations. tools/list is ~91 kB, and
+  // without a hint a client SHOULD treat it as immediately stale and re-fetch
+  // it whenever it needs the list.
+  const std::vector<std::pair<std::string, json>> cacheable = {
+    {"server/discover",          json::object()},
+    {"tools/list",               json::object()},
+    {"prompts/list",             json::object()},
+    {"resources/list",           json::object()},
+    {"resources/templates/list", json::object()},
+    {"resources/read",           {{"uri", "pglicht://default/server/extensions"}}},
+  };
+  for (const auto& [method, extra] : cacheable) {
+    json params = extra;
+    params["_meta"] = modern_meta();
+    json r = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", method},
+                            {"params", params}});
+    ASSERT_TRUE(r.contains("result")) << method << " " << r.dump(2);
+    const json& res = r["result"];
+    ASSERT_EQ(res.value("resultType", ""), "complete") << method;
+    ASSERT_TRUE(res.contains("ttlMs")) << method << " carries no ttlMs";
+    EXPECT_TRUE(res["ttlMs"].is_number_integer()) << method;
+    EXPECT_GE(res["ttlMs"].get<long long>(), 0) << method << ": ttlMs MUST be >= 0";
+    ASSERT_TRUE(res.contains("cacheScope")) << method << " carries no cacheScope";
+    const std::string scope = res["cacheScope"].get<std::string>();
+    EXPECT_TRUE(scope == "public" || scope == "private") << method << ": " << scope;
+  }
+}
+
+TEST_F(PostgresMCPServerTest, CacheScopeIsPrivateWhereTheResultIsNotShareable) {
+  auto scope_of = [&](const std::string& method) {
+    json r = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", method},
+                            {"params", {{"_meta", modern_meta()}}}});
+    return r["result"].value("cacheScope", "");
+  };
+  // tools/list varies by negotiated revision (annotations, title and
+  // outputSchema are each gated) while the cache key is method plus params,
+  // and it embeds the configured default connection name. resources/list
+  // enumerates the operator's schemas. Neither may be served to another caller.
+  EXPECT_EQ(scope_of("tools/list"), "private");
+  EXPECT_EQ(scope_of("resources/list"), "private");
+  // These are compiled in and identical for everyone.
+  EXPECT_EQ(scope_of("prompts/list"), "public");
+  EXPECT_EQ(scope_of("resources/templates/list"), "public");
+  EXPECT_EQ(scope_of("server/discover"), "public");
+}
+
+TEST_F(PostgresMCPServerTest, LegacyResultsCarryNoCachingHints) {
+  // The hints are defined by the same revision that defines resultType, so
+  // they are gated the same way: a legacy result must not grow fields its era
+  // never had.
+  json r = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", "tools/list"},
+                          {"params", json::object()}});
+  EXPECT_FALSE(r["result"].contains("ttlMs"));
+  EXPECT_FALSE(r["result"].contains("cacheScope"));
+  EXPECT_FALSE(r["result"].contains("resultType"));
+}
+
+TEST_F(PostgresMCPServerTest, PaginationWalksEveryItemExactlyOnce) {
+  json items = json::array();
+  for (int i = 0; i < 250; i++) items.push_back({{"n", i}});
+
+  std::vector<int> seen;
+  json params = json::object();
+  int pages = 0;
+  for (;;) {
+    json page = json::object();
+    ASSERT_TRUE(PostgresMCPServer::call_paginate(items, params, "items", page)) << params.dump();
+    pages++;
+    for (const auto& e : page["items"]) seen.push_back(e["n"].get<int>());
+    if (!page.contains("nextCursor")) break;
+    params["cursor"] = page["nextCursor"];
+    ASSERT_LE(pages, 10) << "pagination did not terminate";
+  }
+  EXPECT_GT(pages, 1) << "250 items should not fit in one page";
+  ASSERT_EQ(seen.size(), 250u);
+  for (int i = 0; i < 250; i++) EXPECT_EQ(seen[static_cast<size_t>(i)], i);
+}
+
+TEST_F(PostgresMCPServerTest, CursorsAreOpaqueAndStable) {
+  json items = json::array();
+  for (int i = 0; i < 250; i++) items.push_back(i);
+
+  json first = json::object();
+  ASSERT_TRUE(PostgresMCPServer::call_paginate(items, json::object(), "items", first));
+  ASSERT_TRUE(first.contains("nextCursor"));
+  const std::string cursor = first["nextCursor"].get<std::string>();
+  // Opaque by contract: it must not read as a number a client could do
+  // arithmetic on.
+  EXPECT_TRUE(cursor.find_first_not_of("0123456789") != std::string::npos) << cursor;
+
+  // Stable: the same request yields the same cursor.
+  json again = json::object();
+  ASSERT_TRUE(PostgresMCPServer::call_paginate(items, json::object(), "items", again));
+  EXPECT_EQ(again["nextCursor"].get<std::string>(), cursor);
+}
+
+TEST_F(PostgresMCPServerTest, AnInvalidCursorIsInvalidParams) {
+  for (const char* bad : {"not-base64!!", "", "cGdsaWNodDo5OTk5OTk="}) {
+    json r = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", "tools/list"},
+                            {"params", {{"_meta", modern_meta()}, {"cursor", bad}}}});
+    ASSERT_TRUE(r.contains("error")) << "cursor '" << bad << "' was accepted";
+    EXPECT_EQ(r["error"]["code"], -32602) << bad;
+  }
+  // An empty string is a valid *cursor value* per the spec -- a client must not
+  // read it as end-of-results -- but it is not one this server ever issues, so
+  // it is refused rather than silently treated as "start from the beginning".
+}
+
+TEST_F(PostgresMCPServerTest, NoCurrentListIsTruncatedForAClientThatIgnoresCursors) {
+  // The page size is deliberately larger than anything this server lists
+  // today, so a client that never sends a cursor still sees every tool. A
+  // smaller page would silently hide 44 of the 56 tools from such a client.
+  for (const char* method : {"tools/list", "prompts/list", "resources/templates/list",
+                             "resources/list"}) {
+    json r = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", method},
+                            {"params", {{"_meta", modern_meta()}}}});
+    EXPECT_FALSE(r["result"].contains("nextCursor"))
+        << method << " paginates today, which would truncate a client that ignores it";
+  }
+  json tools = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", "tools/list"},
+                              {"params", {{"_meta", modern_meta()}}}});
+  EXPECT_EQ(tools["result"]["tools"].size(), srv->call_tools_list().size());
+}
+
+// --- 4.0.0 resources, prompts and completions ---
+
+namespace {
+json rpc1(PostgresMCPServer& s, const std::string& method, const json& params) {
+  return s.call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", method}, {"params", params}});
+}
+}  // namespace
+
+TEST_F(PostgresMCPServerTest, CapabilitiesDeclareTheThreeNewSurfaces) {
+  // A private server: initialize sets the negotiated revision for the rest of
+  // that server's life, and the fixture's is shared by every test in the suite.
+  PostgresMCPServer own(test_url);
+  json init = rpc1(own, "initialize",
+                   {{"protocolVersion", "2025-06-18"},
+                    {"capabilities", json::object()},
+                    {"clientInfo", {{"name", "t"}, {"version", "0"}}}});
+  const json& caps = init["result"]["capabilities"];
+  for (const char* c : {"tools", "resources", "prompts", "completions"})
+    EXPECT_TRUE(caps.contains(c)) << c << " missing from initialize";
+
+  // The stateless era advertises the same set, or a modern client would see a
+  // smaller server than a legacy one.
+  json disc = rpc1(own, "server/discover", json::object());
+  const json& dcaps = disc["result"]["capabilities"];
+  for (const char* c : {"tools", "resources", "prompts", "completions"})
+    EXPECT_TRUE(dcaps.contains(c)) << c << " missing from server/discover";
+}
+
+TEST_F(PostgresMCPServerTest, ResourcesListIsBoundedAndDoesNotEnumerateTables) {
+  json r = rpc1(*srv, "resources/list", json::object());
+  const json& res = r["result"]["resources"];
+  ASSERT_TRUE(res.is_array()) << r.dump(2);
+
+  bool saw_schemas = false, saw_grocery = false;
+  for (const auto& e : res) {
+    const std::string uri = e.value("uri", "");
+    EXPECT_EQ(e.value("mimeType", ""), "application/json") << uri;
+    if (uri.find("/schemas") != std::string::npos)          saw_schemas = true;
+    if (uri.find("/schema/grocery") != std::string::npos)   saw_grocery = true;
+    // A 10k-table database must not produce a 10k-entry list; tables are
+    // reached through the template instead.
+    EXPECT_EQ(uri.find("/table/"), std::string::npos)
+        << "resources/list enumerated a table: " << uri;
+  }
+  EXPECT_TRUE(saw_schemas);
+  EXPECT_TRUE(saw_grocery) << "schemas of a reachable connection should be listed";
+}
+
+TEST_F(PostgresMCPServerTest, ResourceTemplatesCoverWhatTheListDoesNot) {
+  json r = rpc1(*srv, "resources/templates/list", json::object());
+  const json& t = r["result"]["resourceTemplates"];
+  ASSERT_TRUE(t.is_array());
+  bool saw_table = false;
+  for (const auto& e : t)
+    if (e.value("uriTemplate", "") == "pglicht://{conn}/schema/{schema}/table/{table}")
+      saw_table = true;
+  EXPECT_TRUE(saw_table);
+}
+
+TEST_F(PostgresMCPServerTest, AResourceServesTheSamePayloadAsItsTool) {
+  // Resources are the existing query methods behind a URI, not a second
+  // implementation that can drift from the first.
+  json r = rpc1(*srv, "resources/read",
+                {{"uri", "pglicht://default/schema/grocery/table/users"}});
+  ASSERT_TRUE(r["result"].contains("contents")) << r.dump(2);
+  const json& c = r["result"]["contents"][0];
+  EXPECT_EQ(c.value("mimeType", ""), "application/json");
+  json body = json::parse(c["text"].get<std::string>());
+  EXPECT_EQ(body, srv->call_table("grocery", "users"));
+}
+
+TEST_F(PostgresMCPServerTest, ResourcesCarryStructureAndNoReadings) {
+  // The volatility principle, and the reason resources had to wait for the
+  // statistics split: a document a client pins into context and re-reads later
+  // must not carry a counter that moves under it.
+  json r = rpc1(*srv, "resources/read",
+                {{"uri", "pglicht://default/schema/grocery/table/users"}});
+  json body = json::parse(r["result"]["contents"][0]["text"].get<std::string>());
+  for (const char* f : {"n_dead_tup", "seq_scan", "idx_scan", "last_vacuum",
+                        "rows", "size", "size_estimate"})
+    EXPECT_FALSE(body.contains(f)) << f << " is a reading, and this is a document";
+  EXPECT_TRUE(body.contains("columns"));
+}
+
+TEST_F(PostgresMCPServerTest, AnUnknownResourceFailsWithInvalidParams) {
+  for (const char* uri : {"pglicht://default/nope",
+                          "pglicht://default/schema/grocery/table",
+                          "https://example.com/x"}) {
+    json r = rpc1(*srv, "resources/read", {{"uri", uri}});
+    ASSERT_TRUE(r.contains("error")) << uri << " " << r.dump(2);
+    EXPECT_EQ(r["error"]["code"], -32602) << uri;
+  }
+}
+
+TEST_F(PostgresMCPServerTest, AResourceNamingAnUnknownConnectionSaysWhichExist) {
+  json r = rpc1(*srv, "resources/read", {{"uri", "pglicht://nosuchconn/schemas"}});
+  ASSERT_TRUE(r.contains("error")) << r.dump(2);
+  // The registry throws a message listing the configured names, so a typo is
+  // answered rather than turned into a connect failure.
+  EXPECT_NE(r["error"]["message"].get<std::string>().find("default"), std::string::npos)
+      << r["error"].dump(2);
+}
+
+TEST_F(PostgresMCPServerTest, PromptsAreListedWithTheirArguments) {
+  json r = rpc1(*srv, "prompts/list", json::object());
+  const json& p = r["result"]["prompts"];
+  ASSERT_TRUE(p.is_array());
+  std::set<std::string> names;
+  for (const auto& e : p) {
+    names.insert(e.value("name", ""));
+    EXPECT_FALSE(e.value("description", "").empty()) << e.value("name", "");
+    EXPECT_TRUE(e["arguments"].is_array()) << e.value("name", "");
+  }
+  for (const char* n : {"diagnose-slow-query", "triage-lock-contention",
+                        "bloat-and-vacuum-review", "buffer-cache-review",
+                        "capacity-check", "replication-slot-review",
+                        "plan-schema-change", "explain-and-fix"})
+    EXPECT_TRUE(names.count(n)) << n << " is missing";
+}
+
+TEST_F(PostgresMCPServerTest, PromptsSendTheModelToCheckPrivilegesFirst) {
+  // Every prompt whose core tools are privilege-gated opens by checking. A
+  // restricted role gets null statistics rather than an error, so a plan built
+  // on tools that will not answer looks like it worked.
+  for (const char* n : {"diagnose-slow-query", "triage-lock-contention",
+                        "bloat-and-vacuum-review", "buffer-cache-review",
+                        "replication-slot-review", "plan-schema-change",
+                        "explain-and-fix"}) {
+    json r = rpc1(*srv, "prompts/get", {{"name", n},
+                                        {"arguments", {{"sql", "SELECT 1"},
+                                                       {"change", "add a column"}}}});
+    const std::string text = r["result"]["messages"][0]["content"]["text"].get<std::string>();
+    EXPECT_NE(text.find("checkPrivileges"), std::string::npos) << n;
+  }
+}
+
+TEST_F(PostgresMCPServerTest, TheSlowQueryPromptBranchesIntoBloatAndVacuum) {
+  // The richest path: a slow statement can end in a plan fix, a vacuum change,
+  // an index, or a schema change, and the prompt has to name all four routes.
+  json r = rpc1(*srv, "prompts/get", {{"name", "diagnose-slow-query"}});
+  const std::string t = r["result"]["messages"][0]["content"]["text"].get<std::string>();
+  for (const char* tool : {"statementStats", "explainQuery", "tableStats",
+                           "tableBloat", "indexBloat", "duplicateIndexes",
+                           "bloat-and-vacuum-review", "plan-schema-change"})
+    EXPECT_NE(t.find(tool), std::string::npos) << tool << " missing from the slow-query path";
+}
+
+TEST_F(PostgresMCPServerTest, TheDiagnosticPromptsChooseBetweenARewriteAndDDL) {
+  // Both prompts can end in four different kinds of fix, and which one it is
+  // has to be a decision rather than a default. Ending at "propose the fix as
+  // DDL" reaches for an index when an ANALYZE or a rewrite would have done --
+  // and an index is a write cost paid forever to buy one read pattern.
+  for (const char* n : {"diagnose-slow-query", "explain-and-fix"}) {
+    json r = rpc1(*srv, "prompts/get",
+                  {{"name", n}, {"arguments", {{"sql", "SELECT 1"}}}});
+    const std::string t = r["result"]["messages"][0]["content"]["text"].get<std::string>();
+    // The four kinds, and the instruction to pick one deliberately.
+    for (const char* k : {"the fix is a rewrite", "the fix is statistics",
+                          "the fix is configuration", "only then is the fix DDL",
+                          "Prefer them in that order"})
+      EXPECT_NE(t.find(k), std::string::npos) << n << " missing: " << k;
+    // The cost argument is what makes the ordering more than a preference.
+    EXPECT_NE(t.find("every INSERT and UPDATE"), std::string::npos) << n;
+    EXPECT_NE(t.find("why the cheaper options were rejected"), std::string::npos) << n;
+
+    // The asymmetry this server can actually exploit: a rewrite is checkable
+    // here, an index is not.
+    EXPECT_NE(t.find("call explainQuery on the rewritten statement"), std::string::npos) << n;
+    // With hypopg an index is checkable too, and the prompt must say so and
+    // say how to find out whether it is available.
+    EXPECT_NE(t.find("evaluateIndex"), std::string::npos) << n;
+    EXPECT_NE(t.find("checkPrivileges says whether hypopg is there"), std::string::npos) << n;
+    EXPECT_NE(t.find("an index is a prediction"), std::string::npos) << n;
+    EXPECT_NE(t.find("plan-schema-change"), std::string::npos)
+        << n << " must hand index creation to the prompt that measures the table";
+  }
+}
+
+TEST_F(PostgresMCPServerTest, TheSlotPromptLeadsWithWhatASlotHoldsBack) {
+  json r = rpc1(*srv, "prompts/get", {{"name", "replication-slot-review"}});
+  const std::string t = r["result"]["messages"][0]["content"]["text"].get<std::string>();
+  // The two consequences that get misdiagnosed as something else.
+  EXPECT_NE(t.find("xmin horizon"), std::string::npos);
+  EXPECT_NE(t.find("wal_status"), std::string::npos);
+  // Dropping a slot is irreversible for its consumer; the prompt must say so.
+  EXPECT_NE(t.find("irreversible"), std::string::npos);
+}
+
+TEST_F(PostgresMCPServerTest, TheSchemaChangePromptRequiresTheChangeAndStatesTheLocks) {
+  json missing = rpc1(*srv, "prompts/get", {{"name", "plan-schema-change"},
+                                            {"arguments", json::object()}});
+  ASSERT_TRUE(missing.contains("error")) << missing.dump(2);
+  EXPECT_EQ(missing["error"]["code"], -32602);
+
+  json r = rpc1(*srv, "prompts/get",
+                {{"name", "plan-schema-change"},
+                 {"arguments", {{"change", "add a NOT NULL enum column"},
+                                {"schema", "shop"}, {"table", "orders"}}}});
+  const std::string t = r["result"]["messages"][0]["content"]["text"].get<std::string>();
+  EXPECT_NE(t.find("add a NOT NULL enum column"), std::string::npos);
+  EXPECT_NE(t.find("shop.orders"), std::string::npos);
+
+  // It must send the model to measure, because the readings are the only thing
+  // the model cannot already know.
+  for (const char* k : {"checkPrivileges", "tableStats", "tableSize",
+                        "tableDetails", "currentActivity", "currentLocks",
+                        "most_common_vals", "oldest running transaction",
+                        "replicationSlots"})
+    EXPECT_NE(t.find(k), std::string::npos) << k << " missing from the measurement step";
+
+  // A statement naming one table routinely locks several, and the unnamed one
+  // is often the busier: a foreign key locks what it references, a partitioned
+  // table means every partition. Measuring only the target misses the lock
+  // that actually hurts.
+  for (const char* k : {"every object the change touches", "not only the one named",
+                        "the table it references", "every partition"})
+    EXPECT_NE(t.find(k), std::string::npos) << k << " missing; the prompt measures one object only";
+
+  // ...and it must ask for a classification and a threshold rather than an
+  // answer, so the reasoning is checkable against a different table.
+  for (const char* k : {"metadata only", "full rewrite", "would flip",
+                        "irreversible", "read-only"})
+    EXPECT_NE(t.find(k), std::string::npos) << k << " missing";
+}
+
+TEST_F(PostgresMCPServerTest, TheSchemaChangePromptTeachesAMethodNotARecipe) {
+  // The point of the prompt is the readings, not the DDL. A model already
+  // knows what CREATE INDEX CONCURRENTLY is; what it cannot know is this
+  // table's size, its indexes and what is holding a lock right now. Baking the
+  // recipe in also makes the prompt wrong at one end of the scale -- always
+  // reaching for the safest-at-scale option is machinery nobody needs on an
+  // empty table -- and version-specific rules go stale silently.
+  json r = rpc1(*srv, "prompts/get",
+                {{"name", "plan-schema-change"}, {"arguments", {{"change", "add an index"}}}});
+  const std::string t = r["result"]["messages"][0]["content"]["text"].get<std::string>();
+  for (const char* recipe : {"CONCURRENTLY", "NOT VALID", "VALIDATE CONSTRAINT",
+                             "ALTER COLUMN TYPE", "PostgreSQL 11"})
+    EXPECT_EQ(t.find(recipe), std::string::npos)
+        << recipe << " is a prescribed recipe; this prompt must derive from measurements";
+  // The principle itself has to be stated, or nothing stops it drifting back.
+  EXPECT_NE(t.find("Do not answer from a recipe"), std::string::npos);
+  EXPECT_NE(t.find("billion"), std::string::npos) << "the scale contrast is the argument";
+  EXPECT_NE(t.find("Partitioning"), std::string::npos) << "the extreme case is the clearest one";
+}
+
+TEST_F(PostgresMCPServerTest, APromptSubstitutesItsArguments) {
+  json r = rpc1(*srv, "prompts/get",
+                {{"name", "bloat-and-vacuum-review"}, {"arguments", {{"schema", "grocery"}}}});
+  ASSERT_TRUE(r["result"].contains("messages")) << r.dump(2);
+  const std::string text =
+      r["result"]["messages"][0]["content"]["text"].get<std::string>();
+  EXPECT_NE(text.find("grocery"), std::string::npos);
+  // The template exists to encode an order of investigation, so it must name
+  // the step that is most often skipped.
+  EXPECT_NE(text.find("replicationSlots"), std::string::npos)
+      << "the bloat prompt must send the model to check the slot first";
+}
+
+TEST_F(PostgresMCPServerTest, APromptFallsBackWhenAnOptionalArgumentIsOmitted) {
+  json r = rpc1(*srv, "prompts/get", {{"name", "bloat-and-vacuum-review"}});
+  ASSERT_TRUE(r["result"].contains("messages")) << r.dump(2);
+  EXPECT_NE(r["result"]["messages"][0]["content"]["text"].get<std::string>().find("public"),
+            std::string::npos);
+}
+
+TEST_F(PostgresMCPServerTest, APromptMissingARequiredArgumentIsRefused) {
+  json r = rpc1(*srv, "prompts/get", {{"name", "explain-and-fix"}, {"arguments", json::object()}});
+  ASSERT_TRUE(r.contains("error")) << r.dump(2);
+  EXPECT_EQ(r["error"]["code"], -32602);
+  EXPECT_NE(r["error"]["message"].get<std::string>().find("sql"), std::string::npos);
+
+  json unknown = rpc1(*srv, "prompts/get", {{"name", "no-such-prompt"}});
+  ASSERT_TRUE(unknown.contains("error"));
+  EXPECT_EQ(unknown["error"]["code"], -32602);
+}
+
+TEST_F(PostgresMCPServerTest, CompletionOffersConnectionsAndSchemas) {
+  json r = rpc1(*srv, "completion/complete",
+                {{"ref", {{"type", "ref/resource"}, {"uri", "pglicht://{conn}/schemas"}}},
+                 {"argument", {{"name", "conn"}, {"value", ""}}}});
+  const json& c = r["result"]["completion"];
+  ASSERT_TRUE(c["values"].is_array()) << r.dump(2);
+  EXPECT_EQ(c["values"][0], "default");
+  EXPECT_FALSE(c["hasMore"].get<bool>());
+
+  json sch = rpc1(*srv, "completion/complete",
+                  {{"ref", {{"type", "ref/resource"}, {"uri", "pglicht://{conn}/schema/{schema}"}}},
+                   {"argument", {{"name", "schema"}, {"value", "groc"}}}});
+  bool saw = false;
+  for (const auto& v : sch["result"]["completion"]["values"])
+    if (v == "grocery") saw = true;
+  EXPECT_TRUE(saw) << sch.dump(2);
+}
+
+TEST_F(PostgresMCPServerTest, CompletionNeverFailsTheSession) {
+  // A completion is a convenience. An argument it knows nothing about, or a
+  // catalog it cannot read, returns an empty list rather than an error.
+  json r = rpc1(*srv, "completion/complete",
+                {{"ref", {{"type", "ref/prompt"}, {"name", "capacity-check"}}},
+                 {"argument", {{"name", "something_unknown"}, {"value", "x"}}}});
+  ASSERT_FALSE(r.contains("error")) << r.dump(2);
+  EXPECT_TRUE(r["result"]["completion"]["values"].is_array());
+  EXPECT_EQ(r["result"]["completion"]["values"].size(), 0u);
+}
+
 TEST_F(PostgresMCPServerTest, TitlesAppearOnlyFromTheRevisionThatDefinedThem) {
   json tools = srv->call_tools_list("2025-06-18");
   bool checked = false;
@@ -3822,6 +4632,280 @@ TEST_F(PostgresMCPServerTest, BufferCacheToolsNameTheExtensionWhenItIsAbsent) {
   }
   pqxx::nontransaction n(*admin_conn);
   n.exec("DROP DATABASE \"" + other + "\" WITH (FORCE)");
+}
+
+TEST_F(PostgresMCPServerTest, EverySessionEndsInRollbackAndLeavesNothing) {
+  // Everything here is read-only, so there is nothing a commit could preserve,
+  // and ending in ROLLBACK makes "the server is as you found it" provable
+  // rather than incidental. Asserted through a temporary table, which is the
+  // one thing a committed transaction would leave visible to the next
+  // connection.
+  pqxx::connection probe(test_url);
+  {
+    pqxx::work w(probe);
+    w.exec("CREATE TABLE grocery.rollback_probe (x int)");
+    w.commit();
+  }
+  const size_t before = srv->call_tables("grocery").size();
+  // Exercise a spread of tools, including the ones that set transaction-scoped
+  // state of their own.
+  srv->call_table("grocery", "users");
+  srv->call_table_stats("grocery", "users");
+  srv->call_explain_query("", "SELECT 1", json::array(), false, 0);
+  srv->call_check_privileges();
+  EXPECT_EQ(srv->call_tables("grocery").size(), before);
+
+  pqxx::work w(probe);
+  // Still exactly one row in pg_class for it: nothing this server did created
+  // or dropped anything.
+  EXPECT_EQ(w.exec("SELECT count(*) FROM pg_class WHERE relname = 'rollback_probe'")[0][0]
+              .as<int>(), 1);
+  w.exec("DROP TABLE grocery.rollback_probe");
+  w.commit();
+}
+
+// --- evaluateIndex (hypopg) ---
+
+namespace {
+bool hypopg_available(PostgresMCPServer& s) {
+  json r = s.call_evaluate_index("SELECT 1", json::array({"CREATE INDEX ON grocery.users (name)"}),
+                                 json::array());
+  const bool present = !(r.contains("error") &&
+                         r["error"].get<std::string>().find("not installed") != std::string::npos);
+  // On a developer machine a missing hypopg is a reason to skip. In CI it is
+  // installed on purpose -- the pooled job is the only place the reset bracket
+  // can be proved -- so there a skip would mean something broke while looking
+  // exactly like something merely absent. PGLICHT_REQUIRE_HYPOPG turns that
+  // silence into a failure.
+  if (!present && std::getenv("PGLICHT_REQUIRE_HYPOPG"))
+    ADD_FAILURE() << "PGLICHT_REQUIRE_HYPOPG is set but hypopg is not installed: "
+                  << r.dump();
+  return present;
+}
+}  // namespace
+
+TEST_F(PostgresMCPServerTest, EvaluateIndexShowsWhetherThePlannerWouldUseIt) {
+  if (!hypopg_available(*srv)) GTEST_SKIP() << "hypopg is not installed here";
+  json r = srv->call_evaluate_index(
+      "SELECT id FROM grocery.orders WHERE amount = 10",
+      json::array({"CREATE INDEX ON grocery.orders (amount)"}), json::array());
+  ASSERT_FALSE(r.contains("error")) << r.dump(2);
+  ASSERT_EQ(r["indexes"].size(), 1u);
+  // "used" is the point of the tool: a proposed index the planner ignores is
+  // the common case, and a cost figure alone hides it.
+  EXPECT_TRUE(r["indexes"][0].contains("used"));
+  EXPECT_TRUE(r["indexes"][0]["used"].is_boolean());
+  EXPECT_TRUE(r["indexes"][0].contains("estimated_size"));
+  EXPECT_TRUE(r["baseline"].contains("plan"));
+  EXPECT_TRUE(r["hypothetical"].contains("plan"));
+  EXPECT_GT(r["baseline"]["total_cost"].get<double>(), 0.0);
+}
+
+TEST_F(PostgresMCPServerTest, EvaluateIndexBuildsNothingAndKeepsTheGuard) {
+  if (!hypopg_available(*srv)) GTEST_SKIP() << "hypopg is not installed here";
+  const std::string before = srv->call_table("grocery", "orders")["indexes"].dump();
+  srv->call_evaluate_index("SELECT id FROM grocery.orders WHERE amount = 10",
+                           json::array({"CREATE INDEX ON grocery.orders (amount)"}),
+                           json::array());
+  // Nothing was built: a hypothetical index exists only in backend memory.
+  EXPECT_EQ(srv->call_table("grocery", "orders")["indexes"].dump(), before);
+  // And the read-only guard is untouched by having planned against one.
+  json r = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", "tools/call"},
+                          {"params", {{"name", "explainQuery"},
+                                      {"arguments", {{"sql", "SELECT 1"}}}}}});
+  EXPECT_FALSE(r["result"]["isError"].get<bool>()) << r.dump(2);
+}
+
+TEST_F(PostgresMCPServerTest, AHypotheticalIndexDoesNotLeakToTheNextCall) {
+  // The reason the reset bracket exists. Measured against hypopg 1.4.3: a
+  // hypothetical index survives ROLLBACK, survives into a new transaction, and
+  // survives DISCARD ALL -- which is exactly what PgBouncer issues as
+  // server_reset_query. Behind a transaction pooler that means one caller's
+  // hypothetical index would reshape the next caller's plans, silently.
+  //
+  // A direct connection is fresh every call, so this can only ever fail behind
+  // the pooler; it passes trivially otherwise rather than failing spuriously.
+  if (!hypopg_available(*srv)) GTEST_SKIP() << "hypopg is not installed here";
+  const char* sql = "SELECT id FROM grocery.orders WHERE amount = 10";
+
+  json first = srv->call_evaluate_index(
+      sql, json::array({"CREATE INDEX ON grocery.orders (amount)"}), json::array());
+  ASSERT_FALSE(first.contains("error")) << first.dump(2);
+  const double baseline = first["baseline"]["total_cost"].get<double>();
+
+  // A second call must see the same baseline. If the first call's index had
+  // leaked onto the backend, this baseline would already be planning with it.
+  for (int i = 0; i < 3; i++) {
+    json again = srv->call_evaluate_index(
+        sql, json::array({"CREATE INDEX ON grocery.orders (id)"}), json::array());
+    ASSERT_FALSE(again.contains("error")) << again.dump(2);
+    EXPECT_DOUBLE_EQ(again["baseline"]["total_cost"].get<double>(), baseline)
+        << "a hypothetical index leaked onto a pooled backend";
+    EXPECT_EQ(again["indexes"].size(), 1u) << "a previous call's index is still present";
+  }
+  // And an ordinary explain must not be planning against one either.
+  json plain = srv->call_explain_query("", sql, json::array(), false, 0);
+  EXPECT_EQ(plain.dump().find("btree_orders"), std::string::npos)
+      << "explainQuery is planning against a leaked hypothetical index";
+}
+
+TEST_F(PostgresMCPServerTest, EvaluateIndexAnswersWhetherAnIndexIsSafeToDrop) {
+  if (!hypopg_available(*srv)) GTEST_SKIP() << "hypopg is not installed here";
+  // The fixture tables are a handful of rows, where a sequential scan costs the
+  // same as an index scan and hiding the index changes nothing. The signal only
+  // exists once the table is big enough for the planner to care.
+  {
+    pqxx::connection c(test_url);
+    pqxx::nontransaction n(c);
+    n.exec("DROP TABLE IF EXISTS grocery.hypo_probe");
+    n.exec("CREATE TABLE grocery.hypo_probe (id bigint PRIMARY KEY, pad text)");
+    n.exec("INSERT INTO grocery.hypo_probe "
+           "SELECT g, repeat('x', 80) FROM generate_series(1, 20000) g");
+    n.exec("ANALYZE grocery.hypo_probe");
+  }
+  json r = srv->call_evaluate_index("SELECT pad FROM grocery.hypo_probe WHERE id = 4242",
+                                    json::array(), json::array({"grocery.hypo_probe_pkey"}));
+  if (r.contains("error") &&
+      r["error"].get<std::string>().find("1.4.0") != std::string::npos) {
+    pqxx::connection c(test_url);
+    pqxx::nontransaction n(c);
+    n.exec("DROP TABLE IF EXISTS grocery.hypo_probe");
+    GTEST_SKIP() << "hypopg predates hypopg_hide_index";
+  }
+  ASSERT_FALSE(r.contains("error")) << r.dump(2);
+  ASSERT_TRUE(r.contains("hidden"));
+  // Hiding the primary key must make the plan worse; that is the whole signal
+  // that the index is not safe to drop.
+  EXPECT_GT(r["hypothetical"]["total_cost"].get<double>(),
+            r["baseline"]["total_cost"].get<double>()) << r["baseline"].dump();
+  {
+    pqxx::connection c(test_url);
+    pqxx::nontransaction n(c);
+    n.exec("DROP TABLE IF EXISTS grocery.hypo_probe");
+  }
+}
+
+TEST_F(PostgresMCPServerTest, EvaluateIndexRefusesAnUnknownIndexClearly) {
+  if (!hypopg_available(*srv)) GTEST_SKIP() << "hypopg is not installed here";
+  json r = srv->call_evaluate_index("SELECT 1", json::array(),
+                                    json::array({"no_such_index_xyz"}));
+  if (r.value("error", "").find("1.4.0") != std::string::npos) GTEST_SKIP();
+  ASSERT_TRUE(r.contains("error")) << r.dump(2);
+  // Named, not a raw server error leaked through.
+  EXPECT_NE(r["error"].get<std::string>().find("no index named"), std::string::npos)
+      << r.dump(2);
+}
+
+TEST_F(PostgresMCPServerTest, EvaluateIndexNeedsSomethingToEvaluate) {
+  json r = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", "tools/call"},
+                          {"params", {{"name", "evaluateIndex"},
+                                      {"arguments", {{"sql", "SELECT 1"}}}}}});
+  EXPECT_TRUE(r["result"]["isError"].get<bool>()) << r.dump(2);
+}
+
+TEST_F(PostgresMCPServerTest, EvaluateIndexIsNeverSwept) {
+  // Same reasoning as explainQuery: the statement is rarely valid elsewhere.
+  json tools = srv->call_tools_list();
+  for (const auto& t : tools) {
+    if (t.value("name", "") != "evaluateIndex") continue;
+    EXPECT_FALSE(t["inputSchema"]["properties"].contains("instance"));
+    EXPECT_FALSE(t["inputSchema"]["properties"].contains("replication_group"));
+    EXPECT_FALSE(t["inputSchema"]["properties"].contains("group"));
+  }
+}
+
+// --- checkPrivileges ---
+
+TEST_F(PostgresMCPServerTest, CheckPrivilegesCountsEveryToolExactlyOnce) {
+  json r = srv->call_check_privileges();
+  ASSERT_TRUE(r.contains("tools")) << r.dump(2);
+  const size_t total    = r["tools"].get<size_t>();
+  const size_t avail    = r["available"].get<size_t>();
+  const size_t degraded = r.contains("degraded") ? r["degraded"].size() : 0;
+  const size_t denied   = r.contains("denied")   ? r["denied"].size()   : 0;
+  // Tools absent from both lists are fully available, so the arithmetic has to
+  // close or the count is telling the caller something untrue.
+  EXPECT_EQ(avail + degraded + denied, total);
+  EXPECT_EQ(total, srv->call_tools_list().size());
+  EXPECT_EQ(r["connection"].get<std::string>(), "default");
+  EXPECT_FALSE(r["role"].get<std::string>().empty());
+}
+
+TEST_F(PostgresMCPServerTest, CheckPrivilegesNamesNoRolesAndNoGrants) {
+  // Which predefined role gates a tool is PostgreSQL's business; the caller
+  // needs to know what works. And emitting DDL would contradict what this
+  // server tells every client about itself -- plans verbatim, no heuristics,
+  // no generated DDL -- so an unavailable tool is described, never prescribed.
+  const std::string dump = srv->call_check_privileges().dump();
+  EXPECT_EQ(dump.find("GRANT"), std::string::npos) << dump;
+  EXPECT_EQ(dump.find("memberships"), std::string::npos);
+  for (const char* role : {"pg_monitor", "pg_read_all_stats", "pg_read_all_data",
+                           "pg_stat_scan_tables", "pg_read_all_settings"})
+    EXPECT_EQ(dump.find(role), std::string::npos) << role << " leaked into the payload";
+}
+
+TEST_F(PostgresMCPServerTest, CheckPrivilegesSeparatesNotInstalledFromNotPermitted) {
+  // Two different fixes for the operator: CREATE EXTENSION versus a grant.
+  // Conflating them is the same defect the 42501 handling fixed in 3.2.0.
+  json r = srv->call_check_privileges();
+  for (const auto& d : r.value("denied", json::array())) {
+    const std::string reason = d["reason"].get<std::string>();
+    const bool classified = reason.find("not installed") != std::string::npos ||
+                            reason.find("restricted to") != std::string::npos ||
+                            reason.find("readable only by") != std::string::npos;
+    EXPECT_TRUE(classified) << d["tool"] << ": " << reason;
+  }
+}
+
+TEST_F(PostgresMCPServerTest, CheckPrivilegesReportsARestrictedRoleAccurately) {
+  const std::string role = "licht_cp_" + std::to_string(getpid());
+  {
+    pqxx::nontransaction n(*admin_conn);
+    n.exec("DROP ROLE IF EXISTS \"" + role + "\"");
+    n.exec("CREATE ROLE \"" + role + "\" LOGIN");
+  }
+  const std::string url = std::regex_replace(
+      test_url, std::regex(R"(\buser\s*=\s*\S+)"), "") + " user=" + role;
+
+  // Same two ways this cannot be exercised as the buffer-cache test: peer auth
+  // refuses the login, and a pooler with a forced user hands back the
+  // superuser's session whichever role was asked for.
+  bool usable = false;
+  try {
+    pqxx::connection probe(url);
+    pqxx::work t(probe);
+    usable = (t.exec("SELECT current_user")[0][0].as<std::string>() == role);
+  } catch (const std::exception&) {
+  }
+
+  if (usable) {
+    PostgresMCPServer unpriv{url};
+    json r = unpriv.call_check_privileges();
+    EXPECT_EQ(r["role"].get<std::string>(), role);
+
+    std::set<std::string> degraded, denied;
+    for (const auto& d : r.value("degraded", json::array())) degraded.insert(d["tool"]);
+    for (const auto& d : r.value("denied", json::array()))   denied.insert(d["tool"]);
+
+    // The three that read row data are degraded, never denied: privilege is
+    // per object, so this role may still hold SELECT on some tables. Calling
+    // them unavailable would be as wrong as calling them available.
+    for (const char* t : {"tableStats", "checkKey", "explainQuery"}) {
+      EXPECT_TRUE(degraded.count(t)) << t << " should be degraded for a bare role";
+      EXPECT_FALSE(denied.count(t)) << t << " is per-object, so it cannot be denied outright";
+    }
+    // pgstattuple is installed by the fixture, so this is a privilege denial
+    // rather than an absent extension.
+    EXPECT_TRUE(denied.count("tableBloat"));
+    EXPECT_NE(r["available"].get<size_t>(), r["tools"].get<size_t>());
+    // The catalog is world-readable, so the great majority still works.
+    EXPECT_GT(r["available"].get<size_t>(), r["tools"].get<size_t>() * 3 / 4);
+  } else {
+    GTEST_SKIP() << "cannot log in as an unprivileged role here";
+  }
+
+  pqxx::nontransaction n(*admin_conn);
+  n.exec("DROP ROLE IF EXISTS \"" + role + "\"");
 }
 
 TEST_F(PostgresMCPServerTest, BufferCacheDeniedNamesTheGrantRatherThanTheExtension) {
@@ -4112,7 +5196,7 @@ TEST_F(TopologyFixture, ListTopologyCarriesInstanceCapacity) {
 TEST_F(TopologyFixture, ListConnectionsCarriesTopologyLabels) {
   auto s = server_from(ini_with(
       "instance = pg-01\nreplication_group = ha\ngroup = prod, billing\n"));
-  json c = s->call_connections();
+  json c = s->call_connections()["connections"];
   ASSERT_EQ(c.size(), 1u);
   EXPECT_EQ(c[0]["instance"], "pg-01");
   EXPECT_EQ(c[0]["instance_source"], "declared");
@@ -4237,21 +5321,13 @@ TEST_F(TopologyFixture, VerifyTopologyRejectsAStandbyDeclaredAsTheSameInstance) 
 
 // --- dual-era protocol ---
 
-namespace {
-
-const char* kProtoVersion  = "io.modelcontextprotocol/protocolVersion";
-const char* kProtoCaps     = "io.modelcontextprotocol/clientCapabilities";
-const char* kProtoSrvInfo  = "io.modelcontextprotocol/serverInfo";
-
-json modern_meta(const std::string& version = "2026-07-28") {
-  return {{kProtoVersion, version}, {kProtoCaps, json::object()}};
-}
-
-}  // namespace
 
 TEST_F(PostgresMCPServerTest, TheSameCallDrivenBothWaysReturnsIdenticalContent) {
-  // The compatibility claim of the whole release, made checkable: the payload
-  // a client reads must not depend on which era it spoke.
+  // Through 3.2.1 this asserted that the two eras returned identical `content`.
+  // 4.0.0 changes the carrier deliberately -- a client that negotiated
+  // 2025-06-18 receives structuredContent and no text block -- so what has to
+  // hold now is that the *payload* is the same either way, which is the claim
+  // that actually mattered.
   json legacy = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", "tools/call"},
                                {"params", {{"name", "listSchemas"},
                                            {"arguments", json::object()}}}});
@@ -4259,15 +5335,99 @@ TEST_F(PostgresMCPServerTest, TheSameCallDrivenBothWaysReturnsIdenticalContent) 
                                {"params", {{"name", "listSchemas"},
                                            {"arguments", json::object()},
                                            {"_meta", modern_meta()}}}});
-  EXPECT_EQ(legacy["result"]["content"], modern["result"]["content"]);
+  auto payload_of = [](const json& r) {
+    const json& res = r["result"];
+    if (res.contains("structuredContent")) return res["structuredContent"];
+    return json::parse(res["content"][0]["text"].get<std::string>());
+  };
+  EXPECT_EQ(payload_of(legacy), payload_of(modern));
+}
+
+TEST_F(PostgresMCPServerTest, NeitherEraReceivesBothFormats) {
+  // The point of the change: sending both would serialise the same payload
+  // twice in one response, and a client that feeds tool results into a model
+  // may inject both. Exactly one carrier, every time.
+  json legacy = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", "tools/call"},
+                               {"params", {{"name", "listSchemas"},
+                                           {"arguments", json::object()}}}});
+  EXPECT_TRUE(legacy["result"].contains("content"));
+  EXPECT_FALSE(legacy["result"].contains("structuredContent"));
+
+  json modern = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 2}, {"method", "tools/call"},
+                               {"params", {{"name", "listSchemas"},
+                                           {"arguments", json::object()},
+                                           {"_meta", modern_meta()}}}});
+  EXPECT_TRUE(modern["result"].contains("structuredContent"));
+  EXPECT_FALSE(modern["result"].contains("content"));
+}
+
+TEST_F(PostgresMCPServerTest, StructuredContentStartsAtTheRevisionThatDefinedIt) {
+  // 2025-03-26 brought annotations but not structuredContent, so a client
+  // there must still get the text block. The boundary is the revision that
+  // defined the feature, not "modern versus legacy".
+  for (const auto& [proto, structured] :
+       std::vector<std::pair<std::string, bool>>{{"2024-11-05", false},
+                                                 {"2025-03-26", false},
+                                                 {"2025-06-18", true},
+                                                 {"2025-11-25", true}}) {
+    PostgresMCPServer s(test_url);
+    s.call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", "initialize"},
+                {"params", {{"protocolVersion", proto},
+                            {"capabilities", json::object()},
+                            {"clientInfo", {{"name", "t"}, {"version", "0"}}}}}});
+    json r = s.call_rpc({{"jsonrpc", "2.0"}, {"id", 2}, {"method", "tools/call"},
+                         {"params", {{"name", "listSchemas"},
+                                     {"arguments", json::object()}}}});
+    EXPECT_EQ(r["result"].contains("structuredContent"), structured) << proto;
+    EXPECT_EQ(r["result"].contains("content"), !structured) << proto;
+  }
+}
+
+TEST_F(PostgresMCPServerTest, TheTextBlockIsSerialisedCompactly) {
+  // Indentation was 18-39% of the payload across real catalog reads, and no
+  // consumer reads it -- they all parse the text as JSON.
+  json r = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", "tools/call"},
+                          {"params", {{"name", "listTables"},
+                                      {"arguments", {{"schema", "grocery"}}}}}});
+  const std::string text = r["result"]["content"][0]["text"].get<std::string>();
+  EXPECT_EQ(text.find("\n"), std::string::npos) << "text block is still pretty-printed";
+  // Still valid JSON, and still the same payload.
+  json reparsed;
+  ASSERT_NO_THROW(reparsed = json::parse(text));
+  EXPECT_TRUE(reparsed.is_object());
+}
+
+TEST_F(PostgresMCPServerTest, EveryToolPayloadIsAnObject) {
+  // structuredContent may only be a JSON object. A tool returning a top-level
+  // array or null is unrepresentable in the format modern clients receive, so
+  // this is an invariant now rather than a coincidence. currentLocks and
+  // listConnections were the two arrays; an empty result set was the null.
+  for (const auto& [tool, args] : std::vector<std::pair<std::string, json>>{
+           {"listConnections", json::object()},
+           {"currentLocks", json::object()},
+           {"listSchemas", json::object()},
+           {"listEnums", {{"schema", "pg_catalog"}}},   // empty result set
+           {"listTables", {{"schema", "grocery"}}}}) {
+    json r = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", "tools/call"},
+                            {"params", {{"name", tool},
+                                        {"arguments", args},
+                                        {"_meta", modern_meta()}}}});
+    ASSERT_TRUE(r["result"].contains("structuredContent")) << tool << r.dump(2);
+    EXPECT_TRUE(r["result"]["structuredContent"].is_object())
+        << tool << " returns a " << r["result"]["structuredContent"].type_name();
+  }
 }
 
 TEST_F(PostgresMCPServerTest, ALegacyResponseIsUnchangedFrom311) {
   json r = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", "tools/call"},
                           {"params", {{"name", "listSchemas"},
                                       {"arguments", json::object()}}}});
-  // Nothing new may appear in a legacy result, or the compatibility claim is
-  // assumed rather than proven.
+  // A legacy client keeps the text-block carrier and gains none of the
+  // modern-only result fields. It does *not* get 3.1.1's bytes any more:
+  // 4.0.0 compacted the serialisation and changed three payload shapes. That
+  // is the release being a major, not a regression -- but the envelope claim
+  // still has to hold, because a legacy client parses it.
+  EXPECT_TRUE(r["result"].contains("content"));
   EXPECT_FALSE(r["result"].contains("resultType"));
   EXPECT_FALSE(r["result"].contains("_meta"));
 }
@@ -4378,8 +5538,13 @@ json rpc_call(PostgresMCPServer& srv, const std::string& tool, json args) {
 }
 
 // The tool payload, unwrapped from the MCP text content block.
+// Era-aware: a modern client receives structuredContent and no text block, a
+// legacy one receives the text block and nothing else. Tests that only care
+// about the payload should not have to know which.
 json rpc_payload(const json& response) {
-  return json::parse(response["result"]["content"][0]["text"].get<std::string>());
+  const json& r = response["result"];
+  if (r.contains("structuredContent")) return r["structuredContent"];
+  return json::parse(r["content"][0]["text"].get<std::string>());
 }
 
 }  // namespace
@@ -4634,7 +5799,7 @@ TEST_F(TopologyFixture, SweepArgumentsAreAdvertisedOnlyWhereTheyApply) {
 TEST_F(PostgresMCPServerTest, ListConnectionsOmitsTopologyWhenNoneIsConfigured) {
   // A DATABASE_URL deployment has one connection and no topology; the fields
   // must be absent rather than empty, so 3.1.1 output is unchanged.
-  json c = srv->call_connections();
+  json c = srv->call_connections()["connections"];
   ASSERT_EQ(c.size(), 1u);
   EXPECT_FALSE(c[0].contains("instance"));
   EXPECT_FALSE(c[0].contains("replication_group"));
@@ -4666,7 +5831,10 @@ TEST_F(PostgresMCPServerTest, EveryOtherToolTakesAConnectionArgument) {
 }
 
 TEST_F(PostgresMCPServerTest, ListConnectionsReportsDefaultWithoutSecrets) {
-  json result = srv->call_connections();
+  json envelope = srv->call_connections();
+  // 4.0.0: wrapped, for the same reason as currentLocks.
+  ASSERT_TRUE(envelope.is_object());
+  json result = envelope["connections"];
   ASSERT_TRUE(result.is_array());
   ASSERT_EQ(result.size(), 1u);
   EXPECT_EQ(result[0]["name"].get<std::string>(), "default");


### PR DESCRIPTION
A breaking release, the first since 3.0.0.

## Why it breaks

`listTables`, `searchTables` and `tableDetails` each returned two unrelated things in one payload — the shape of an object, which changes on DDL, and readings taken off it, which change continuously. That made all three `per_server: true` in `tool_scopes()`, so a `replication_group` sweep re-ran the entire structural payload once per replica to get byte-identical bytes back. That table is keyed on tool *name*, so no flag or argument could have fixed it. Splitting the tools is the fix, and correcting the classification is the point of the release.

## Breaking changes

| change | why |
|---|---|
| `listTables` / `searchTables` / `tableDetails` return structure only | the sweep classification above |
| `size` → `size_estimate`, dated by `estimated_from` | the old key meant *estimated* in one tool and *measured* in another |
| `tableDetails` no longer returns `most_common_vals` | it is literal sampled row data, from the tool agents call most often to inspect structure |
| `listConnections` → `{connections: […]}`, `currentLocks` → `{locks: […]}`; an empty result is `{}` not `null` | `structuredContent` may only be a JSON object |
| a client on MCP `2025-06-18` or later gets `structuredContent` and **no** text block | see Tokens below |

`CHANGES.md` states each break and says which field moved to which tool.

## 52 → 58 tools

`tableStats`, `listTableStats` (catalog statistics) · `tableSize`, `listTableSizes` (measured, lock-gated) · `checkPrivileges` · `evaluateIndex`.

Plus three capabilities that did not exist before: **resources** (9 kinds, 5 templates), **prompts** (8), **completions**. `outputSchema` on all 58 tools, `ttlMs`/`cacheScope` on the six cacheable results, and `cursor` pagination on the four list operations.

## Tokens

Sending both `content` and `structuredContent` would serialise the same payload twice in one response, and a client that feeds tool results into a model's context may inject both. One format per client — chosen by the negotiated revision, never both — cuts **27–46%** off a modern client's wire bytes.

Separately, `tools/list` is ~93 kB and entirely static, and nothing marked it cacheable, so a conforming client should have treated it as immediately stale and re-fetched it whenever it needed the tool list. The caching hint removes that fixed per-session cost.

If you have a client that advertises `2025-06-18` but only reads `content`, pin it to `2025-03-26` and it behaves as before.

## `evaluateIndex`, and the finding worth reading

Plans a statement against hypothetical indexes via [hypopg](https://github.com/HypoPG/hypopg) — `create` tests a candidate without building it, `hide` plans *without* an existing one, which answers the "is this safe to drop?" question `duplicateIndexes` raises and cannot settle. Nothing is built, no lock is taken, and the statement is never executed.

**The reset bracket is load-bearing, and this was measured rather than assumed.** A hypothetical index lives in backend-local memory for the whole session and is cleared by **none** of `ROLLBACK`, a new transaction, or `DISCARD ALL` — which is exactly what PgBouncer issues as `server_reset_query`. Only `hypopg_reset()` removes it. Without the bracket, one caller's hypothetical index silently reshapes the next caller's plans behind a transaction pooler.

## Also

- **Every session now ends in `ROLLBACK`, explicitly.** Nothing here ever commits; stating it makes "the server is as you found it" provable rather than incidental.
- **`checkPrivileges`** reports which tools the current role can actually use. Measured on PostgreSQL 18: a bare `LOGIN` role runs **47 of 58** at full fidelity, `pg_monitor` **54**, and the ones remaining are those that read row data. It names no role memberships and no `GRANT` statements — describing an unavailable tool is diagnosis; prescribing a privilege escalation is not this server's call.
- CI installs hypopg in the `pooled` job only, with `PGLICHT_REQUIRE_HYPOPG=1` so a skip there becomes a failure. That job runs behind PgBouncer and is the only place the reset bracket can be proved — the test passes vacuously on a direct connection.

## Verification

- **380 direct / 378 pooled** on the full rig (throwaway cluster + PgBouncer in transaction mode + streamed standby). The two pooled skips are the restricted-role tests defeated by the pooler's forced user, as before.
- Zero warnings under `-Werror`; clean under ASan/UBSan; man page lints clean under `mandoc -T lint`.
- An `outputSchema` conformance test walks real payloads from 35 tools on every run — it caught a wrong type before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
