### PR TITLE
v4.1.1: send the text block to every client again

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -89,12 +89,18 @@ jobs:
             -DPGLICHT_SANITIZER=${{ matrix.sanitizer }}
           cmake --build cpp/build --target pg_licht_mcp_test
 
-      # Needs no database and does not vary by PostgreSQL version, so it runs
-      # once here rather than twenty times downstream.
-      - name: Lint the man page
+      # Neither needs a database nor varies by PostgreSQL version, so they run
+      # once here rather than twenty times downstream. protocol_compat pins the
+      # response-shape contract -- which client gets a text block, and what the
+      # two environment switches do -- end to end against the real binary,
+      # because both switches are read once per process and cannot be toggled
+      # from inside the gtest suite.
+      - name: Lint the man page and check the response-shape contract
         if: matrix.config == 'plain'
         working-directory: cpp/build
-        run: ctest -R manpage_lint --output-on-failure
+        run: |
+          cmake --build . --target pg_licht_mcp
+          ctest -R "manpage_lint|protocol_compat" --output-on-failure
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,77 @@
 # Changelog
 
+## 4.1.1 (unreleased)
+
+A compatibility fix for the output format 4.0.0 introduced, and the escape
+hatch that release should have shipped with.
+
+### Fixed
+
+- **Every client gets a text block again, by default.** 4.0.0 sent
+  `structuredContent` *instead of* `content` to any client that negotiated MCP
+  revision `2025-06-18` or later, on the reasoning that sending both serialises
+  the same payload twice and a client feeding results into a model's context
+  may inject both — doubling the tokens on every call. The compatibility the
+  spec's "send both" advice protects was assumed to be covered by the
+  negotiated revision: a client that cannot read `structuredContent` would not
+  ask for a revision that has it.
+
+  **That assumption was wrong, and a first-party client disproved it on the
+  first day.** Claude Code negotiates `2025-06-18` and reads `content`, so
+  every tool call came back looking empty — reported as *"the content was
+  missing from the response object"*. A client can advertise a revision it does
+  not fully implement, and this server cannot tell.
+
+  The default is now what the specification advises. The single-format
+  behaviour is opt-in:
+
+  ```
+  PG_LICHT_STRUCTURED_ONLY=1
+  ```
+
+  The token saving is real — 27–46% on a typical call — but it is not worth a
+  silently empty answer, and only an operator who has confirmed their client
+  reads structured content can know it is safe. That is the right way round for
+  a switch whose failure mode is a result that looks like nothing at all.
+
+- **The mitigation documented in 4.0.0 was unreachable.** CHANGES, the README
+  and the man page all said that a client advertising `2025-06-18` while
+  reading only `content` could be pinned to `2025-03-26`. There is no such
+  setting: `claude mcp add` offers transport, environment, headers and scope,
+  and no protocol version — the revision is chosen by the client's MCP library.
+  Documenting a workaround nobody can apply was worse than the original
+  decision. It is corrected wherever it appeared, and replaced with a switch
+  that works:
+
+  ```
+  PG_LICHT_MAX_PROTOCOL=2025-03-26
+  ```
+
+  `initialize` answers with the requested revision only when this server will
+  speak it, so trimming that list is how an operator forces an older response
+  shape from the server side, without the client offering any way to ask.
+
+- **An unsupported revision is answered with the highest this server speaks,
+  not the oldest.** The fallback was hardcoded to `2024-11-05`, so capping at
+  `2025-03-26` and being asked for `2025-06-18` dropped all the way to
+  `2024-11-05` — costing the client the annotations and titles it could have
+  used. The specification says to answer with another revision the server
+  supports; the highest one is the useful choice.
+
+### Notes
+
+- `PG_LICHT_MAX_PROTOCOL` governs the `initialize` handshake. The stateless
+  revision carries its version per request in `_meta` and is not negotiated, so
+  a client using it is unaffected by the cap — which is why the default change
+  above matters more: it covers both eras.
+- Both switches are read once per process. A server that changed its wire shape
+  mid-session would be worse than one that cannot, so they are deliberately not
+  reloadable.
+- A new `protocol_compat` ctest pins the whole contract end to end against the
+  real binary: which client gets a text block, what each switch does, and that
+  a nonsense cap is ignored rather than leaving nothing to negotiate. It needs
+  no database, because `listConnections` answers from the registry.
+
 ## 4.1.0 (2026-09-03)
 
 Latency and startup, for registries of remote databases. No tool's name, input
@@ -207,7 +279,9 @@ no argument or flag could have fixed it.
   defining it.
 
   If you have a client that advertises `2025-06-18` but only reads `content`,
-  pin it to `2025-03-26` and it keeps working unchanged.
+  see 4.1.1: this was the wrong default, and the mitigation originally
+  documented here — "pin it to `2025-03-26`" — was not something a client could
+  be made to do.
 
 - **The text block is serialised compactly.** It was pretty-printed with
   two-space indentation, which measured 18–39% of the payload across real

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.1.1 (unreleased)
+## 4.1.1 (2026-09-04)
 
 A compatibility fix for the output format 4.0.0 introduced, and the escape
 hatch that release should have shipped with.

--- a/README.md
+++ b/README.md
@@ -73,14 +73,13 @@ transaction mode it does not run `server_reset_query` at all by default.
 ## Output format
 
 A client that negotiates MCP revision `2025-06-18` or later receives
-`structuredContent` and no text block; one on an earlier revision receives the
-text block and no `structuredContent`. Never both — sending both would
-serialise the same payload twice, and a client that feeds tool results into a
-model's context may inject both, doubling the tokens on every call. Combined
-with dropping the pretty-printing, a modern client's wire bytes fall by 27–46%.
+`structuredContent`; every client receives the text block as well.
 
-If you have a client that advertises `2025-06-18` but only reads `content`, pin
-it to `2025-03-26` and it keeps working unchanged.
+Both are sent by default, because a client can advertise a revision it does not
+fully implement and this server cannot tell. Set `PG_LICHT_STRUCTURED_ONLY=1`
+to send only the structured payload once you have confirmed your client reads
+it, or `PG_LICHT_MAX_PROTOCOL=2025-03-26` to refuse to negotiate anything
+newer.
 
 Every tool declares an `outputSchema` to clients that can use it. The schemas
 describe but never reject: payloads here are version-conditional, and any tool

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(pg_licht_mcp VERSION 4.1.0 LANGUAGES CXX)
+project(pg_licht_mcp VERSION 4.1.1 LANGUAGES CXX)
 
 # Standard bin/ and share/man/ layout, so `cmake --install` produces a tree that
 # can be dropped onto a prefix as-is: the release tarballs are staged this way,
@@ -77,6 +77,14 @@ if(BUILD_TESTING)
     else()
         message(STATUS "mandoc not found: skipping the manpage_lint test")
     endif()
+
+    # The response-shape contract, end to end against the real binary. Both
+    # switches it covers are read once per process from the environment, so
+    # they cannot be exercised from inside the gtest suite. It needs no
+    # database: listConnections answers from the registry without connecting.
+    add_test(NAME protocol_compat
+             COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test/protocol-compat.sh
+                     $<TARGET_FILE:pg_licht_mcp>)
 endif()
 
 message(STATUS "Using compiler: ${CMAKE_CXX_COMPILER} (${CMAKE_CXX_COMPILER_ID})")

--- a/cpp/man/pg_licht_mcp.1
+++ b/cpp/man/pg_licht_mcp.1
@@ -1,7 +1,7 @@
 .\" Copyright (c) 2026 Daniel Cristian.
 .\" Licensed under the Apache License, Version 2.0; see LICENSE.
 .\"
-.Dd September 3, 2026
+.Dd September 4, 2026
 .Dt PG_LICHT_MCP 1
 .Os pg-licht
 .Sh NAME
@@ -1480,28 +1480,43 @@ argument.
 A client that negotiated MCP revision
 .Li 2025-06-18
 or later receives its answer as
-.Va structuredContent
-and no text block.
-A client on an earlier revision receives the text block and no
 .Va structuredContent .
-Never both.
+Every client, whatever it negotiated, also receives the text block.
 .Pp
-The specification suggests serving both for backwards compatibility, and this
-implementation deliberately does not.
-Sending both serialises the same payload twice in one response, and a client
-that feeds tool results into a model's context may inject both, doubling the
-tokens on every call.
-The compatibility that suggestion protects is already covered by the negotiated
-revision: a client that cannot read
+Sending both is what the specification advises, and 4.0.0 did not: it sent the
+structured payload instead of the text block, reasoning that a client which
+cannot read
 .Va structuredContent
-does not ask for a revision that has it.
-If a client advertises
+would not ask for a revision that has it.
+A client can advertise a revision it does not fully implement, and this server
+cannot tell \(em Claude Code negotiates
 .Li 2025-06-18
-but reads only
+and reads
 .Va content ,
-pin it to
-.Li 2025-03-26
-and it behaves as before.
+so every call came back appearing to have no content at all.
+The token saving from sending one format is real, but not at the price of an
+answer that looks empty.
+.Pp
+Two environment variables change this, both read once at startup.
+.Bl -tag -width Ds
+.It Ev PG_LICHT_STRUCTURED_ONLY
+Send only
+.Va structuredContent
+to clients that negotiated
+.Li 2025-06-18
+or later, which is what 4.0.0 and 4.1.0 did by default.
+Worth setting once you have confirmed your client reads structured content: it
+removes 27-46% of the bytes on a typical call.
+.It Ev PG_LICHT_MAX_PROTOCOL
+Refuse to negotiate any revision above this one.
+.Ic initialize
+answers with the revision the client asked for only when it appears in the list
+this server will speak, and with the highest it will speak otherwise, so
+capping the list is how an operator forces an older response shape from the
+server side.
+This governs the handshake only: the stateless revision carries its version per
+request and is not negotiated.
+.El
 .Pp
 The text block is serialised compactly.
 Indentation measured 18-39% of the payload across real catalog reads and no

--- a/cpp/src/server.h
+++ b/cpp/src/server.h
@@ -6953,9 +6953,32 @@ private:
   // open-ended, because echoing a version nobody exercises asserts support for
   // features that may not exist.
   static const std::vector<std::string>& supported_protocols() {
-    static const std::vector<std::string> v = {
-      "2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"
-    };
+    static const std::vector<std::string> v = [] {
+      std::vector<std::string> all = {
+        "2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"
+      };
+      // PG_LICHT_MAX_PROTOCOL caps what this server will agree to in the
+      // handshake. initialize replies with the client's requested revision only
+      // if it appears here, and falls back to 2024-11-05 otherwise -- so
+      // trimming this list is how an operator forces an older, text-only
+      // response shape without the client offering any way to ask for one.
+      //
+      // It exists because a client can advertise a revision it does not fully
+      // implement. Claude Code negotiates 2025-06-18 and reads `content`; a
+      // server that answers such a client with structuredContent alone leaves
+      // it with nothing, reported as "the content was missing from the response
+      // object". There is no client-side setting for this: `claude mcp add`
+      // offers transport, env, headers and scope, and no protocol version.
+      //
+      // Revision strings are ISO dates, so a string comparison orders them.
+      const char* cap = std::getenv("PG_LICHT_MAX_PROTOCOL");
+      if (cap == nullptr || *cap == '\0') return all;
+      std::vector<std::string> kept;
+      for (const auto& p : all) if (p <= cap) kept.push_back(p);
+      // A cap below every known revision would leave nothing to negotiate,
+      // which is worse than ignoring it.
+      return kept.empty() ? all : kept;
+    }();
     return v;
   }
 
@@ -6996,9 +7019,17 @@ private:
     // 3.1.1 ignored params.protocolVersion and always replied 2024-11-05.
     // Honouring it is what lets tool annotations reach a client that
     // understands them while a 2024-11-05 client keeps byte-identical output.
-    std::string want = params.value("protocolVersion", std::string());
-    std::string reply = "2024-11-05";
-    for (const auto& v : supported_protocols())
+    //
+    // When the requested revision is one this server will not speak, the spec
+    // says to answer with another it does support. Answering with the *highest*
+    // rather than the oldest is what makes PG_LICHT_MAX_PROTOCOL behave as an
+    // operator would expect: capping at 2025-03-26 and being asked for
+    // 2025-06-18 should yield 2025-03-26, not drop all the way to 2024-11-05
+    // and silently cost the client annotations and titles it can use.
+    const std::string want = params.value("protocolVersion", std::string());
+    const auto& supported = supported_protocols();
+    std::string reply = supported.back();   // highest this server will speak
+    for (const auto& v : supported)
       if (v == want) { reply = v; break; }
     client_protocol_ = reply;
 
@@ -7922,21 +7953,37 @@ private:
     return true;
   }
 
-  // The revision that defined `outputSchema` and `structuredContent`. A client
-  // that negotiated it receives the structured payload and no text block; one
-  // that did not receives the text block and nothing else. Never both.
+  // The revision that defined `outputSchema` and `structuredContent`.
   //
-  // The spec suggests serving both for backwards compatibility, and this
-  // deliberately does not. Sending both means serialising the same payload
-  // twice in one response, and a client that feeds tool results into a model's
-  // context may well inject both -- doubling the tokens for every call. The
-  // compatibility the suggestion protects is already covered here by the
-  // negotiated revision: a client that cannot read `structuredContent` does
-  // not ask for a revision that has it. This is the same rule 3.2.0 settled on
-  // for `annotations` and `title` (see the roadmap's refined rule): a
-  // protocol-revision feature is emitted only to a client that negotiated the
-  // revision defining it.
+  // 4.0.0 sent the structured payload *instead of* the text block to any client
+  // that negotiated this revision, on the reasoning that sending both
+  // serialises the same payload twice and a client feeding results into a
+  // model's context may inject both, doubling the tokens. The compatibility the
+  // spec's "send both" advice protects was assumed to be covered by the
+  // negotiated revision: a client that cannot read structuredContent would not
+  // ask for a revision that has it.
+  //
+  // That assumption was wrong, and a first-party client disproved it on the
+  // first day: Claude Code negotiates 2025-06-18 and reads `content`, so it
+  // received a result it reported as having no content at all. A client can
+  // advertise a revision it does not fully implement, and there is no way for
+  // this server to tell.
+  //
+  // So the default is now what the spec advises -- both -- and the single
+  // format is opt-in through PG_LICHT_STRUCTURED_ONLY, for operators who have
+  // confirmed their client reads structured content and want the bytes back.
+  // The token saving is real, but it is not worth a silently empty answer, and
+  // an operator who has verified their client is the only one who can know.
   static constexpr const char* kStructuredContentRevision = "2025-06-18";
+
+  // Opt in to the single-format behaviour 4.0.0 and 4.1.0 had by default.
+  static bool structured_only() {
+    static const bool v = [] {
+      const char* e = std::getenv("PG_LICHT_STRUCTURED_ONLY");
+      return e != nullptr && *e != '\0' && std::string(e) != "0";
+    }();
+    return v;
+  }
 
   bool wants_structured_content() const {
     return request_protocol_ >= kStructuredContentRevision;
@@ -7950,10 +7997,16 @@ private:
   // rather than reading it. This is the only remaining path that carries it,
   // since a modern client no longer receives a text block at all.
   json tool_result(const json& payload) const {
-    if (wants_structured_content())
-      return {{"structuredContent", payload}, {"isError", false}};
-    return {{"content", {{{"type", "text"}, {"text", payload.dump()}}}},
-            {"isError", false}};
+    json out;
+    const bool structured = wants_structured_content();
+    if (structured) out["structuredContent"] = payload;
+    // The text block goes to everyone unless an operator has opted out of it.
+    // It is still compact: the indentation was 18-39% of the payload and no
+    // consumer reads it, since every one parses the text as JSON.
+    if (!structured || !structured_only())
+      out["content"] = {{{"type", "text"}, {"text", payload.dump()}}};
+    out["isError"] = false;
+    return out;
   }
 
   void send_response(const json& id, const json& result) {

--- a/cpp/src/test_main.cpp
+++ b/cpp/src/test_main.cpp
@@ -5494,22 +5494,32 @@ TEST_F(PostgresMCPServerTest, TheSameCallDrivenBothWaysReturnsIdenticalContent) 
   EXPECT_EQ(payload_of(legacy), payload_of(modern));
 }
 
-TEST_F(PostgresMCPServerTest, NeitherEraReceivesBothFormats) {
-  // The point of the change: sending both would serialise the same payload
-  // twice in one response, and a client that feeds tool results into a model
-  // may inject both. Exactly one carrier, every time.
+TEST_F(PostgresMCPServerTest, EveryClientGetsATextBlockByDefault) {
+  // 4.0.0 sent structuredContent *instead of* the text block to a client that
+  // negotiated 2025-06-18, and a first-party client that advertises that
+  // revision while reading `content` was left with nothing -- reported as "the
+  // content was missing from the response object". A client can advertise a
+  // revision it does not fully implement, and this server cannot tell.
+  //
+  // So the default is what the spec advises: both.
   json legacy = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 1}, {"method", "tools/call"},
                                {"params", {{"name", "listSchemas"},
                                            {"arguments", json::object()}}}});
   EXPECT_TRUE(legacy["result"].contains("content"));
-  EXPECT_FALSE(legacy["result"].contains("structuredContent"));
+  EXPECT_FALSE(legacy["result"].contains("structuredContent"))
+      << "a pre-2025-06-18 client must not be sent a field its revision lacks";
 
   json modern = srv->call_rpc({{"jsonrpc", "2.0"}, {"id", 2}, {"method", "tools/call"},
                                {"params", {{"name", "listSchemas"},
                                            {"arguments", json::object()},
                                            {"_meta", modern_meta()}}}});
   EXPECT_TRUE(modern["result"].contains("structuredContent"));
-  EXPECT_FALSE(modern["result"].contains("content"));
+  EXPECT_TRUE(modern["result"].contains("content"))
+      << "the text block is what a client reading `content` needs to see";
+
+  // Whichever it reads, it reads the same thing.
+  EXPECT_EQ(modern["result"]["structuredContent"],
+            json::parse(modern["result"]["content"][0]["text"].get<std::string>()));
 }
 
 TEST_F(PostgresMCPServerTest, StructuredContentStartsAtTheRevisionThatDefinedIt) {
@@ -5530,7 +5540,8 @@ TEST_F(PostgresMCPServerTest, StructuredContentStartsAtTheRevisionThatDefinedIt)
                          {"params", {{"name", "listSchemas"},
                                      {"arguments", json::object()}}}});
     EXPECT_EQ(r["result"].contains("structuredContent"), structured) << proto;
-    EXPECT_EQ(r["result"].contains("content"), !structured) << proto;
+    // The text block goes to everyone by default, whatever the revision.
+    EXPECT_TRUE(r["result"].contains("content")) << proto;
   }
 }
 

--- a/cpp/test/protocol-compat.sh
+++ b/cpp/test/protocol-compat.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# The response-shape contract, exercised end to end against the real binary.
+#
+# Both switches it covers are read once per process from the environment, so
+# they cannot be toggled from inside the gtest suite -- the values are cached in
+# function-local statics by design, since a server that changed its wire shape
+# mid-session would be worse than one that cannot. Hence a process-level test.
+#
+# No database is needed: listConnections answers from the registry without
+# connecting, so a deliberately unroutable host still exercises the full
+# request/response path.
+#
+#   cpp/test/protocol-compat.sh /path/to/pg_licht_mcp
+set -euo pipefail
+
+BIN="${1:-${TEST_BIN:-cpp/build/pg_licht_mcp}}"
+[ -x "$BIN" ] || { echo "not executable: $BIN" >&2; exit 1; }
+URL="host=192.0.2.1 port=5432 dbname=x user=y connect_timeout=1"
+
+fail=0
+check() {  # check <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then printf '  ok    %-46s %s\n' "$1" "$3"
+  else printf '  FAIL  %-46s expected %s, got %s\n' "$1" "$2" "$3"; fail=1; fi
+}
+
+# Emits: "<negotiated>|<sorted result keys of the tools/call>"
+probe() {  # probe <requested protocol>
+  printf '%s\n%s\n' \
+    "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"$1\",\"capabilities\":{},\"clientInfo\":{\"name\":\"t\",\"version\":\"0\"}}}" \
+    '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"listConnections","arguments":{}}}' \
+  | "$BIN" "$URL" 2>/dev/null | python3 -c '
+import json,sys
+neg=""; keys=""
+for line in sys.stdin:
+    line=line.strip()
+    if not line.startswith("{"): continue
+    o=json.loads(line)
+    if o.get("id")==1: neg=o["result"]["protocolVersion"]
+    if o.get("id")==2: keys=",".join(sorted(k for k in o["result"] if k!="isError"))
+print(f"{neg}|{keys}")'
+}
+
+echo "default -- every client gets a text block"
+r=$(probe 2024-11-05); check "2024-11-05 negotiated"    "2024-11-05" "${r%%|*}"
+                       check "2024-11-05 result"        "content"    "${r##*|}"
+r=$(probe 2025-06-18); check "2025-06-18 negotiated"    "2025-06-18" "${r%%|*}"
+                       check "2025-06-18 result"        "content,structuredContent" "${r##*|}"
+
+echo
+echo "PG_LICHT_STRUCTURED_ONLY=1 -- opt in to the single format"
+export PG_LICHT_STRUCTURED_ONLY=1
+r=$(probe 2025-06-18); check "2025-06-18 result"        "structuredContent" "${r##*|}"
+r=$(probe 2024-11-05); check "2024-11-05 unaffected"    "content"    "${r##*|}"
+unset PG_LICHT_STRUCTURED_ONLY
+
+echo
+echo "PG_LICHT_MAX_PROTOCOL=2025-03-26 -- refuse to negotiate any higher"
+export PG_LICHT_MAX_PROTOCOL=2025-03-26
+r=$(probe 2025-06-18); check "2025-06-18 downgraded to" "2025-03-26" "${r%%|*}"
+                       check "and the result carries"   "content"    "${r##*|}"
+r=$(probe 2024-11-05); check "2024-11-05 still fine"    "2024-11-05" "${r%%|*}"
+unset PG_LICHT_MAX_PROTOCOL
+
+echo
+echo "a nonsense cap is ignored rather than leaving nothing to negotiate"
+export PG_LICHT_MAX_PROTOCOL=1999-01-01
+r=$(probe 2025-06-18); check "2025-06-18 still negotiated" "2025-06-18" "${r%%|*}"
+unset PG_LICHT_MAX_PROTOCOL
+
+echo
+[ "$fail" -eq 0 ] && echo "OK: response-shape contract holds" || { echo "protocol-compat FAILED"; exit 1; }


### PR DESCRIPTION
A compatibility fix for the output format 4.0.0 introduced, and the escape hatch that release should have shipped with.

## What broke

4.0.0 sent `structuredContent` **instead of** `content` to any client that negotiated MCP revision `2025-06-18` or later. The reasoning: sending both serialises the same payload twice, and a client feeding results into a model's context may inject both — doubling the tokens on every call. The compatibility the spec's *"send both"* advice protects was assumed to be covered by the negotiated revision, since a client that cannot read `structuredContent` would not ask for a revision that has it.

**That assumption was wrong, and a first-party client disproved it on the first day.** Claude Code negotiates `2025-06-18` and reads `content`, so every tool call came back appearing empty — reported as *"the content was missing from the response object"*.

A client can advertise a revision it does not fully implement, and this server cannot tell.

## The response matrix now

```
                              default             STRUCTURED_ONLY=1   MAX_PROTOCOL=2025-03-26
negotiates 2024-11-05         content             content             content
negotiates 2025-06-18         content +           structuredContent   → 2025-03-26, content
                              structuredContent
```

## Three changes

**1. Both formats by default.** What the specification advises. The single format is opt-in via `PG_LICHT_STRUCTURED_ONLY=1`, for an operator who has confirmed their client reads structured content and wants the 27–46% of bytes back. The saving is real, but not at the price of an answer that looks like nothing at all — and only the operator can know it is safe. That is the right way round for a switch whose failure mode is silence.

**2. The mitigation 4.0.0 documented was unreachable.** CHANGES, the README and the man page all said a client advertising `2025-06-18` while reading only `content` could be *"pinned to `2025-03-26`"*. There is no such setting — `claude mcp add` offers transport, environment, headers and scope, and no protocol version; the revision is chosen by the client's MCP library. Documenting a workaround nobody can apply was worse than the original decision.

Corrected everywhere it appeared, and replaced with `PG_LICHT_MAX_PROTOCOL`, which trims what `initialize` will agree to — so an operator can force an older response shape from the side that actually decides it.

**Verified against a real client**, which is the part only a client can answer: Claude accepts the downgrade rather than disconnecting.

**3. An unsupported revision is answered with the highest this server speaks, not the oldest.** The fallback was hardcoded to `2024-11-05`, so capping at `2025-03-26` and being asked for `2025-06-18` dropped all the way down — costing the client annotations and titles it could have used. The spec says to answer with another revision the server supports; the highest is the useful one.

Found by writing the test, not by reading the code.

## Testing

Both switches are read once per process — deliberately, since a server that changed its wire shape mid-session would be worse than one that cannot — so they cannot be toggled inside the gtest suite. A new **`protocol_compat` ctest** drives the real binary through the whole matrix, including that a nonsense cap is ignored rather than leaving nothing to negotiate. It needs no database, because `listConnections` answers from the registry.

It runs in the `build-plain` CI job alongside `manpage_lint` — once, rather than twenty times downstream.

- **383 gtest**, **388 direct / pooled OK** on the full rig, ASan, UBSan and ThreadSanitizer clean, ctest green, man page lints clean.
- Exercised through a live MCP client on both the default and the capped configuration.

## Note

`PG_LICHT_MAX_PROTOCOL` governs the `initialize` handshake. The stateless revision carries its version per request in `_meta` and is not negotiated, so a client using it is unaffected by the cap — which is why change 1 matters more: it covers both eras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
